### PR TITLE
Prepare v0.4.1 trusted publishing and DSH-first README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11.3.0
+          run_install: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: node -e 'const version = require("./package.json").version; if (process.env.RELEASE_TAG !== `v${version}`) throw new Error(`release ${process.env.RELEASE_TAG} does not match package v${version}`)'
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - run: pnpm test
+      - run: pnpm run try:dsh
+      - run: pnpm pack --pack-destination /tmp
+      - name: Install OIDC-capable npm CLI
+        run: npm install --global --ignore-scripts npm@11.18.0
+      - name: Publish with npm trusted publishing
+        run: npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.4.1] - 2026-08-15
+
+### Changed
+
+- Reworked the English and Chinese README opening around one concrete DSH incident, the deterministic/model boundary, and a direct npm install path.
+- Changed installation examples to track the npm `latest` release instead of a hard-coded package version.
+
+### Security
+
+- Added npm trusted publishing through a single GitHub Actions workflow with short-lived OIDC authentication and automatic provenance.
+- The release workflow checks the tag/package version contract, tests the package, runs the real DSH headless proof, and packs the artifact before publishing.
+
 ## [0.4.0] - 2026-08-14
 
 ### Added
@@ -20,4 +32,5 @@ All notable changes to Upstream Radar are documented here.
 - Version matching and compatibility facts are calculated outside the model.
 - Agent analysis is read-only and requires project evidence and explicit uncertainty.
 
+[0.4.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.4.1
 [0.4.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.4.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <h1 align="center">Upstream Radar</h1>
 
-<p align="center"><strong>Dependency changes that wake your DSH Agent only when your project is actually affected.</strong></p>
+<p align="center"><strong>Always-on vulnerability and breaking-change radar for DeepSeek Harness plugins.</strong></p>
 
 <p align="center">
   English · <a href="README.zh-CN.md">简体中文</a>
@@ -15,6 +15,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/upstream-radar"><img alt="npm version" src="https://img.shields.io/npm/v/upstream-radar?style=flat-square&color=2563eb"></a>
+  <a href="https://github.com/MicroMilo/upstream-radar/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/MicroMilo/upstream-radar?style=flat-square&color=f59e0b"></a>
   <a href="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/MicroMilo/upstream-radar/ci.yml?branch=main&style=flat-square&label=CI"></a>
   <a href="examples/dsh/README.md"><img alt="Tested with DSH 0.1.0-rc.6" src="https://img.shields.io/badge/tested_with_DSH-0.1.0--rc.6-5b5bd6?style=flat-square"></a>
   <a href="https://github.com/MicroMilo/upstream-radar/releases"><img alt="GitHub release" src="https://img.shields.io/github/v/release/MicroMilo/upstream-radar?style=flat-square"></a>
@@ -22,21 +23,71 @@
 </p>
 
 <p align="center">
-  <a href="#run-the-proof">Run the proof</a> ·
+  <a href="#see-one-incident">See one incident</a> ·
   <a href="#install-in-dsh">Install in DSH</a> ·
+  <a href="#run-the-proof">Run the proof</a> ·
   <a href="#how-the-loop-works">How it works</a> ·
   <a href="ROADMAP.md">Roadmap</a>
 </p>
 
 ---
 
-A vulnerability feed can tell you that a package is affected. It usually cannot tell you which DSH plugin brought that exact version into your profile, whether the vulnerable path reaches your project, or whether the available upgrade breaks DSH on the way out.
+A vulnerability feed stops at “package X is affected.” Upstream Radar keeps going: it identifies the exact installed dependency path, maintains one durable incident, and wakes a [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) Agent with the project evidence needed for a useful investigation.
 
-Upstream Radar closes that loop inside [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness):
+```text
+OSV advisory or npm release
+  -> exact installed plugin path
+  -> new / updated / resolved incident
+  -> project-specific DSH Agent analysis task
+```
 
-- **Exact path, not a package-name guess.** It preserves physical dependency nodes, duplicate versions, and the root-to-package path that actually matched.
-- **An incident, not alert spam.** It stores `new`, `updated`, and `resolved` state and keeps only the current task for each incident.
-- **Program facts before model judgment.** Version matching and compatibility boundaries stay deterministic; the DSH Agent investigates only project-specific reachability and migration impact.
+**No matching installed path means no Agent wake-up.** Version matching and compatibility facts are calculated by code; the model handles only repository-specific judgment.
+
+## See one incident
+
+If an advisory affects only one of two installed `parser` versions, Radar reports the path that actually matched:
+
+```text
+[HIGH][NEW] Dependency vulnerability
+Project: Payments API (payments-api)
+Plugin: plugin@1.0.0
+Affected: parser@2.9.0
+Advisory: GHSA-demo-2026-parser / CVE-2026-1234
+Paths:
+  plugin@1.0.0 -> logger@4.0.2 -> parser@2.9.0
+Fixed versions: 3.0.0
+Route: payments-platform via feishu:payments-security
+```
+
+That incident becomes a plugin-originated DSH notice. It is not copied into a generic chatbot prompt.
+
+| Upstream signal | Radar proves deterministically | DSH Agent investigates |
+| --- | --- | --- |
+| Vulnerability or malicious package | affected `name@version`, every installed path, fixed versions, incident state | whether project code reaches it, attacker input can reach it, and the least disruptive fix |
+| Candidate npm release | version boundary and Node.js, peer, export, entrypoint, bundle, and dependency changes | which APIs or Cordis configuration would break and what migration is appropriate |
+
+## Install in DSH
+
+Upstream Radar is an npm-published DSH bundle, so no install-time build permission is required:
+
+```bash
+dsh plugin --profile web add upstream-radar@latest
+```
+
+Point the bundle at an explicit project inventory, choose a durable state file, then boot the profile:
+
+```bash
+export UPSTREAM_RADAR_CONFIG=/absolute/path/radar-config.json
+export UPSTREAM_RADAR_STATE=/absolute/path/radar-state.json
+export UPSTREAM_RADAR_INTERVAL_SECONDS=1800
+
+dsh --profile web --dump-config
+dsh --profile web
+```
+
+Start from [the example inventory](examples/radar/config.json). If `UPSTREAM_RADAR_CONFIG` is not set, the bundle stays dormant and performs no polling.
+
+Once running, Radar polls OSV and npm, persists incident state before delivery, and submits only changed incidents to the first live root DSH Agent.
 
 ## Run the proof
 
@@ -63,34 +114,7 @@ The command fails unless DSH proves all four facts:
 }
 ```
 
-This proof runs in CI on Node.js 22. See the executable [showcase contract](examples/dsh/README.md) and its checked-in [result](examples/dsh/reports/headless-smoke.json).
-
-To include a current OSV and npm poll before the DSH handoff:
-
-```bash
-pnpm run try:dsh:live
-```
-
-## Install in DSH
-
-Upstream Radar is an npm-published DSH bundle, so no install-time build permission is required:
-
-```bash
-dsh plugin --profile web add upstream-radar@0.4.0
-```
-
-Point the bundle at an explicit project inventory, choose a durable state file, then boot the profile:
-
-```bash
-export UPSTREAM_RADAR_CONFIG=/absolute/path/radar-config.json
-export UPSTREAM_RADAR_STATE=/absolute/path/radar-state.json
-export UPSTREAM_RADAR_INTERVAL_SECONDS=1800
-
-dsh --profile web --dump-config
-dsh --profile web
-```
-
-Start from [the example inventory](examples/radar/config.json). If `UPSTREAM_RADAR_CONFIG` is not set, the bundle stays dormant and performs no polling.
+This proof runs in CI on Node.js 22. See the executable [showcase contract](examples/dsh/README.md) and its checked-in [result](examples/dsh/reports/headless-smoke.json). Run `pnpm run try:dsh:live` to include a current OSV and npm poll before the DSH handoff.
 
 ## How the loop works
 
@@ -114,7 +138,7 @@ The handoff uses `ctx.agents.roots()[0].followup(...)` with:
 
 It is a native DSH lifecycle integration—not a chat bridge or a remote-control bot.
 
-## One vulnerable path, not a false-positive package name
+## Why package-name alerts are not enough
 
 Given this installed graph:
 
@@ -127,18 +151,7 @@ plugin@1.0.0
     └── parser@2.9.0
 ```
 
-an advisory affecting only `parser@2.9.0` produces:
-
-```text
-[HIGH][NEW] Dependency vulnerability
-Project: Payments API (payments-api)
-Plugin: plugin@1.0.0
-Affected: parser@2.9.0
-Path: plugin@1.0.0 -> logger@4.0.2 -> parser@2.9.0
-Fixed versions: 3.0.0
-```
-
-The unaffected `parser@3.2.1` remains a distinct node.
+an advisory affecting `parser@2.9.0` matches only the `plugin -> logger -> parser` branch. The unaffected `parser@3.2.1` remains a distinct physical node instead of becoming a package-name false positive.
 
 ## Vulnerabilities are only half the upstream problem
 
@@ -214,6 +227,7 @@ Upstream Radar is alpha software built for the developer-preview DSH ecosystem. 
 - [Threat model](docs/threat-model.md)
 - [Roadmap](ROADMAP.md)
 - [Changelog](CHANGELOG.md)
+- [Release process](docs/releasing.md)
 - [Contributing](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 
 <h1 align="center">Upstream Radar</h1>
 
-<p align="center"><strong>只有当上游变化真正命中项目时，才唤醒你的 DSH Agent。</strong></p>
+<p align="center"><strong>面向 DeepSeek Harness 插件的常驻漏洞与破坏性更新雷达。</strong></p>
 
 <p align="center">
   <a href="README.md">English</a> · 简体中文
@@ -15,20 +15,71 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/upstream-radar"><img alt="npm 版本" src="https://img.shields.io/npm/v/upstream-radar?style=flat-square&color=2563eb"></a>
+  <a href="https://github.com/MicroMilo/upstream-radar/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/MicroMilo/upstream-radar?style=flat-square&color=f59e0b"></a>
   <a href="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/MicroMilo/upstream-radar/ci.yml?branch=main&style=flat-square&label=CI"></a>
   <a href="examples/dsh/README.md"><img alt="已使用 DSH 0.1.0-rc.6 验证" src="https://img.shields.io/badge/tested_with_DSH-0.1.0--rc.6-5b5bd6?style=flat-square"></a>
+  <a href="https://github.com/MicroMilo/upstream-radar/releases"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/MicroMilo/upstream-radar?style=flat-square"></a>
   <a href="LICENSE"><img alt="Apache-2.0 许可证" src="https://img.shields.io/badge/license-Apache--2.0-0f766e?style=flat-square"></a>
 </p>
 
 ---
 
-普通漏洞源只能告诉你“某个包有问题”。它通常无法回答：这个精确版本是被哪个 DSH 插件带进来的、真实依赖路径是什么、项目是否会触发漏洞，以及升级时会不会顺手破坏 DSH 兼容性。
+普通漏洞源到“某个包有问题”就结束了。Upstream Radar 会继续找到实际安装的依赖路径，维护一个可持续更新的事件，再把带有项目证据的调查任务交给 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) Agent。
 
-Upstream Radar 把这条链路闭合在 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 内部：
+```text
+OSV 漏洞公告或 npm 新版本
+  -> 真正命中的插件依赖路径
+  -> new / updated / resolved 事件
+  -> 面向具体项目的 DSH Agent 分析任务
+```
 
-- **看精确路径，不按包名猜。** 保留物理依赖节点、重复版本和真正命中的完整路径。
-- **维护事件状态，不制造告警洪水。** 记录 `new`、`updated`、`resolved`，同一事件只保留当前任务。
-- **程序先确定事实，模型只做判断。** 版本命中和兼容边界由程序计算；DSH Agent 只调查项目可达性和迁移影响。
+**没有命中实际安装路径，就不会唤醒 Agent。** 版本匹配和兼容性事实由程序计算；模型只负责结合仓库做判断。
+
+## 先看一个真实事件
+
+同一个插件里安装了两个 `parser` 版本，而公告只影响其中一个时，Radar 会报告真正命中的路径：
+
+```text
+[HIGH][NEW] Dependency vulnerability
+Project: Payments API (payments-api)
+Plugin: plugin@1.0.0
+Affected: parser@2.9.0
+Advisory: GHSA-demo-2026-parser / CVE-2026-1234
+Paths:
+  plugin@1.0.0 -> logger@4.0.2 -> parser@2.9.0
+Fixed versions: 3.0.0
+Route: payments-platform via feishu:payments-security
+```
+
+这个事件会成为带有插件身份的 DSH notice，而不是被复制进一段泛泛的聊天提示词。
+
+| 上游信号 | Radar 用程序确定 | DSH Agent 结合项目调查 |
+| --- | --- | --- |
+| 漏洞或恶意软件包 | 受影响的精确版本、每条安装路径、修复版本和事件状态 | 项目是否调用、攻击者输入能否到达、代价最低的修复办法 |
+| npm 候选版本 | 版本边界，以及 Node、peer、exports、入口、bundle 和依赖变化 | 哪些 API 或 Cordis 配置会受影响、应该如何迁移 |
+
+## 安装到 DSH
+
+Upstream Radar 发布的是已经构建好的 npm bundle，不需要开放安装期构建权限：
+
+```bash
+dsh plugin --profile web add upstream-radar@latest
+```
+
+指定项目清单和持久化状态文件后启动 profile：
+
+```bash
+export UPSTREAM_RADAR_CONFIG=/absolute/path/radar-config.json
+export UPSTREAM_RADAR_STATE=/absolute/path/radar-state.json
+export UPSTREAM_RADAR_INTERVAL_SECONDS=1800
+
+dsh --profile web --dump-config
+dsh --profile web
+```
+
+可以从[示例清单](examples/radar/config.json)开始。如果没有设置 `UPSTREAM_RADAR_CONFIG`，插件会保持休眠，不发起轮询。
+
+启动后，Radar 会轮询 OSV 与 npm，先把事件状态持久化，再把有变化的事件交给第一个在线的根 DSH Agent。
 
 ## 在真实 DSH 中运行证明
 
@@ -53,32 +104,7 @@ pnpm run try:dsh
 }
 ```
 
-要把当前 OSV 和 npm 数据也加入启动轮询：
-
-```bash
-pnpm run try:dsh:live
-```
-
-## 安装到 DSH
-
-Upstream Radar 发布的是已经构建好的 npm bundle，不需要开放安装期构建权限：
-
-```bash
-dsh plugin --profile web add upstream-radar@0.4.0
-```
-
-指定项目清单和持久化状态文件后启动 profile：
-
-```bash
-export UPSTREAM_RADAR_CONFIG=/absolute/path/radar-config.json
-export UPSTREAM_RADAR_STATE=/absolute/path/radar-state.json
-export UPSTREAM_RADAR_INTERVAL_SECONDS=1800
-
-dsh --profile web --dump-config
-dsh --profile web
-```
-
-可以从[示例清单](examples/radar/config.json)开始。如果没有设置 `UPSTREAM_RADAR_CONFIG`，插件会保持休眠，不发起轮询。
+运行 `pnpm run try:dsh:live`，可以在 DSH 投递前加入一次当前 OSV 与 npm 数据轮询。
 
 ## 闭环如何工作
 
@@ -102,7 +128,7 @@ dsh --profile web
 
 这是 DSH 原生生命周期集成，不是聊天机器人，也不是远程控制入口。
 
-## 一个真实命中的路径
+## 为什么只按包名告警不够
 
 ```text
 plugin@1.0.0
@@ -113,18 +139,7 @@ plugin@1.0.0
     └── parser@2.9.0
 ```
 
-如果公告只影响 `parser@2.9.0`，Radar 输出的是：
-
-```text
-[HIGH][NEW] Dependency vulnerability
-Project: Payments API (payments-api)
-Plugin: plugin@1.0.0
-Affected: parser@2.9.0
-Path: plugin@1.0.0 -> logger@4.0.2 -> parser@2.9.0
-Fixed versions: 3.0.0
-```
-
-不受影响的 `parser@3.2.1` 仍然是独立节点。
+如果公告只影响 `parser@2.9.0`，它只会命中 `plugin -> logger -> parser` 这条分支。不受影响的 `parser@3.2.1` 仍然是独立的物理节点，不会变成按包名产生的误报。
 
 ## 不只监控漏洞，也监控 breaking changes
 
@@ -162,6 +177,7 @@ Upstream Radar 目前是面向 DSH developer preview 生态的 alpha 软件，�
 - [威胁模型](docs/threat-model.md)
 - [Roadmap](ROADMAP.md)
 - [Changelog](CHANGELOG.md)
+- [发布流程](docs/releasing.md)
 - [贡献指南](CONTRIBUTING.md)
 - [安全策略](SECURITY.md)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,35 @@
+# Releasing Upstream Radar
+
+Upstream Radar publishes to npm through GitHub Actions trusted publishing. The release workflow uses a short-lived OIDC identity; the repository stores no npm write token. npm automatically attaches provenance to a successful public release.
+
+## One-time npm configuration
+
+The `upstream-radar` package trusts this exact publisher identity:
+
+```text
+GitHub owner: MicroMilo
+Repository: upstream-radar
+Workflow: publish.yml
+Allowed action: npm publish
+```
+
+The relationship can be inspected or replaced with npm CLI 11.5.1 or newer. Account-level two-factor authentication is required to change it.
+
+## Release contract
+
+1. Update `package.json`, `src/version.ts`, and `CHANGELOG.md` to the same version.
+2. Regenerate checked-in showcase reports when their rendered version changes.
+3. Merge the release commit into `main` after CI passes.
+4. Publish a non-prerelease GitHub Release whose tag is exactly `v<package version>`.
+5. Wait for the `Publish npm package` workflow to pass.
+6. Verify the npm version, integrity, and provenance before announcing the release.
+
+The workflow refuses a tag/package mismatch. It installs with lifecycle scripts disabled, runs the full test suite and real DSH headless proof, packs the artifact, and only then asks npm for a short-lived publish credential.
+
+## Security properties
+
+- No `NPM_TOKEN` secret is present in GitHub Actions.
+- Only `.github/workflows/publish.yml` in `MicroMilo/upstream-radar` is trusted by npm.
+- The publish job runs on a GitHub-hosted runner with `id-token: write` scoped to that job.
+- A prerelease GitHub Release cannot publish to npm through this workflow.
+- npm provenance links the published artifact back to its repository and build workflow; it does not claim that the package is vulnerability-free.

--- a/examples/reports/block-remote-shell.json
+++ b/examples/reports/block-remote-shell.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/block-remote-shell.txt
+++ b/examples/reports/block-remote-shell.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.4.0
+Upstream Radar 0.4.1
 Target: showcase-block-remote-shell@1.0.0
 Artifact: sha256:0f40219b5cafd126e2215143fdeb4fe818a31cc401ba799841e0c2c800297ad9
 DSH bundle: no

--- a/examples/reports/clean-dsh-plugin.json
+++ b/examples/reports/clean-dsh-plugin.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/clean-dsh-plugin.txt
+++ b/examples/reports/clean-dsh-plugin.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.4.0
+Upstream Radar 0.4.1
 Target: showcase-clean-dsh-plugin@1.0.0
 Artifact: sha256:82dccb0367dd96bfdb737f2844aa023d8456949e2afe5630b99da271686c43ea
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/reports/dsh-cloudflare-browser-run-0.1.1.json
+++ b/examples/reports/dsh-cloudflare-browser-run-0.1.1.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "target": {
     "kind": "npm",

--- a/examples/reports/dsh-cloudflare-browser-run-0.1.1.txt
+++ b/examples/reports/dsh-cloudflare-browser-run-0.1.1.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.4.0
+Upstream Radar 0.4.1
 Target: dsh-cloudflare-browser-run@0.1.1
 Artifact: sha256:27fe660b2fe40b15b70a206310b883ca15722d8ffaacab63232b71128d28701f
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/reports/review-install-script.json
+++ b/examples/reports/review-install-script.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/review-install-script.txt
+++ b/examples/reports/review-install-script.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.4.0
+Upstream Radar 0.4.1
 Target: showcase-review-install-script@1.0.0
 Artifact: sha256:fc43ac3189873f3fc3c207ce834b8670a8d74cc0121452a2e4400c4501d9f217
 DSH bundle: no

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Always-on vulnerability and breaking-change impact monitoring for DeepSeek Harness plugins.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.4.0'
+export const TOOL_VERSION = '0.4.1'


### PR DESCRIPTION
## What changed

- Reframes the English and Chinese README around one concrete dependency incident, the deterministic Radar/DSH Agent boundary, and the direct npm install path.
- Adds a GitHub Actions release workflow for npm trusted publishing with short-lived OIDC credentials and automatic provenance.
- Documents the release contract, bumps the package to `0.4.1`, and regenerates checked-in showcase reports.

## Why

The project homepage should explain the useful closed loop before asking readers to absorb the architecture. Releases should also be traceable to this repository and workflow without storing a long-lived npm write token.

## Validation

- `pnpm test` — 53/53 tests pass
- `pnpm run showcase:admission:reports`
- `pnpm run showcase:radar:reports`
- `pnpm run try:dsh:report` — real DSH `0.1.0-rc.6` bundle delivery passes
- `pnpm pack` — `upstream-radar-0.4.1.tgz` created
- README relative links, workflow YAML, version contract, and `git diff --check` pass
