### PR TITLE
feat: initialize Radar from a DSH profile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -30,6 +30,6 @@ body:
     id: version
     attributes:
       label: Upstream Radar version
-      placeholder: 0.4.0
+      placeholder: 0.5.0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Questions and DSH integration ideas
+    url: https://github.com/MicroMilo/upstream-radar/discussions
+    about: Ask how to connect Radar to a DSH profile or share a real monitoring scenario.
   - name: Sensitive security report
     url: https://github.com/MicroMilo/upstream-radar/security/policy
     about: Read the security policy before sharing sensitive details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.5.0] - 2026-08-15
+
+### Added
+
+- Added `upstream-radar init --profile <name>` to discover third-party bundles from a real DSH profile and generate a reviewable Radar inventory.
+- Added a real DSH profile initialization test covering bundle filtering, exact npm artifact inspection, and safe output creation.
+
+### Changed
+
+- Made the DSH first-use path start from the installed profile instead of asking users to hand-write a dependency graph.
+- Documented the boundary between the generated public npm artifact graph and profile-specific package-manager overrides.
+
 ## [0.4.1] - 2026-08-15
 
 ### Changed
@@ -34,3 +46,4 @@ All notable changes to Upstream Radar are documented here.
 
 [0.4.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.4.1
 [0.4.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.4.0
+[0.5.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,19 @@ pnpm run scan:self
 pnpm run showcase:radar
 ```
 
+To try the DSH-first setup against a disposable profile, install a bundle and generate the inventory:
+
+```bash
+dsh plugin --profile contributor-qa add dsh-cloudflare-browser-run@0.1.1
+pnpm dlx upstream-radar@latest init \
+  --profile contributor-qa \
+  --project-name "Contributor QA" \
+  --workspace "$PWD" \
+  --output ./upstream-radar.config.json
+```
+
+The generated graph is a reviewable view of each exact public npm artifact. A profile that applies package-manager overrides or patches still needs an explicit review before it is used as the monitoring source.
+
 The repository intentionally denies dependency lifecycle scripts through `.npmrc` and keeps zero runtime dependencies. A proposal to add a runtime dependency should explain why a small audited implementation or platform primitive is insufficient.
 
 ## Event and finding design

--- a/README.md
+++ b/README.md
@@ -74,18 +74,30 @@ Upstream Radar is an npm-published DSH bundle, so no install-time build permissi
 dsh plugin --profile web add upstream-radar@latest
 ```
 
-Point the bundle at an explicit project inventory, choose a durable state file, then boot the profile:
+Generate the inventory from the DSH profile instead of writing the dependency graph by hand:
 
 ```bash
-export UPSTREAM_RADAR_CONFIG=/absolute/path/radar-config.json
-export UPSTREAM_RADAR_STATE=/absolute/path/radar-state.json
+pnpm dlx upstream-radar@latest init \
+  --profile web \
+  --project-name "My DSH project" \
+  --workspace "$PWD" \
+  --output ./upstream-radar.config.json
+```
+
+The initializer reads the profile's actual third-party bundles, resolves each exact npm artifact with lifecycle scripts disabled, and writes a reviewable config. It never starts DSH or enables polling by itself. Review the generated file, then point the bundle at it and choose a durable state file:
+
+```bash
+export UPSTREAM_RADAR_CONFIG=$PWD/upstream-radar.config.json
+export UPSTREAM_RADAR_STATE=$PWD/upstream-radar.state.json
 export UPSTREAM_RADAR_INTERVAL_SECONDS=1800
 
 dsh --profile web --dump-config
 dsh --profile web
 ```
 
-Start from [the example inventory](examples/radar/config.json). If `UPSTREAM_RADAR_CONFIG` is not set, the bundle stays dormant and performs no polling.
+The generated graph is the exact public npm artifact graph for the installed bundle versions. If your DSH profile applies package-manager overrides, patches, or unusual peer resolution, review those differences before enabling continuous monitoring.
+
+For a hand-written or CI fixture, use [the example inventory](examples/radar/config.json). If `UPSTREAM_RADAR_CONFIG` is not set, the bundle stays dormant and performs no polling.
 
 Once running, Radar polls OSV and npm, persists incident state before delivery, and submits only changed incidents to the first live root DSH Agent.
 
@@ -208,7 +220,7 @@ upstream-radar inspect npm:dsh-cloudflare-browser-run@0.1.1 --deep
 
 ## Current boundaries
 
-- Project inventory is explicit JSON; active DSH profile discovery is not implemented yet.
+- `init --profile <name>` discovers a named DSH profile and generates a reviewable inventory; automatic active-profile selection and native pnpm override/peer resolution are not implemented yet.
 - npm lock graphs are supported; pnpm and Yarn graph adapters are not implemented.
 - OSV and npm `latest` are the live sources; GitHub release and migration-guide ingestion are deferred.
 - Delivery currently targets the first live root Agent rather than a project-specific session.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,18 +66,30 @@ Upstream Radar 发布的是已经构建好的 npm bundle，不需要开放安装
 dsh plugin --profile web add upstream-radar@latest
 ```
 
-指定项目清单和持久化状态文件后启动 profile：
+不用手写依赖图，可以直接从 DSH profile 生成项目清单：
 
 ```bash
-export UPSTREAM_RADAR_CONFIG=/absolute/path/radar-config.json
-export UPSTREAM_RADAR_STATE=/absolute/path/radar-state.json
+pnpm dlx upstream-radar@latest init \
+  --profile web \
+  --project-name "我的 DSH 项目" \
+  --workspace "$PWD" \
+  --output ./upstream-radar.config.json
+```
+
+初始化命令会读取 profile 中实际安装的第三方 bundle，用禁用 lifecycle scripts 的方式解析每个精确 npm artifact，然后写出一份可审查的配置。它不会自行启动 DSH，也不会自行开启轮询。检查生成文件后，再指定清单、持久化状态文件并启动 profile：
+
+```bash
+export UPSTREAM_RADAR_CONFIG=$PWD/upstream-radar.config.json
+export UPSTREAM_RADAR_STATE=$PWD/upstream-radar.state.json
 export UPSTREAM_RADAR_INTERVAL_SECONDS=1800
 
 dsh --profile web --dump-config
 dsh --profile web
 ```
 
-可以从[示例清单](examples/radar/config.json)开始。如果没有设置 `UPSTREAM_RADAR_CONFIG`，插件会保持休眠，不发起轮询。
+生成的依赖图对应已安装 bundle 版本的精确公共 npm artifact。如果你的 DSH profile 使用了 package-manager override、patch 或特殊的 peer 解析规则，开启持续监控前仍需要人工检查这些差异。
+
+如果需要手写配置或制作 CI fixture，可以参考[示例清单](examples/radar/config.json)。如果没有设置 `UPSTREAM_RADAR_CONFIG`，插件会保持休眠，不发起轮询。
 
 启动后，Radar 会轮询 OSV 与 npm，先把事件状态持久化，再把有变化的事件交给第一个在线的根 DSH Agent。
 
@@ -164,7 +176,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 已经支持：npm lock 依赖图、重复版本路径、OSV 精确版本匹配、恶意包记录、npm release 监听、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
 
-暂未支持：自动发现当前 DSH profile、pnpm/Yarn 图适配、GitHub release 与迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
+`init --profile <name>` 已经可以发现指定的 DSH profile 并生成可审查清单；暂未支持自动选择当前 active profile、原生解析 pnpm override/peer 规则、Yarn 图适配、GitHub release 与迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 
 Upstream Radar 目前是面向 DSH developer preview 生态的 alpha 软件，事件结构和适配边界仍可能变化。
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,8 @@
 - [ ] Read GitHub releases, changelogs, comparison diffs, and migration guides.
 - [ ] Track DSH package families as one coordinated release rather than unrelated npm packages.
 - [ ] Resolve the lowest clean plugin upgrade, not merely the latest release.
-- [ ] Discover the active DSH profile and its installed lock graph automatically.
+- [x] Discover a named DSH profile's installed third-party bundles and generate a reviewable inventory.
+- [ ] Discover the active DSH profile without `--profile` and use its native pnpm lock graph as the source of truth.
 - [ ] Run plugin load and representative compatibility probes in a disposable DSH profile.
 - [ ] Record `compatible`, `incompatible`, and `unknown` against an explicit DSH version matrix.
 

--- a/examples/reports/block-remote-shell.json
+++ b/examples/reports/block-remote-shell.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.4.1"
+    "version": "0.5.0"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/block-remote-shell.txt
+++ b/examples/reports/block-remote-shell.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.4.1
+Upstream Radar 0.5.0
 Target: showcase-block-remote-shell@1.0.0
 Artifact: sha256:0f40219b5cafd126e2215143fdeb4fe818a31cc401ba799841e0c2c800297ad9
 DSH bundle: no

--- a/examples/reports/clean-dsh-plugin.json
+++ b/examples/reports/clean-dsh-plugin.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.4.1"
+    "version": "0.5.0"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/clean-dsh-plugin.txt
+++ b/examples/reports/clean-dsh-plugin.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.4.1
+Upstream Radar 0.5.0
 Target: showcase-clean-dsh-plugin@1.0.0
 Artifact: sha256:82dccb0367dd96bfdb737f2844aa023d8456949e2afe5630b99da271686c43ea
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/reports/dsh-cloudflare-browser-run-0.1.1.json
+++ b/examples/reports/dsh-cloudflare-browser-run-0.1.1.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.4.1"
+    "version": "0.5.0"
   },
   "target": {
     "kind": "npm",

--- a/examples/reports/dsh-cloudflare-browser-run-0.1.1.txt
+++ b/examples/reports/dsh-cloudflare-browser-run-0.1.1.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.4.1
+Upstream Radar 0.5.0
 Target: dsh-cloudflare-browser-run@0.1.1
 Artifact: sha256:27fe660b2fe40b15b70a206310b883ca15722d8ffaacab63232b71128d28701f
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/reports/review-install-script.json
+++ b/examples/reports/review-install-script.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.4.1"
+    "version": "0.5.0"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/review-install-script.txt
+++ b/examples/reports/review-install-script.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.4.1
+Upstream Radar 0.5.0
 Target: showcase-review-install-script@1.0.0
 Artifact: sha256:fc43ac3189873f3fc3c207ce834b8670a8d74cc0121452a2e4400c4501d9f217
 DSH bundle: no

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Always-on vulnerability and breaking-change impact monitoring for DeepSeek Harness plugins.",
   "type": "module",
   "license": "Apache-2.0",
@@ -20,7 +20,11 @@
     "dependency-security",
     "vulnerability-monitoring",
     "breaking-changes",
-    "supply-chain"
+    "supply-chain",
+    "dependency-graph",
+    "osv",
+    "agent-security",
+    "npm"
   ],
   "engines": {
     "node": ">=22"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { assessCompatibilityChange } from './compatibility.js'
 import { createAnalysisTask, renderAgentAnalysisPrompt } from './dsh-analysis.js'
+import { createRadarConfigFromDshProfile, resolveDshProfileDirectory, writeRadarConfig } from './init.js'
 import { parsePackageManifestSnapshot, parseRadarConfig } from './inventory.js'
 import { inspectNpmPackage } from './npm.js'
 import { NpmReleaseClient } from './npm-release.js'
@@ -30,6 +31,7 @@ function usage(): string {
   return `Upstream Radar — always-on dependency and compatibility monitoring for DSH plugins
 
 Usage:
+  upstream-radar init --profile <name> [options]
   upstream-radar scan <directory> [--json] [--fail-on <warn|review|block|never>]
   upstream-radar inspect npm:<package>@<exact-version> [--deep] [--json] [--fail-on <warn|review|block|never>]
   upstream-radar radar check <config.json> [--state <state.json>] [--json]
@@ -40,6 +42,7 @@ Usage:
   upstream-radar version
 
 Commands:
+  init     discover third-party bundles in a DSH profile and write a reviewable inventory
   scan     bounded, read-only inspection of a local package directory
   inspect  fetch and verify the exact npm artifact before inspecting its contents
   radar    monitor vulnerability changes or assess a candidate compatibility change
@@ -51,6 +54,9 @@ Options:
   --state <path>       persistent radar state (default: <config.json>.state.json)
   --osv-base-url <url> alternate HTTPS OSV API base URL
   --notes <path>       release notes used as untrusted compatibility evidence
+  --profile <name>     DSH profile to inspect for init (default DSH_HOME/profiles/<name>)
+  --output <path>      init output path (default: ./upstream-radar.config.json)
+  --force              allow init to replace an existing output file
   --json               emit the canonical JSON report
   --fail-on <verdict>  CI threshold; default is review
 
@@ -202,6 +208,66 @@ async function runRadar(args: readonly string[]): Promise<number> {
   return 0
 }
 
+async function runInit(args: readonly string[]): Promise<number> {
+  let profile: string | undefined
+  let output = 'upstream-radar.config.json'
+  let projectId: string | undefined
+  let projectName: string | undefined
+  let repository: string | undefined
+  let workspace: string | undefined
+  let registry: string | undefined
+  let force = false
+  let json = false
+  const channels: string[] = []
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--force') force = true
+    else if (argument === '--json') json = true
+    else if (argument === '--profile' || argument === '--output' || argument === '--project-id'
+      || argument === '--project-name' || argument === '--repository' || argument === '--workspace'
+      || argument === '--channel' || argument === '--registry') {
+      const value = args[index + 1]
+      if (value === undefined || value.startsWith('-')) throw new Error(`${argument} requires a value`)
+      if (argument === '--profile') profile = value
+      else if (argument === '--output') output = value
+      else if (argument === '--project-id') projectId = value
+      else if (argument === '--project-name') projectName = value
+      else if (argument === '--repository') repository = value
+      else if (argument === '--workspace') workspace = value
+      else if (argument === '--channel') channels.push(value)
+      else registry = value
+      index += 1
+    } else {
+      throw new Error(`unknown option for init: ${argument}`)
+    }
+  }
+  if (profile === undefined) throw new Error('init requires --profile <name>')
+  const config = await createRadarConfigFromDshProfile({
+    profileDirectory: resolveDshProfileDirectory(profile),
+    ...(projectId === undefined ? {} : { projectId }),
+    ...(projectName === undefined ? {} : { projectName }),
+    ...(repository === undefined ? {} : { repository }),
+    ...(workspace === undefined ? {} : { workspace }),
+    ...(channels.length === 0 ? {} : { channels }),
+    ...(registry === undefined ? {} : { registry }),
+  })
+  const outputPath = await writeRadarConfig(config, { output, force })
+  const plugins = config.projects[0]?.plugins ?? []
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ output: outputPath, profile, plugins: plugins.map(plugin => ({
+      name: plugin.package.name,
+      version: plugin.package.version,
+      nodes: plugin.graph.nodes.length,
+      edges: plugin.graph.edges.length,
+    })) }, null, 2)}\n`)
+  } else {
+    process.stdout.write(`Created ${outputPath}\nDiscovered ${plugins.length} DSH plugin bundle(s):\n`)
+    for (const plugin of plugins) process.stdout.write(`  ${plugin.package.name}@${plugin.package.version} (${plugin.graph.nodes.length} dependency nodes)\n`)
+    process.stdout.write('\nReview the generated inventory, then set UPSTREAM_RADAR_CONFIG before starting DSH.\n')
+  }
+  return 0
+}
+
 async function main(args: readonly string[]): Promise<number> {
   const command = args[0]
   if (command === undefined || command === '--help' || command === '-h' || command === 'help') {
@@ -212,6 +278,7 @@ async function main(args: readonly string[]): Promise<number> {
     process.stdout.write(`${TOOL_VERSION}\n`)
     return 0
   }
+  if (command === 'init') return runInit(args.slice(1))
   if (command === 'radar') return runRadar(args.slice(1))
   if (command === 'task') return runTask(args.slice(1))
   if (command !== 'scan' && command !== 'inspect') throw new Error(`unknown command: ${command}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,14 @@ export { emptyRadarState, pollRadar, type AdvisorySource, type RadarPollResult, 
 export { assessCompatibilityChange, assessCompatibilityChanges, type CompatibilityChangeInput } from './compatibility.js'
 export { createAnalysisTask, renderAgentAnalysisPrompt, renderDshAnalysisPrompt } from './dsh-analysis.js'
 export { parsePackageManifestSnapshot, parseRadarConfig } from './inventory.js'
+export {
+  createRadarConfigFromDshProfile,
+  resolveDshProfileDirectory,
+  writeRadarConfig,
+  type DshInitOptions,
+  type InitInspector,
+  type WriteRadarConfigOptions,
+} from './init.js'
 export { loadRadarState, parseRadarState, saveRadarState } from './radar-state.js'
 export { renderRadarEvent, renderRadarEvents } from './radar-render.js'
 export { crossesBreakingVersionBoundary, parseSemver, satisfiesSemverRange } from './semver.js'

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,171 @@
+import { access, readFile, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, isAbsolute, join, relative, resolve } from 'node:path'
+import { inspectNpmPackage, type InspectNpmOptions } from './npm.js'
+import { parsePackageManifestSnapshot, parseRadarConfig } from './inventory.js'
+import {
+  INVENTORY_SCHEMA,
+  RADAR_CONFIG_SCHEMA,
+  type DependencyGraph,
+  type PackageManifestSnapshot,
+  type PluginInstallation,
+  type RadarConfig,
+} from './radar-types.js'
+
+const MAX_JSON_BYTES = 8 * 1024 * 1024
+
+type InitInspection = {
+  evidence: {
+    npm?: {
+      dependencyAudit: {
+        graph?: DependencyGraph
+      }
+    }
+  }
+}
+
+export type InitInspector = (spec: string, options: InspectNpmOptions) => Promise<InitInspection>
+
+export interface DshInitOptions {
+  profileDirectory: string
+  projectId?: string
+  projectName?: string
+  repository?: string
+  workspace?: string
+  channels?: string[]
+  registry?: string
+  inspect?: InitInspector
+}
+
+export interface WriteRadarConfigOptions {
+  output: string
+  force?: boolean
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${label} must be an object`)
+  return value as Record<string, unknown>
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 4_096) throw new Error(`${label} must be a non-empty string`)
+  return value
+}
+
+async function readJson(path: string): Promise<unknown> {
+  const contents = await readFile(path, 'utf8')
+  if (Buffer.byteLength(contents) > MAX_JSON_BYTES) throw new Error(`${path} exceeds the ${MAX_JSON_BYTES} byte limit`)
+  try {
+    return JSON.parse(contents) as unknown
+  } catch {
+    throw new Error(`${path} is not valid JSON`)
+  }
+}
+
+async function readPackageManifest(profileDirectory: string, packageName: string): Promise<PackageManifestSnapshot> {
+  const nodeModulesDirectory = resolve(profileDirectory, 'node_modules')
+  const path = resolve(nodeModulesDirectory, packageName, 'package.json')
+  const relativePath = relative(nodeModulesDirectory, path)
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    throw new Error(`DSH bundle name escapes the profile node_modules directory: ${packageName}`)
+  }
+  return parsePackageManifestSnapshot(await readJson(path))
+}
+
+function isDshInfrastructure(packageName: string): boolean {
+  return packageName === 'upstream-radar'
+    || packageName === 'cordis'
+    || packageName.startsWith('@deepseek-ai/')
+    || packageName.startsWith('@cordis/')
+}
+
+function defaultProjectId(workspace: string): string {
+  const name = basename(resolve(workspace)).toLowerCase().replace(/[^a-z0-9._-]+/g, '-')
+  return name.replace(/^-+|-+$/g, '').slice(0, 512) || 'dsh-project'
+}
+
+function defaultProjectName(workspace: string): string {
+  return basename(resolve(workspace)) || 'DSH project'
+}
+
+/** Resolve a DSH profile using the same DSH_HOME convention as the launcher. */
+export function resolveDshProfileDirectory(profile: string, dshHome = process.env.DSH_HOME): string {
+  const home = dshHome?.trim() === '' || dshHome === undefined ? join(homedir(), '.dsh') : dshHome
+  const profileName = requiredString(profile, 'profile')
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(profileName)) {
+    throw new Error('profile must be a simple DSH profile name (letters, numbers, ., _, and -)')
+  }
+  return resolve(home, 'profiles', profileName)
+}
+
+/** Build a reviewable Radar inventory from the third-party bundles in a DSH profile. */
+export async function createRadarConfigFromDshProfile(options: DshInitOptions): Promise<RadarConfig> {
+  const profileDirectory = resolve(options.profileDirectory)
+  const profileManifest = asRecord(await readJson(join(profileDirectory, 'package.json')), 'DSH profile package.json')
+  const dsh = asRecord(profileManifest.dsh, 'DSH profile dsh')
+  const profile = asRecord(dsh.profile, 'DSH profile dsh.profile')
+  const bundles = profile.bundles
+  if (!Array.isArray(bundles) || bundles.length === 0 || !bundles.every(item => typeof item === 'string')) {
+    throw new Error('DSH profile package.json does not contain dsh.profile.bundles')
+  }
+
+  const workspace = options.workspace ?? process.cwd()
+  const projectId = options.projectId ?? defaultProjectId(workspace)
+  const projectName = options.projectName ?? defaultProjectName(workspace)
+  const inspect = options.inspect ?? inspectNpmPackage
+  const plugins: PluginInstallation[] = []
+  for (const packageName of bundles) {
+    if (isDshInfrastructure(packageName)) continue
+    const manifest = await readPackageManifest(profileDirectory, packageName)
+    if (manifest.name !== packageName) {
+      throw new Error(`installed manifest name ${manifest.name} does not match DSH bundle ${packageName}`)
+    }
+    const report = await inspect(`npm:${manifest.name}@${manifest.version}`, {
+      deep: true,
+      ...(options.registry === undefined ? {} : { registry: options.registry }),
+    })
+    const graph = report.evidence.npm?.dependencyAudit.graph
+    if (graph === undefined) {
+      throw new Error(`could not resolve the exact dependency graph for ${manifest.name}@${manifest.version}`)
+    }
+    plugins.push({
+      package: { ecosystem: 'npm', name: manifest.name, version: manifest.version },
+      manifest,
+      graph,
+    })
+  }
+  if (plugins.length === 0) throw new Error('DSH profile has no third-party bundles to monitor')
+
+  const config: RadarConfig = {
+    schema: RADAR_CONFIG_SCHEMA,
+    projects: [{
+      schema: INVENTORY_SCHEMA,
+      project: {
+        id: projectId,
+        name: projectName,
+        ...(options.repository === undefined ? {} : { repository: options.repository }),
+        workspace,
+        ...(options.channels === undefined || options.channels.length === 0 ? {} : { channels: options.channels }),
+      },
+      environment: { nodeVersion: process.versions.node },
+      plugins,
+    }],
+  }
+  parseRadarConfig(config)
+  return config
+}
+
+export async function writeRadarConfig(config: RadarConfig, options: WriteRadarConfigOptions): Promise<string> {
+  const output = resolve(options.output)
+  if (!options.force) {
+    try {
+      await access(output)
+      throw new Error(`${output} already exists; pass --force to replace it`)
+    } catch (error: unknown) {
+      if (error instanceof Error && !('code' in error)) throw error
+      if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error
+    }
+  }
+  await writeFile(output, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 })
+  return output
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.4.1'
+export const TOOL_VERSION = '0.5.0'

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import { createRadarConfigFromDshProfile, resolveDshProfileDirectory, writeRadarConfig } from '../src/init.js'
+
+const graph = {
+  schema: 'upstream-radar.dependency-graph/v1alpha1' as const,
+  rootNodeId: 'node_modules/demo-plugin',
+  nodes: [
+    { id: 'node_modules/demo-plugin', name: 'demo-plugin', version: '1.2.3' },
+    { id: 'node_modules/parser', name: 'parser', version: '2.9.0' },
+  ],
+  edges: [{ from: 'node_modules/demo-plugin', to: 'node_modules/parser', kind: 'runtime' as const }],
+}
+
+describe('DSH profile initialization', () => {
+  it('discovers third-party bundles and writes a reviewable inventory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-init-'))
+    const profile = join(root, 'profiles', 'web')
+    try {
+      await mkdir(join(profile, 'node_modules', 'demo-plugin'), { recursive: true })
+      await writeFile(join(profile, 'package.json'), JSON.stringify({
+        name: 'dsh-profile-web',
+        dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'upstream-radar', 'demo-plugin'] } },
+      }))
+      await writeFile(join(profile, 'node_modules', 'demo-plugin', 'package.json'), JSON.stringify({
+        name: 'demo-plugin',
+        version: '1.2.3',
+        main: './dist/index.js',
+        dsh: { bundle: { patch: './cordis.patch.yml' } },
+      }))
+
+      const calls: string[] = []
+      const config = await createRadarConfigFromDshProfile({
+        profileDirectory: profile,
+        projectId: 'payments-api',
+        projectName: 'Payments API',
+        workspace: '/workspace/payments-api',
+        channels: ['feishu:payments-security'],
+        inspect: async (spec) => {
+          calls.push(spec)
+          return { evidence: { npm: { dependencyAudit: { graph } } } }
+        },
+      })
+
+      assert.deepEqual(calls, ['npm:demo-plugin@1.2.3'])
+      assert.equal(config.projects[0]?.project.name, 'Payments API')
+      assert.equal(config.projects[0]?.plugins[0]?.package.name, 'demo-plugin')
+      assert.equal(config.projects[0]?.plugins[0]?.graph.nodes.length, 2)
+
+      const output = join(root, 'upstream-radar.config.json')
+      await writeRadarConfig(config, { output })
+      const saved = JSON.parse(await readFile(output, 'utf8')) as typeof config
+      assert.equal(saved.projects[0]?.plugins[0]?.package.version, '1.2.3')
+      await assert.rejects(writeRadarConfig(config, { output }), /already exists/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps profile lookup inside DSH_HOME', () => {
+    assert.equal(
+      resolveDshProfileDirectory('web', '/tmp/dsh-home'),
+      '/tmp/dsh-home/profiles/web',
+    )
+    assert.throws(
+      () => resolveDshProfileDirectory('../outside', '/tmp/dsh-home'),
+      /simple DSH profile name/,
+    )
+  })
+
+  it('does not follow a bundle path outside the profile', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-init-'))
+    const profile = join(root, 'profiles', 'web')
+    try {
+      await mkdir(profile, { recursive: true })
+      await writeFile(join(profile, 'package.json'), JSON.stringify({
+        name: 'dsh-profile-web',
+        dsh: { profile: { bundles: ['../../outside'] } },
+      }))
+      await assert.rejects(
+        createRadarConfigFromDshProfile({ profileDirectory: profile }),
+        /escapes the profile node_modules directory/,
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## What changed

- add `upstream-radar init --profile <name>` to discover installed third-party DSH bundles
- resolve each exact public npm artifact with lifecycle scripts disabled and generate a reviewable Radar inventory
- keep the generated graph boundary explicit: profile-specific overrides and native pnpm peer resolution still require review
- add path-traversal and manifest-name checks for profile bundle discovery
- make the DSH-first quick start the README default in English and Chinese
- update the 0.5.0 changelog, roadmap, contributor path, issue/discussion links, and checked-in showcase reports

## Verification

- `pnpm test` — 56 passing tests
- `pnpm run check`
- `pnpm run scan:self`
- `pnpm run try:dsh:report`
- real DSH profile init against `dsh-cloudflare-browser-run@0.1.1` — 18 nodes, 65 edges
- `pnpm pack` — `upstream-radar@0.5.0`

## Product intent

This removes the largest first-use friction for DSH users: hand-writing the dependency graph before Radar can monitor it. The command creates a file users can inspect and approve; it does not start DSH or enable polling automatically.
