### PR TITLE
feat: add one-command radar watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.6.0] - 2026-08-16
+
+### Added
+
+- Add `upstream-radar radar watch` with a safe bounded interval and `--once` mode for simple local, CI, and demo runs.
+- Document the CLI fallback while keeping native DSH delivery as the recommended always-on path.
+
 ## [0.5.3] - 2026-08-15
 
 ### Changed
@@ -72,3 +79,4 @@ All notable changes to Upstream Radar are documented here.
 [0.5.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.1
 [0.5.2]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.2
 [0.5.3]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.3
+[0.6.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.0

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ dsh --profile web
 
 The initializer writes a reviewable inventory; it does not start polling until `UPSTREAM_RADAR_CONFIG` is set. Read the [full DSH setup](#install-in-dsh) for state files, profile boundaries, and the real runtime proof.
 
+If you want to try the monitoring loop without booting a DSH profile, run one cycle from a reviewed inventory:
+
+```bash
+upstream-radar radar watch ./upstream-radar.config.json --once
+```
+
+Remove `--once` to keep a local monitor alive. This is a lightweight CLI surface for demos, CI, and diagnosis; the native DSH bundle remains the recommended always-on path because it can deliver the task to a live Agent.
+
 <p align="center">
   <picture>
     <source media="(max-width: 600px)" srcset="docs/assets/upstream-radar-hero-mobile.jpg">
@@ -156,6 +164,14 @@ This proof runs in CI on Node.js 22. See the executable [showcase contract](exam
 6. Send a plugin-originated follow-up to the first live root DSH Agent.
 7. Keep the task on disk when no Agent is available; cancel it when the incident resolves.
 
+For a local process or a scheduled runner, the same loop is available as:
+
+```bash
+upstream-radar radar watch ./upstream-radar.config.json --interval 1800
+```
+
+Use `--once --json` for a machine-readable CI check. The command persists the same state file and emits only new, changed, or resolved incidents.
+
 The handoff uses `ctx.agents.roots()[0].followup(...)` with:
 
 ```json
@@ -241,6 +257,7 @@ upstream-radar inspect npm:dsh-cloudflare-browser-run@0.1.1 --deep
 - `init --profile <name>` discovers a named DSH profile and generates a reviewable inventory; automatic active-profile selection and native pnpm override/peer resolution are not implemented yet.
 - npm lock graphs are supported; pnpm and Yarn graph adapters are not implemented.
 - OSV and npm `latest` are the live sources; GitHub release and migration-guide ingestion are deferred.
+- `radar watch` is a CLI monitoring fallback; it does not deliver tasks into DSH by itself.
 - Delivery currently targets the first live root Agent rather than a project-specific session.
 - Agent conclusions stay in the DSH Session; Radar does not ingest them back into incident state yet.
 - No Issue, branch, Pull Request, dependency override, or merge is created automatically.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@
 - [x] Route every event to a project, owner, and configured channel.
 - [x] Persist pending DSH Agent analysis tasks before delivery.
 - [x] Ship an installable DSH bundle with a bounded fixed polling interval.
+- [x] Ship a one-command CLI watch loop for demos, CI, and local diagnosis.
 - [x] Provide a deterministic vulnerability and breaking-change showcase.
 - [x] Prove bundle installation, plugin-source attribution, Session persistence, and Agent delivery in a real DSH headless profile.
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -32,6 +32,14 @@ dsh --profile web
 
 初始化命令会写出一份可审查的清单；只有设置 `UPSTREAM_RADAR_CONFIG` 后才会开始轮询。完整的状态文件、profile 边界和真实运行证明见[完整 DSH 配置](#安装到-dsh)。
 
+如果只想先试跑一次监控，而不启动 DSH profile，可以使用同一份清单：
+
+```bash
+upstream-radar radar watch ./upstream-radar.config.json --once
+```
+
+去掉 `--once` 就会持续运行。这个入口适合演示、CI 和排查；需要把任务交给在线 Agent 时，仍然应该安装 DSH bundle。
+
 <p align="center">
   <picture>
     <source media="(max-width: 600px)" srcset="assets/upstream-radar-hero-mobile.jpg">
@@ -145,6 +153,14 @@ pnpm run try:dsh
 6. 通过 `ctx.agents.roots()[0].followup(...)` 唤醒在线 DSH Agent。
 7. Agent 不在线时保留任务；事件解决后撤销过期任务。
 
+如果需要在本地进程或定时任务里运行同一套监控，也可以使用：
+
+```bash
+upstream-radar radar watch ./upstream-radar.config.json --interval 1800
+```
+
+CI 中使用 `--once --json`。它复用同一个状态文件，只输出新建、变化和恢复的事件。
+
 投递消息保留明确的插件身份：
 
 ```json
@@ -194,6 +210,8 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 已经支持：npm lock 依赖图、重复版本路径、OSV 精确版本匹配、恶意包记录、npm release 监听、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
 
 `init --profile <name>` 已经可以发现指定的 DSH profile 并生成可审查清单；暂未支持自动选择当前 active profile、原生解析 pnpm override/peer 规则、Yarn 图适配、GitHub release 与迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
+
+`radar watch` 是 CLI 监控入口，本身不会把任务投递给 DSH；需要 Agent 分析时应使用原生 DSH bundle。
 
 Upstream Radar 目前是面向 DSH developer preview 生态的 alpha 软件，事件结构和适配边界仍可能变化。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Dependency security monitoring for DeepSeek Harness (DSH) plugins: find the exact vulnerable path or breaking update, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ Usage:
   upstream-radar scan <directory> [--json] [--fail-on <warn|review|block|never>]
   upstream-radar inspect npm:<package>@<exact-version> [--deep] [--json] [--fail-on <warn|review|block|never>]
   upstream-radar radar check <config.json> [--state <state.json>] [--json]
+  upstream-radar radar watch <config.json> [--state <state.json>] [--interval <seconds>] [--once] [--json]
   upstream-radar radar compare <config.json> <before.json> <candidate.json> [--notes <release-notes.txt>] [--json]
   upstream-radar task list <state.json> [--json]
   upstream-radar task show <state.json> [task-id] [--json]
@@ -49,7 +50,7 @@ Commands:
   init     discover third-party bundles in a DSH profile and write a reviewable inventory
   scan     bounded, read-only inspection of a local package directory
   inspect  fetch and verify the exact npm artifact before inspecting its contents
-  radar    monitor vulnerability changes or assess a candidate compatibility change
+  radar    monitor vulnerability changes, watch continuously, or assess a candidate compatibility change
   task     inspect or acknowledge the durable DSH analysis outbox
 
 Options:
@@ -57,6 +58,8 @@ Options:
   --registry <url>     HTTPS npm registry (default: https://registry.npmjs.org/)
   --state <path>       persistent radar state (default: <config.json>.state.json)
   --osv-base-url <url> alternate HTTPS OSV API base URL
+  --interval <seconds> watch interval from 300 to 86400 seconds (default: 1800)
+  --once               run one watch cycle and exit (useful for CI and demos)
   --notes <path>       release notes used as untrusted compatibility evidence
   --profile <name>     DSH profile to inspect for init (default DSH_HOME/profiles/<name>)
   --output <path>      init output path (default: ./upstream-radar.config.json)
@@ -147,8 +150,8 @@ async function readJson(path: string): Promise<unknown> {
 
 async function runRadar(args: readonly string[]): Promise<number> {
   const subcommand = args[0]
-  if (subcommand !== 'check' && subcommand !== 'compare') {
-    throw new Error('radar requires check or compare')
+  if (subcommand !== 'check' && subcommand !== 'watch' && subcommand !== 'compare') {
+    throw new Error('radar requires check, watch or compare')
   }
   const configPath = args[1]
   if (configPath === undefined || configPath.startsWith('-')) throw new Error(`radar ${subcommand} requires a config file`)
@@ -156,17 +159,33 @@ async function runRadar(args: readonly string[]): Promise<number> {
   let json = false
   let statePath: string | undefined
   let osvBaseUrl: string | undefined
+  let registry: string | undefined
   let notesPath: string | undefined
+  let intervalSeconds = 1_800
+  let intervalProvided = false
+  let once = false
   for (let index = 2; index < args.length; index += 1) {
     const argument = args[index]
     if (argument === '--json') {
       json = true
-    } else if (argument === '--state' || argument === '--osv-base-url' || argument === '--notes') {
+    } else if (argument === '--once') {
+      once = true
+    } else if (argument === '--state' || argument === '--osv-base-url' || argument === '--registry'
+      || argument === '--notes' || argument === '--interval') {
       const value = args[index + 1]
       if (value === undefined || value.startsWith('-')) throw new Error(`${argument} requires a value`)
       if (argument === '--state') statePath = value
       else if (argument === '--osv-base-url') osvBaseUrl = value
-      else notesPath = value
+      else if (argument === '--registry') registry = value
+      else if (argument === '--notes') notesPath = value
+      else {
+        intervalProvided = true
+        const parsed = Number(value)
+        if (!Number.isSafeInteger(parsed) || parsed < 300 || parsed > 86_400) {
+          throw new Error('--interval must be an integer between 300 and 86400')
+        }
+        intervalSeconds = parsed
+      }
       index += 1
     } else if (argument?.startsWith('-')) {
       throw new Error(`unknown option for radar ${subcommand}: ${argument}`)
@@ -175,22 +194,76 @@ async function runRadar(args: readonly string[]): Promise<number> {
     }
   }
 
-  const config = parseRadarConfig(await readJson(configPath))
-  if (subcommand === 'check') {
-    if (positional.length > 0 || notesPath !== undefined) throw new Error('radar check received unexpected arguments')
-    const stateFile = statePath ?? `${resolve(configPath)}.state.json`
+  const readConfig = async () => parseRadarConfig(await readJson(configPath))
+  const osv = new OsvClient({
+    ...(osvBaseUrl === undefined ? {} : { baseUrl: osvBaseUrl }),
+  })
+  const releases = new NpmReleaseClient({
+    ...(registry === undefined ? {} : { registry }),
+  })
+  const stateFile = statePath ?? `${resolve(configPath)}.state.json`
+  const runCheck = async () => {
+    const config = await readConfig()
     const state = statePath === ':memory:' ? emptyRadarState() : await loadRadarState(stateFile)
-    const result = await pollRadar(config.projects, state, new OsvClient({
-      ...(osvBaseUrl === undefined ? {} : { baseUrl: osvBaseUrl }),
-    }), new Date(), new NpmReleaseClient())
+    const result = await pollRadar(config.projects, state, osv, new Date(), releases)
     if (statePath !== ':memory:') await saveRadarState(stateFile, result.state)
+    return result
+  }
+  const writeCheckResult = (result: Awaited<ReturnType<typeof pollRadar>>, compactJson = false): void => {
     process.stdout.write(json
-      ? `${JSON.stringify(result, null, 2)}\n`
+      ? `${JSON.stringify(result, null, compactJson ? 0 : 2)}\n`
       : `${renderRadarEvents(result.events)}${result.sourceErrors.map(error => `Source warning (${error.source}): ${safeErrorMessage(error.message)}\n`).join('')}Prepared ${result.analysisTasks.length} DSH analysis task(s); queried ${result.packagesQueried} exact package versions and ${result.releasePackagesQueried} release streams.\n`)
+  }
+
+  if (subcommand === 'check') {
+    if (positional.length > 0 || notesPath !== undefined || once || intervalProvided) {
+      throw new Error('radar check received an option meant for watch or compare')
+    }
+    writeCheckResult(await runCheck())
     return 0
   }
 
-  if (statePath !== undefined || osvBaseUrl !== undefined) throw new Error('radar compare does not accept --state or --osv-base-url')
+  if (subcommand === 'watch') {
+    if (positional.length > 0 || notesPath !== undefined) throw new Error('radar watch received unexpected arguments')
+    let stopped = false
+    let timer: NodeJS.Timeout | undefined
+    let wake: (() => void) | undefined
+    const stop = (): void => {
+      stopped = true
+      if (timer !== undefined) clearTimeout(timer)
+      wake?.()
+    }
+    process.once('SIGINT', stop)
+    process.once('SIGTERM', stop)
+    try {
+      do {
+        try {
+          writeCheckResult(await runCheck(), true)
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error)
+          process.stderr.write(`upstream-radar: watch cycle failed: ${safeErrorMessage(message)}\n`)
+          if (once) return 1
+        }
+        if (once || stopped) break
+        await new Promise<void>(resolvePromise => {
+          wake = resolvePromise
+          timer = setTimeout(resolvePromise, intervalSeconds * 1_000)
+        })
+        timer = undefined
+        wake = undefined
+      } while (!stopped)
+    } finally {
+      if (timer !== undefined) clearTimeout(timer)
+      process.removeListener('SIGINT', stop)
+      process.removeListener('SIGTERM', stop)
+    }
+    return 0
+  }
+
+  if (statePath !== undefined || osvBaseUrl !== undefined || registry !== undefined || once || intervalProvided) {
+    throw new Error('radar compare does not accept check or watch options')
+  }
+  const config = await readConfig()
   if (positional.length !== 2) throw new Error('radar compare requires before.json and candidate.json')
   const previous = parsePackageManifestSnapshot(await readJson(positional[0] ?? ''))
   const candidate = parsePackageManifestSnapshot(await readJson(positional[1] ?? ''))

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.5.3'
+export const TOOL_VERSION = '0.6.0'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -15,6 +15,21 @@ const cli = resolve(repository, 'dist/src/cli.js')
 const fixture = resolve(repository, 'examples/fixtures/clean-dsh-plugin')
 
 describe('CLI option parsing', () => {
+  it('advertises a one-command watch loop and validates its safety interval', () => {
+    const help = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8' })
+    assert.equal(help.status, 0)
+    assert.match(help.stdout, /radar watch <config\.json>/)
+    assert.match(help.stdout, /--once\s+run one watch cycle and exit/)
+
+    const invalid = spawnSync(process.execPath, [cli, 'radar', 'watch', 'missing.json', '--interval', '299'], { encoding: 'utf8' })
+    assert.equal(invalid.status, 1)
+    assert.match(invalid.stderr, /--interval must be an integer between 300 and 86400/)
+
+    const misplaced = spawnSync(process.execPath, [cli, 'radar', 'compare', 'missing.json', 'before.json', 'candidate.json', '--interval', '1800'], { encoding: 'utf8' })
+    assert.equal(misplaced.status, 1)
+    assert.match(misplaced.stderr, /radar compare does not accept check or watch options/)
+  })
+
   it('rejects unknown options instead of silently weakening a scan', () => {
     const result = spawnSync(process.execPath, [cli, 'scan', fixture, '--jsno'], { encoding: 'utf8' })
     assert.equal(result.status, 1)


### PR DESCRIPTION
## What changed

- add `upstream-radar radar watch <config>` for continuous local monitoring
- add `--once` for CI and reproducible demos
- add a bounded 300–86400 second interval and graceful SIGINT/SIGTERM shutdown
- reload the reviewed inventory each cycle and persist the existing Radar state
- document the CLI fallback in English and Chinese while keeping native DSH delivery as the recommended always-on path
- prepare the package as `0.6.0`

## Why

The DSH bundle already provides the native Agent handoff, but trying the deterministic monitoring loop required users to assemble a one-shot command and an external scheduler. This gives the project a copy-pasteable entrypoint without weakening the DSH boundary.

## Verification

- `pnpm test` — 57 passing tests
- `pnpm run try:dsh:report` — bundle installed, task reached the model, plugin source preserved, pending tasks cleared
- `pnpm pack` — `upstream-radar@0.6.0` tarball contains the new CLI
- live `radar watch --once` — queried OSV and npm and rendered current vulnerability events