### PR TITLE
feat: streamline the DSH quick start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.5.1] - 2026-08-15
+
+### Changed
+
+- Put the DSH quick start before the visual hero so the first screen explains how to run Radar.
+- Make `init` print copy-pasteable environment variables and the profile start command, with the recommended state path included in JSON output.
+- Sharpen npm and README descriptions around exact vulnerable paths, breaking updates, and DSH Agent follow-up.
+
 ## [0.5.0] - 2026-08-15
 
 ### Added
@@ -47,3 +55,4 @@ All notable changes to Upstream Radar are documented here.
 [0.4.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.4.1
 [0.4.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.4.0
 [0.5.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.0
+[0.5.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.1

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
-<p align="center">
-  <picture>
-    <source media="(max-width: 600px)" srcset="docs/assets/upstream-radar-hero-mobile.jpg">
-    <img src="docs/assets/upstream-radar-hero.jpg" alt="Upstream Radar watches a dependency graph, highlights one affected path, and routes one signal to a DSH Agent." width="100%">
-  </picture>
-</p>
-
 <h1 align="center">Upstream Radar</h1>
 
-<p align="center"><strong>Always-on vulnerability and breaking-change radar for DeepSeek Harness plugins.</strong></p>
+<p align="center"><strong>Always-on dependency radar for DeepSeek Harness plugins: exact paths, breaking-change signals, and project-aware Agent follow-up.</strong></p>
 
 <p align="center">
   English · <a href="README.zh-CN.md">简体中文</a>
@@ -23,11 +16,36 @@
 </p>
 
 <p align="center">
+  <a href="#try-it-in-60-seconds">Try it in 60 seconds</a> ·
   <a href="#see-one-incident">See one incident</a> ·
   <a href="#install-in-dsh">Install in DSH</a> ·
   <a href="#run-the-proof">Run the proof</a> ·
   <a href="#how-the-loop-works">How it works</a> ·
   <a href="ROADMAP.md">Roadmap</a>
+</p>
+
+## Try it in 60 seconds
+
+Use a DSH profile that already contains at least one third-party bundle. Replace `web` with your profile name:
+
+```bash
+dsh plugin --profile web add upstream-radar@latest
+pnpm dlx upstream-radar@latest init \
+  --profile web \
+  --project-name "My DSH project" \
+  --workspace "$PWD" \
+  --output ./upstream-radar.config.json
+export UPSTREAM_RADAR_CONFIG=$PWD/upstream-radar.config.json
+dsh --profile web
+```
+
+The initializer writes a reviewable inventory; it does not start polling until `UPSTREAM_RADAR_CONFIG` is set. Read the [full DSH setup](#install-in-dsh) for state files, profile boundaries, and the real runtime proof.
+
+<p align="center">
+  <picture>
+    <source media="(max-width: 600px)" srcset="docs/assets/upstream-radar-hero-mobile.jpg">
+    <img src="docs/assets/upstream-radar-hero.jpg" alt="Upstream Radar watches a dependency graph, highlights one affected path, and routes one signal to a DSH Agent." width="100%">
+  </picture>
 </p>
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,13 +1,6 @@
-<p align="center">
-  <picture>
-    <source media="(max-width: 600px)" srcset="docs/assets/upstream-radar-hero-mobile.jpg">
-    <img src="docs/assets/upstream-radar-hero.jpg" alt="Upstream Radar 监控依赖图，只高亮真正受影响的路径，并把一个信号交给 DSH Agent。" width="100%">
-  </picture>
-</p>
-
 <h1 align="center">Upstream Radar</h1>
 
-<p align="center"><strong>面向 DeepSeek Harness 插件的常驻漏洞与破坏性更新雷达。</strong></p>
+<p align="center"><strong>面向 DeepSeek Harness 插件的常驻依赖雷达：精确路径、破坏性更新信号，以及带项目证据的 Agent 跟进。</strong></p>
 
 <p align="center">
   <a href="README.md">English</a> · 简体中文
@@ -20,6 +13,30 @@
   <a href="examples/dsh/README.md"><img alt="已使用 DSH 0.1.0-rc.6 验证" src="https://img.shields.io/badge/tested_with_DSH-0.1.0--rc.6-5b5bd6?style=flat-square"></a>
   <a href="https://github.com/MicroMilo/upstream-radar/releases"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/MicroMilo/upstream-radar?style=flat-square"></a>
   <a href="LICENSE"><img alt="Apache-2.0 许可证" src="https://img.shields.io/badge/license-Apache--2.0-0f766e?style=flat-square"></a>
+</p>
+
+## 60 秒开始
+
+使用一个已经安装至少一个第三方 bundle 的 DSH profile，把 `web` 换成你的 profile 名称：
+
+```bash
+dsh plugin --profile web add upstream-radar@latest
+pnpm dlx upstream-radar@latest init \
+  --profile web \
+  --project-name "我的 DSH 项目" \
+  --workspace "$PWD" \
+  --output ./upstream-radar.config.json
+export UPSTREAM_RADAR_CONFIG=$PWD/upstream-radar.config.json
+dsh --profile web
+```
+
+初始化命令会写出一份可审查的清单；只有设置 `UPSTREAM_RADAR_CONFIG` 后才会开始轮询。完整的状态文件、profile 边界和真实运行证明见[完整 DSH 配置](#安装到-dsh)。
+
+<p align="center">
+  <picture>
+    <source media="(max-width: 600px)" srcset="docs/assets/upstream-radar-hero-mobile.jpg">
+    <img src="docs/assets/upstream-radar-hero.jpg" alt="Upstream Radar 监控依赖图，只高亮真正受影响的路径，并把一个信号交给 DSH Agent。" width="100%">
+  </picture>
 </p>
 
 ---

--- a/examples/reports/block-remote-shell.json
+++ b/examples/reports/block-remote-shell.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/block-remote-shell.txt
+++ b/examples/reports/block-remote-shell.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.5.0
+Upstream Radar 0.5.1
 Target: showcase-block-remote-shell@1.0.0
 Artifact: sha256:0f40219b5cafd126e2215143fdeb4fe818a31cc401ba799841e0c2c800297ad9
 DSH bundle: no

--- a/examples/reports/clean-dsh-plugin.json
+++ b/examples/reports/clean-dsh-plugin.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/clean-dsh-plugin.txt
+++ b/examples/reports/clean-dsh-plugin.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.5.0
+Upstream Radar 0.5.1
 Target: showcase-clean-dsh-plugin@1.0.0
 Artifact: sha256:82dccb0367dd96bfdb737f2844aa023d8456949e2afe5630b99da271686c43ea
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/reports/dsh-cloudflare-browser-run-0.1.1.json
+++ b/examples/reports/dsh-cloudflare-browser-run-0.1.1.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "target": {
     "kind": "npm",

--- a/examples/reports/dsh-cloudflare-browser-run-0.1.1.txt
+++ b/examples/reports/dsh-cloudflare-browser-run-0.1.1.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.5.0
+Upstream Radar 0.5.1
 Target: dsh-cloudflare-browser-run@0.1.1
 Artifact: sha256:27fe660b2fe40b15b70a206310b883ca15722d8ffaacab63232b71128d28701f
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/reports/review-install-script.json
+++ b/examples/reports/review-install-script.json
@@ -2,7 +2,7 @@
   "schema": "upstream-radar.scan/v1alpha1",
   "tool": {
     "name": "upstream-radar",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "target": {
     "kind": "directory",

--- a/examples/reports/review-install-script.txt
+++ b/examples/reports/review-install-script.txt
@@ -1,4 +1,4 @@
-Upstream Radar 0.5.0
+Upstream Radar 0.5.1
 Target: showcase-review-install-script@1.0.0
 Artifact: sha256:fc43ac3189873f3fc3c207ce834b8670a8d74cc0121452a2e4400c4501d9f217
 DSH bundle: no

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "upstream-radar",
-  "version": "0.5.0",
-  "description": "Always-on vulnerability and breaking-change impact monitoring for DeepSeek Harness plugins.",
+  "version": "0.5.1",
+  "description": "Find the exact vulnerable path or breaking update in a DeepSeek Harness plugin, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",
   "author": "MicroMilo",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,10 @@ function safeErrorMessage(value: string): string {
   )).slice(0, 2_048)
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
 function usage(): string {
   return `Upstream Radar — always-on dependency and compatibility monitoring for DSH plugins
 
@@ -252,6 +256,7 @@ async function runInit(args: readonly string[]): Promise<number> {
     ...(registry === undefined ? {} : { registry }),
   })
   const outputPath = await writeRadarConfig(config, { output, force })
+  const statePath = `${outputPath}.state.json`
   const plugins = config.projects[0]?.plugins ?? []
   if (json) {
     process.stdout.write(`${JSON.stringify({ output: outputPath, profile, plugins: plugins.map(plugin => ({
@@ -259,11 +264,11 @@ async function runInit(args: readonly string[]): Promise<number> {
       version: plugin.package.version,
       nodes: plugin.graph.nodes.length,
       edges: plugin.graph.edges.length,
-    })) }, null, 2)}\n`)
+    })), state: statePath }, null, 2)}\n`)
   } else {
     process.stdout.write(`Created ${outputPath}\nDiscovered ${plugins.length} DSH plugin bundle(s):\n`)
     for (const plugin of plugins) process.stdout.write(`  ${plugin.package.name}@${plugin.package.version} (${plugin.graph.nodes.length} dependency nodes)\n`)
-    process.stdout.write('\nReview the generated inventory, then set UPSTREAM_RADAR_CONFIG before starting DSH.\n')
+    process.stdout.write(`\nReview the generated inventory, then run:\n  export UPSTREAM_RADAR_CONFIG=${shellQuote(outputPath)}\n  export UPSTREAM_RADAR_STATE=${shellQuote(statePath)}\n  dsh --profile ${shellQuote(profile)}\n`)
   }
   return 0
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.5.0'
+export const TOOL_VERSION = '0.5.1'


### PR DESCRIPTION
## What changed

- move the title and value proposition above the visual hero
- add a copy-pasteable 60-second DSH quick start in English and Chinese
- make `init` print quoted config/state exports and the profile start command
- include the recommended state path in JSON output
- sharpen npm/GitHub/README wording around exact vulnerable paths, breaking updates, and DSH Agent follow-up
- refresh checked-in reports for `0.5.1`

## Verification

- `pnpm test` — 56 passing tests
- `pnpm run check`
- `pnpm run scan:self`
- `node scripts/showcase.mjs --write-reports`
- `node scripts/radar-showcase.mjs --write-reports`
- `node scripts/dsh-headless-showcase.mjs --write-report`
- `pnpm pack` — `upstream-radar@0.5.1`
- real DSH profile init prints runnable next steps
