### PR TITLE
fix: make CLI examples directly runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.6.1] - 2026-08-16
+
+### Fixed
+
+- Make the new CLI examples directly runnable from a fresh setup with `pnpm dlx upstream-radar@latest` instead of assuming a global binary.
+
 ## [0.6.0] - 2026-08-16
 
 ### Added
@@ -80,3 +86,4 @@ All notable changes to Upstream Radar are documented here.
 [0.5.2]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.2
 [0.5.3]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.3
 [0.6.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.0
+[0.6.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.1

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The initializer writes a reviewable inventory; it does not start polling until `
 If you want to try the monitoring loop without booting a DSH profile, run one cycle from a reviewed inventory:
 
 ```bash
-upstream-radar radar watch ./upstream-radar.config.json --once
+pnpm dlx upstream-radar@latest radar watch ./upstream-radar.config.json --once
 ```
 
 Remove `--once` to keep a local monitor alive. This is a lightweight CLI surface for demos, CI, and diagnosis; the native DSH bundle remains the recommended always-on path because it can deliver the task to a live Agent.
@@ -167,7 +167,7 @@ This proof runs in CI on Node.js 22. See the executable [showcase contract](exam
 For a local process or a scheduled runner, the same loop is available as:
 
 ```bash
-upstream-radar radar watch ./upstream-radar.config.json --interval 1800
+pnpm dlx upstream-radar@latest radar watch ./upstream-radar.config.json --interval 1800
 ```
 
 Use `--once --json` for a machine-readable CI check. The command persists the same state file and emits only new, changed, or resolved incidents.
@@ -248,8 +248,8 @@ Advisories, release notes, links, package names, and repository strings remain u
 The bounded pre-install scanner remains available as a supporting collector:
 
 ```bash
-upstream-radar scan /path/to/dsh-plugin
-upstream-radar inspect npm:dsh-cloudflare-browser-run@0.1.1 --deep
+pnpm dlx upstream-radar@latest scan /path/to/dsh-plugin
+pnpm dlx upstream-radar@latest inspect npm:dsh-cloudflare-browser-run@0.1.1 --deep
 ```
 
 ## Current boundaries

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -35,7 +35,7 @@ dsh --profile web
 如果只想先试跑一次监控，而不启动 DSH profile，可以使用同一份清单：
 
 ```bash
-upstream-radar radar watch ./upstream-radar.config.json --once
+pnpm dlx upstream-radar@latest radar watch ./upstream-radar.config.json --once
 ```
 
 去掉 `--once` 就会持续运行。这个入口适合演示、CI 和排查；需要把任务交给在线 Agent 时，仍然应该安装 DSH bundle。
@@ -156,7 +156,7 @@ pnpm run try:dsh
 如果需要在本地进程或定时任务里运行同一套监控，也可以使用：
 
 ```bash
-upstream-radar radar watch ./upstream-radar.config.json --interval 1800
+pnpm dlx upstream-radar@latest radar watch ./upstream-radar.config.json --interval 1800
 ```
 
 CI 中使用 `--once --json`。它复用同一个状态文件，只输出新建、变化和恢复的事件。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Dependency security monitoring for DeepSeek Harness (DSH) plugins: find the exact vulnerable path or breaking update, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.6.0'
+export const TOOL_VERSION = '0.6.1'


### PR DESCRIPTION
## What changed

- use `pnpm dlx upstream-radar@latest` in the new watch examples
- make the supporting scan and inspect examples directly runnable too
- prepare patch release `0.6.1`

## Why

The 0.6.0 README assumed a globally installed `upstream-radar` binary even though the first-use path uses `pnpm dlx`. A fresh user copying the next command could therefore get `command not found`.

## Verification

- `pnpm test` — 57 passing tests
- `pnpm run try:dsh:report` — DSH handoff proof passes
- `pnpm pack` — `upstream-radar@0.6.1` package contents verified