### PR TITLE
feat: add durable source health alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.8.0] - 2026-08-16
+
+### Added
+
+- Persist per-source health with last attempt, last success, consecutive failures, and bounded error details.
+- Create one durable DSH `source-health` notice after three consecutive source failures and resolve it when the source recovers.
+- Add source-health lifecycle evidence to the deterministic showcase.
+
 ## [0.7.1] - 2026-08-16
 
 ### Fixed
@@ -111,3 +119,4 @@ All notable changes to Upstream Radar are documented here.
 [0.6.2]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.2
 [0.7.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.7.0
 [0.7.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.7.1
+[0.8.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.8.0

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The generated graph is the exact public npm artifact graph for the installed bun
 
 For a hand-written or CI fixture, use [the example inventory](examples/radar/config.json). If `UPSTREAM_RADAR_CONFIG` is not set, the bundle stays dormant and performs no polling.
 
-Once running, Radar polls OSV, npm, and public GitHub Releases, persists incident state before delivery, and submits only changed incidents to the first live root DSH Agent. If a source is temporarily unavailable, Radar keeps the last confirmed state instead of claiming that the project is clean, and continues delivering already queued tasks.
+Once running, Radar polls OSV, npm, and public GitHub Releases, persists incident state before delivery, and submits only changed incidents to the first live root DSH Agent. If a source is temporarily unavailable, Radar keeps the last confirmed state instead of claiming that the project is clean, continues delivering already queued tasks, and creates one source-health notice after three consecutive failures.
 
 ## Run the proof
 
@@ -257,7 +257,7 @@ pnpm dlx --package=upstream-radar@latest upstream-radar inspect npm:dsh-cloudfla
 - `init --profile <name>` discovers a named DSH profile and generates a reviewable inventory; automatic active-profile selection and native pnpm override/peer resolution are not implemented yet.
 - npm lock graphs are supported; pnpm and Yarn graph adapters are not implemented.
 - OSV, npm `latest`, and public GitHub Release notes are live sources; changelog, comparison-diff, and migration-guide ingestion are deferred.
-- A failed OSV check preserves confirmed matches and returns a visible source warning; durable source health history and health alerts are not implemented yet.
+- A failed OSV check preserves confirmed matches and returns a visible source warning; source health is durable and routed through DSH after three consecutive failures, while source-claim conflict handling and external health destinations are not implemented yet.
 - `radar watch` is a CLI monitoring fallback; it does not deliver tasks into DSH by itself.
 - Delivery currently targets the first live root Agent rather than a project-specific session.
 - Agent conclusions stay in the DSH Session; Radar does not ingest them back into incident state yet.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,8 @@
 - [ ] Deduplicate OSV, GHSA, CVE, and malicious-package aliases.
 - [ ] Detect when a previously unavailable fixed version is published.
 - [ ] Calculate whether a top-level plugin update actually removes every affected path.
-- [ ] Add source reliability and conflict handling without asking the model to decide version applicability.
+- [x] Persist per-source health, alert after three consecutive failures, and resolve the alert when the source recovers without asking the model to decide version applicability.
+- [ ] Detect conflicting source claims without asking the model to decide version applicability.
 - [x] Preserve confirmed vulnerability state and pending DSH tasks when OSV is temporarily unavailable; surface the failure to CLI and DSH logs.
 
 ## Milestone 4 — GitHub execution arm

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -207,7 +207,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：npm lock 依赖图、重复版本路径、OSV 精确版本匹配、恶意包记录、npm release 监听、公开 GitHub Release 说明、OSV 故障时保留已确认状态、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
+已经支持：npm lock 依赖图、重复版本路径、OSV 精确版本匹配、恶意包记录、npm release 监听、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
 
 `init --profile <name>` 已经可以发现指定的 DSH profile 并生成可审查清单；暂未支持自动选择当前 active profile、原生解析 pnpm override/peer 规则、Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,8 @@ The npm deep collector resolves in a temporary project with lifecycle scripts di
 
 If OSV is unavailable, the cycle records a source warning, keeps the last confirmed vulnerability matches, emits no false `resolved` events, and still proceeds to deliver already-persisted DSH tasks. A failed source is never treated as a clean result.
 
+The same cycle persists `lastAttemptedAt`, `lastSucceededAt`, consecutive failures, and a bounded error for each attempted source. Three consecutive failures create one project-routed `source-health` event in the same outbox; a successful check resolves it.
+
 The active-match key binds project, plugin version, affected package version, and advisory id. An unchanged advisory does not create another event.
 
 ## Compatibility cycle

--- a/docs/checks.zh-CN.md
+++ b/docs/checks.zh-CN.md
@@ -15,7 +15,7 @@
 | Breaking signals | 新版本是否跨兼容边界或改变关键声明 | 比较版本、入口、exports、Node、DSH bundle 和 peer 范围 | confirmed/strong/needs-analysis |
 | DSH 分析入口 | 如何避免“新闻”直接指挥 Agent | 将所有来源文字标记为不可信数据，要求只读和项目证据 | 由 DSH 原生投递；CLI 只用于检查持久 analysis task |
 | 去重与恢复 | 重启、重复轮询是否丢失、刷屏或投递过期任务 | 保存活跃漏洞、活跃兼容性问题和待分析任务；同一 incident 的新任务替换旧任务，resolved 会撤销旧任务 | 至少一次投递，不变不重复，不过期投递 |
-| 源失败隔离 | OSV 暂时查不到时，是否会被误判成“没有漏洞” | 保留上一次确认的漏洞状态，不生成假的 `resolved`，仍继续投递已有 DSH 任务；CLI/JSON 返回源警告 | `sourceErrors: osv`，CLI 单次检查返回失败 |
+| 源失败与健康 | OSV 暂时查不到时，是否会被误判成“没有漏洞”，以及负责人能否知道源长期不可用 | 保留上一次确认的漏洞状态，不生成假的 `resolved`，仍继续投递已有 DSH 任务；连续 3 次失败生成持久 `source-health` DSH notice，恢复后 `resolved`；CLI/JSON 返回源警告 | `sourceErrors: osv`、源健康状态、source-health 生命周期 |
 
 ## 支持性的安装前检查
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -85,6 +85,10 @@ The update replaces the older offline task instead of accumulating two analyses.
 
 The showcase then simulates an OSV timeout. Radar emits no new or resolved vulnerability event, keeps the previously confirmed match, keeps the pending DSH task, and returns a visible `sourceErrors: osv` warning. The evidence is saved as `examples/radar/reports/07-source-outage.json`.
 
+## Scene 7 — repeated failures become one source-health notice
+
+After three consecutive failed OSV checks, Radar creates one project-routed `source-health` incident and sends it through the same durable DSH outbox. When OSV recovers, the source-health incident resolves and its pending task is removed. The lifecycle is saved as `examples/radar/reports/08-source-health-lifecycle.json`.
+
 ## Live sources
 
 The fixture isolates behavior from network timing. Production cycles use:

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -73,5 +73,5 @@ Delivery is at-least-once. The state/outbox write happens before `Agent.followup
 - GitHub comparison diffs, changelogs, and migration guides are not fetched automatically.
 - One live root DSH Agent acts as the security inbox; project-session selection is not implemented.
 - The prompt establishes a read-only contract, but enforcement still depends on the DSH Agent's configured tools and permission policy.
-- Feed failures are reported by the cycle; OSV failures preserve the last confirmed matches and pending tasks, while durable per-source health history and health alerts remain future work.
+- Feed failures are reported by the cycle; OSV failures preserve the last confirmed matches and pending tasks, and three consecutive failures create a durable source-health alert. Conflicting source claims and external health destinations remain future work.
 - The scanner uses the host npm CLI with scripts disabled; it is not a microVM detonation boundary.

--- a/examples/radar/reports/01-baseline.json
+++ b/examples/radar/reports/01-baseline.json
@@ -9,6 +9,14 @@
     "schema": "upstream-radar.radar-state/v1alpha1",
     "activeVulnerabilities": {},
     "activeCompatibility": {},
-    "pendingAnalysisTasks": []
+    "pendingAnalysisTasks": [],
+    "sourceHealth": {
+      "osv": {
+        "lastAttemptedAt": "2026-08-14T00:30:00.000Z",
+        "lastSucceededAt": "2026-08-14T00:30:00.000Z",
+        "consecutiveFailures": 0
+      }
+    },
+    "activeSourceHealth": {}
   }
 }

--- a/examples/radar/reports/02-vulnerability-alert.json
+++ b/examples/radar/reports/02-vulnerability-alert.json
@@ -332,6 +332,14 @@
           "reasoning_summary": "short explanation separating deterministic facts from model analysis"
         }
       }
-    ]
+    ],
+    "sourceHealth": {
+      "osv": {
+        "lastAttemptedAt": "2026-08-14T01:01:00.000Z",
+        "lastSucceededAt": "2026-08-14T01:01:00.000Z",
+        "consecutiveFailures": 0
+      }
+    },
+    "activeSourceHealth": {}
   }
 }

--- a/examples/radar/reports/07-source-outage.json
+++ b/examples/radar/reports/07-source-outage.json
@@ -177,6 +177,15 @@
           "reasoning_summary": "short explanation separating deterministic facts from model analysis"
         }
       }
-    ]
+    ],
+    "sourceHealth": {
+      "osv": {
+        "lastAttemptedAt": "2026-08-14T05:00:00.000Z",
+        "consecutiveFailures": 1,
+        "lastSucceededAt": "2026-08-14T01:01:00.000Z",
+        "lastError": "simulated OSV timeout"
+      }
+    },
+    "activeSourceHealth": {}
   }
 }

--- a/examples/radar/reports/08-source-health-lifecycle.json
+++ b/examples/radar/reports/08-source-health-lifecycle.json
@@ -1,0 +1,64 @@
+{
+  "alert": {
+    "schema": "upstream-radar.event/v1alpha1",
+    "id": "event-55c41b7231d1f448470550a5",
+    "incidentId": "payments-api\u0000osv",
+    "kind": "source-health",
+    "change": "new",
+    "detectedAt": "2026-08-14T06:30:00.000Z",
+    "project": {
+      "id": "payments-api",
+      "name": "Payments API",
+      "repository": "https://github.com/acme/payments-api",
+      "workspace": "examples/radar/project",
+      "owner": "payments-platform",
+      "channels": [
+        "feishu:payments-security"
+      ]
+    },
+    "route": {
+      "owner": "payments-platform",
+      "channels": [
+        "feishu:payments-security"
+      ]
+    },
+    "source": "osv",
+    "status": "degraded",
+    "failureCount": 3,
+    "lastAttemptedAt": "2026-08-14T06:30:00.000Z",
+    "error": "simulated OSV timeout"
+  },
+  "recovered": {
+    "schema": "upstream-radar.event/v1alpha1",
+    "id": "event-064acdf3633b58f283b51ab4",
+    "incidentId": "payments-api\u0000osv",
+    "kind": "source-health",
+    "change": "resolved",
+    "detectedAt": "2026-08-14T07:00:00.000Z",
+    "project": {
+      "id": "payments-api",
+      "name": "Payments API",
+      "repository": "https://github.com/acme/payments-api",
+      "workspace": "examples/radar/project",
+      "owner": "payments-platform",
+      "channels": [
+        "feishu:payments-security"
+      ]
+    },
+    "route": {
+      "owner": "payments-platform",
+      "channels": [
+        "feishu:payments-security"
+      ]
+    },
+    "source": "osv",
+    "status": "healthy",
+    "failureCount": 0,
+    "lastAttemptedAt": "2026-08-14T07:00:00.000Z",
+    "lastSucceededAt": "2026-08-14T07:00:00.000Z"
+  },
+  "pendingTaskCounts": {
+    "afterAlert": 1,
+    "afterRecovery": 0
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Dependency security monitoring for DeepSeek Harness (DSH) plugins: find the exact vulnerable path or breaking update, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/scripts/radar-showcase.mjs
+++ b/scripts/radar-showcase.mjs
@@ -199,4 +199,46 @@ process.stdout.write([
 ].join('\n'))
 await save('07-source-outage.json', outage)
 
-process.stdout.write('\nShowcase complete: feed change -> exact graph match -> project route -> current DSH task -> resolved incident -> source outage without false resolution.\n')
+heading(7, 'Repeated failures become one routed source-health notice')
+const healthFirst = await pollRadar(
+  config.projects,
+  emptyRadarState(),
+  unavailableSource('simulated OSV timeout'),
+  new Date('2026-08-14T05:30:00.000Z'),
+)
+const healthSecond = await pollRadar(
+  config.projects,
+  healthFirst.state,
+  unavailableSource('simulated OSV timeout'),
+  new Date('2026-08-14T06:00:00.000Z'),
+)
+const healthThird = await pollRadar(
+  config.projects,
+  healthSecond.state,
+  unavailableSource('simulated OSV timeout'),
+  new Date('2026-08-14T06:30:00.000Z'),
+)
+const healthRecovered = await pollRadar(
+  config.projects,
+  healthThird.state,
+  source([]),
+  new Date('2026-08-14T07:00:00.000Z'),
+)
+const healthEvent = healthThird.events.find(event => event.kind === 'source-health')
+const recoveryEvent = healthRecovered.events.find(event => event.kind === 'source-health')
+if (healthEvent === undefined || recoveryEvent === undefined) throw new Error('showcase source-health lifecycle did not produce both transitions')
+process.stdout.write([
+  `ALERT: ${healthEvent.source} failed ${healthEvent.failureCount} times; queued DSH tasks: ${healthThird.state.pendingAnalysisTasks.length}`,
+  `RECOVERED: ${recoveryEvent.source}; queued DSH tasks: ${healthRecovered.state.pendingAnalysisTasks.length}`,
+  '',
+].join('\n'))
+await save('08-source-health-lifecycle.json', {
+  alert: healthEvent,
+  recovered: recoveryEvent,
+  pendingTaskCounts: {
+    afterAlert: healthThird.state.pendingAnalysisTasks.length,
+    afterRecovery: healthRecovered.state.pendingAnalysisTasks.length,
+  },
+})
+
+process.stdout.write('\nShowcase complete: feed change -> exact graph match -> project route -> current DSH task -> resolved incident -> source outage -> source-health alert and recovery.\n')

--- a/src/dsh-analysis.ts
+++ b/src/dsh-analysis.ts
@@ -35,7 +35,9 @@ export function createAnalysisTask(event: RadarEvent): AnalysisTask {
 export function renderAgentAnalysisPrompt(task: AnalysisTask): string {
   const focus = task.event.kind === 'compatibility'
     ? '判断这个候选升级会不会破坏当前项目，定位受影响的 API、配置或运行环境，并给出最小迁移与验证方案。'
-    : '判断该漏洞的触发条件在当前项目中是否成立，定位实际调用和数据入口，并给出当前项目可以执行的修复方案。'
+    : task.event.kind === 'source-health'
+      ? '确认监控源当前不可用对告警覆盖造成的影响，向项目负责人说明不要把“没有新事件”当作安全结论，并给出恢复该监控源的最小行动。'
+      : '判断该漏洞的触发条件在当前项目中是否成立，定位实际调用和数据入口，并给出当前项目可以执行的修复方案。'
 
   return `[UPSTREAM RADAR ANALYSIS TASK]
 

--- a/src/dsh-plugin.ts
+++ b/src/dsh-plugin.ts
@@ -56,9 +56,9 @@ function safeMessage(error: unknown): string {
 
 function taskSummary(task: AnalysisTask): string {
   const project = task.event.project.name.slice(0, 60)
-  return task.event.kind === 'compatibility'
-    ? `Compatibility change for ${project}`
-    : `${task.event.kind === 'malware' ? 'Malicious package' : 'Vulnerability'} for ${project}`
+  if (task.event.kind === 'compatibility') return `Compatibility change for ${project}`
+  if (task.event.kind === 'source-health') return `Monitoring source degraded for ${project}`
+  return `${task.event.kind === 'malware' ? 'Malicious package' : 'Vulnerability'} for ${project}`
 }
 
 export function createDshRadarMessage(task: AnalysisTask): DshRadarMessage {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,12 @@ export {
   type ProjectReference,
   type RadarEvent,
   type RadarConfig,
+  type RadarSource,
   type RadarSeverity,
   type RadarState,
+  type SourceHealthEvent,
+  type SourceHealthStatus,
+  type StoredSourceHealthMatch,
   type VulnerabilityAdvisory,
   type VulnerabilityEvent,
 } from './radar-types.js'

--- a/src/radar-render.ts
+++ b/src/radar-render.ts
@@ -47,8 +47,28 @@ function renderCompatibility(event: CompatibilityEvent): string[] {
   return lines
 }
 
+function renderSourceHealth(event: Extract<RadarEvent, { kind: 'source-health' }>): string[] {
+  const title = event.change === 'resolved' ? 'Source recovered' : 'Monitoring source degraded'
+  const lines = [
+    `[SOURCE HEALTH][${event.change.toUpperCase()}] ${title}`,
+    `Project: ${display(event.project.name)} (${display(event.project.id)})`,
+    `Source: ${display(event.source)}`,
+    `Consecutive failures: ${event.failureCount}`,
+    `Last attempted: ${display(event.lastAttemptedAt)}`,
+  ]
+  if (event.lastSucceededAt !== undefined) lines.push(`Last succeeded: ${display(event.lastSucceededAt)}`)
+  if (event.error !== undefined) lines.push(`Error: ${display(event.error)}`)
+  lines.push(`Route: ${event.route.owner === undefined ? '(no owner)' : display(event.route.owner)} via ${event.route.channels.map(item => display(item)).join(', ')}`)
+  return lines
+}
+
 export function renderRadarEvent(event: RadarEvent): string {
-  return `${(event.kind === 'compatibility' ? renderCompatibility(event) : renderVulnerability(event)).join('\n')}\n`
+  const lines = event.kind === 'compatibility'
+    ? renderCompatibility(event)
+    : event.kind === 'source-health'
+      ? renderSourceHealth(event)
+      : renderVulnerability(event)
+  return `${lines.join('\n')}\n`
 }
 
 export function renderRadarEvents(events: readonly RadarEvent[]): string {

--- a/src/radar-state.ts
+++ b/src/radar-state.ts
@@ -21,6 +21,27 @@ export function parseRadarState(value: unknown): RadarState {
   if (active === undefined) throw new Error('radar state has no active vulnerability map')
   const activeCompatibility = asRecord(root.activeCompatibility)
   if (activeCompatibility === undefined) throw new Error('radar state has no active compatibility map')
+  const sourceHealth = root.sourceHealth === undefined ? {} : asRecord(root.sourceHealth)
+  if (sourceHealth === undefined) throw new Error('radar state has an invalid source health map')
+  const activeSourceHealth = root.activeSourceHealth === undefined ? {} : asRecord(root.activeSourceHealth)
+  if (activeSourceHealth === undefined) throw new Error('radar state has an invalid active source health map')
+  if (Object.keys(sourceHealth).length > 10 || Object.keys(activeSourceHealth).length > 1_000_000) {
+    throw new Error('radar state exceeds the source health limit')
+  }
+  const sourceNames = new Set(['osv', 'npm-releases', 'github-releases'])
+  for (const [source, rawStatus] of Object.entries(sourceHealth)) {
+    const status = asRecord(rawStatus)
+    const failures = status?.consecutiveFailures
+    if (!sourceNames.has(source)
+      || typeof status?.lastAttemptedAt !== 'string'
+      || typeof failures !== 'number' || !Number.isSafeInteger(failures)
+      || failures < 0 || failures > 1_000_000
+      || (status.lastSucceededAt !== undefined && typeof status.lastSucceededAt !== 'string')
+      || (status.lastError !== undefined
+        && (typeof status.lastError !== 'string' || status.lastError.length > 2_048))) {
+      throw new Error(`radar state contains an invalid source health status: ${source}`)
+    }
+  }
   if (!Array.isArray(root.pendingAnalysisTasks) || root.pendingAnalysisTasks.length > 100_000) {
     throw new Error('radar state has an invalid pending analysis queue')
   }
@@ -30,7 +51,7 @@ export function parseRadarState(value: unknown): RadarState {
     if (task?.schema !== ANALYSIS_TASK_SCHEMA || typeof task.id !== 'string'
       || typeof task.createdAt !== 'string' || event?.schema !== RADAR_EVENT_SCHEMA
       || typeof event.id !== 'string' || typeof event.incidentId !== 'string'
-      || (event.kind !== 'vulnerability' && event.kind !== 'malware' && event.kind !== 'compatibility')) {
+      || (event.kind !== 'vulnerability' && event.kind !== 'malware' && event.kind !== 'compatibility' && event.kind !== 'source-health')) {
       throw new Error('radar state contains an invalid pending analysis task')
     }
   }
@@ -54,6 +75,15 @@ export function parseRadarState(value: unknown): RadarState {
     if (stored?.key !== key || event?.schema !== RADAR_EVENT_SCHEMA
       || event.kind !== 'compatibility' || event.incidentId !== key) {
       throw new Error(`radar state contains an invalid compatibility match: ${key.slice(0, 256)}`)
+    }
+  }
+  for (const [key, rawStored] of Object.entries(activeSourceHealth)) {
+    const stored = asRecord(rawStored)
+    const event = asRecord(stored?.event)
+    if (stored?.key !== key || event?.schema !== RADAR_EVENT_SCHEMA
+      || event.kind !== 'source-health' || event.incidentId !== key
+      || !sourceNames.has(typeof event.source === 'string' ? event.source : '')) {
+      throw new Error(`radar state contains an invalid source health match: ${key.slice(0, 256)}`)
     }
   }
   return structuredClone(value) as RadarState

--- a/src/radar-types.ts
+++ b/src/radar-types.ts
@@ -118,11 +118,12 @@ interface RadarEventBase {
   detectedAt: string
   project: ProjectReference
   route: EventRoute
-  plugin: PackageCoordinate
+  plugin?: PackageCoordinate
 }
 
 export interface VulnerabilityEvent extends RadarEventBase {
   kind: 'vulnerability' | 'malware'
+  plugin: PackageCoordinate
   affected: PackageCoordinate
   paths: PackageCoordinate[][]
   advisory: VulnerabilityAdvisory
@@ -140,6 +141,7 @@ export interface CompatibilitySignal {
 
 export interface CompatibilityEvent extends RadarEventBase {
   kind: 'compatibility'
+  plugin: PackageCoordinate
   installed: PackageCoordinate
   candidate: PackageCoordinate
   signals: CompatibilitySignal[]
@@ -147,7 +149,26 @@ export interface CompatibilityEvent extends RadarEventBase {
   releaseNotesUrl?: string
 }
 
-export type RadarEvent = VulnerabilityEvent | CompatibilityEvent
+export type RadarSource = 'osv' | 'npm-releases' | 'github-releases'
+
+export interface SourceHealthStatus {
+  lastAttemptedAt: string
+  lastSucceededAt?: string
+  consecutiveFailures: number
+  lastError?: string
+}
+
+export interface SourceHealthEvent extends RadarEventBase {
+  kind: 'source-health'
+  source: RadarSource
+  status: 'degraded' | 'healthy'
+  failureCount: number
+  lastAttemptedAt: string
+  lastSucceededAt?: string
+  error?: string
+}
+
+export type RadarEvent = VulnerabilityEvent | CompatibilityEvent | SourceHealthEvent
 
 export interface StoredVulnerabilityMatch {
   key: string
@@ -159,11 +180,18 @@ export interface StoredCompatibilityMatch {
   event: CompatibilityEvent
 }
 
+export interface StoredSourceHealthMatch {
+  key: string
+  event: SourceHealthEvent
+}
+
 export interface RadarState {
   schema: typeof RADAR_STATE_SCHEMA
   activeVulnerabilities: Record<string, StoredVulnerabilityMatch>
   activeCompatibility: Record<string, StoredCompatibilityMatch>
   pendingAnalysisTasks: AnalysisTask[]
+  sourceHealth?: Record<string, SourceHealthStatus>
+  activeSourceHealth?: Record<string, StoredSourceHealthMatch>
 }
 
 export interface AnalysisTask {

--- a/src/radar.ts
+++ b/src/radar.ts
@@ -14,8 +14,12 @@ import {
   type PackageCoordinate,
   type ProjectInventory,
   type RadarEvent,
+  type RadarSource,
   type RadarState,
+  type SourceHealthEvent,
+  type SourceHealthStatus,
   type StoredCompatibilityMatch,
+  type StoredSourceHealthMatch,
   type StoredVulnerabilityMatch,
   type VulnerabilityEvent,
 } from './radar-types.js'
@@ -34,9 +38,11 @@ export interface RadarPollResult {
   releasePackagesQueried: number
   events: RadarEvent[]
   analysisTasks: AnalysisTask[]
-  sourceErrors: Array<{ source: 'osv' | 'npm-releases' | 'github-releases'; message: string }>
+  sourceErrors: Array<{ source: RadarSource; message: string }>
   state: RadarState
 }
+
+const SOURCE_FAILURE_ALERT_THRESHOLD = 3
 
 function hash(value: string): string {
   return createHash('sha256').update(value).digest('hex').slice(0, 24)
@@ -86,8 +92,86 @@ function compatibilityEventChanged(previous: RadarEvent, current: RadarEvent): b
     || previous.releaseNotesUrl !== current.releaseNotesUrl
 }
 
+function sourceHealthKey(projectId: string, source: RadarSource): string {
+  return `${projectId}\0${source}`
+}
+
+function sourceHealthEventId(
+  key: string,
+  change: SourceHealthEvent['change'],
+  detectedAt: string,
+  status: SourceHealthStatus,
+): string {
+  return `event-${hash(`${key}\0${change}\0${detectedAt}\0${status.consecutiveFailures}\0${status.lastError ?? ''}`)}`
+}
+
+function recordSourceHealth(
+  previous: Record<string, SourceHealthStatus>,
+  source: RadarSource,
+  attemptedAt: string,
+  succeeded: boolean,
+  error?: string,
+): Record<string, SourceHealthStatus> {
+  const current = previous[source]
+  const next: SourceHealthStatus = succeeded
+    ? {
+        lastAttemptedAt: attemptedAt,
+        lastSucceededAt: attemptedAt,
+        consecutiveFailures: 0,
+      }
+    : {
+        lastAttemptedAt: attemptedAt,
+        consecutiveFailures: (current?.consecutiveFailures ?? 0) + 1,
+        ...(current?.lastSucceededAt === undefined ? {} : { lastSucceededAt: current.lastSucceededAt }),
+        ...(error === undefined ? {} : { lastError: error }),
+      }
+  return { ...previous, [source]: next }
+}
+
+function sourceHealthEventChanged(previous: SourceHealthEvent, current: SourceHealthEvent): boolean {
+  return JSON.stringify(previous.project) !== JSON.stringify(current.project)
+    || JSON.stringify(previous.route) !== JSON.stringify(current.route)
+    || previous.source !== current.source
+    || previous.status !== current.status
+    || previous.error !== current.error
+}
+
+function createSourceHealthEvent(
+  inventory: ProjectInventory,
+  source: RadarSource,
+  status: 'degraded' | 'healthy',
+  change: SourceHealthEvent['change'],
+  detectedAt: string,
+  health: SourceHealthStatus,
+): SourceHealthEvent {
+  const key = sourceHealthKey(inventory.project.id, source)
+  return {
+    schema: RADAR_EVENT_SCHEMA,
+    id: sourceHealthEventId(key, change, detectedAt, health),
+    incidentId: key,
+    kind: 'source-health',
+    change,
+    detectedAt,
+    project: { ...inventory.project },
+    route: route(inventory),
+    source,
+    status,
+    failureCount: health.consecutiveFailures,
+    lastAttemptedAt: health.lastAttemptedAt,
+    ...(health.lastSucceededAt === undefined ? {} : { lastSucceededAt: health.lastSucceededAt }),
+    ...(health.lastError === undefined ? {} : { error: health.lastError }),
+  }
+}
+
 export function emptyRadarState(): RadarState {
-  return { schema: RADAR_STATE_SCHEMA, activeVulnerabilities: {}, activeCompatibility: {}, pendingAnalysisTasks: [] }
+  return {
+    schema: RADAR_STATE_SCHEMA,
+    activeVulnerabilities: {},
+    activeCompatibility: {},
+    pendingAnalysisTasks: [],
+    sourceHealth: {},
+    activeSourceHealth: {},
+  }
 }
 
 /** Query exact installed versions, calculate affected paths, and emit state transitions only. */
@@ -103,6 +187,8 @@ export async function pollRadar(
   if (!Number.isFinite(now.getTime())) throw new Error('radar check time is invalid')
   const checkedAt = now.toISOString()
   const sourceErrors: RadarPollResult['sourceErrors'] = []
+  const attemptedSources = new Set<RadarSource>()
+  let sourceHealth = { ...(previousState.sourceHealth ?? {}) }
 
   const uniquePackages = new Map<string, PackageCoordinate>()
   for (const inventory of inventories) {
@@ -115,14 +201,18 @@ export async function pollRadar(
   }
   let matches = new Map<string, AdvisoryMatch[]>()
   let vulnerabilityCheckSucceeded = true
+  attemptedSources.add('osv')
   try {
     matches = await source.query([...uniquePackages.values()])
+    sourceHealth = recordSourceHealth(sourceHealth, 'osv', checkedAt, true)
   } catch (error: unknown) {
     const raw = error instanceof Error ? error.message : String(error)
+    const message = raw.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?').slice(0, 2_048)
     sourceErrors.push({
       source: 'osv',
-      message: raw.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?').slice(0, 2_048),
+      message,
     })
+    sourceHealth = recordSourceHealth(sourceHealth, 'osv', checkedAt, false, message)
     vulnerabilityCheckSucceeded = false
   }
 
@@ -220,32 +310,40 @@ export async function pollRadar(
   }
   let activeCompatibility = previousState.activeCompatibility
   if (releaseSource !== undefined) {
+    attemptedSources.add('npm-releases')
     let releases: Map<string, NpmReleaseObservation>
     let releaseCheckSucceeded = false
     try {
       releases = await releaseSource.query([...releasePackages.values()])
       releaseCheckSucceeded = true
+      sourceHealth = recordSourceHealth(sourceHealth, 'npm-releases', checkedAt, true)
     } catch (error: unknown) {
       const raw = error instanceof Error ? error.message : String(error)
+      const message = raw.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?').slice(0, 2_048)
       sourceErrors.push({
         source: 'npm-releases',
-        message: raw.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?').slice(0, 2_048),
+        message,
       })
+      sourceHealth = recordSourceHealth(sourceHealth, 'npm-releases', checkedAt, false, message)
       releases = new Map()
     }
     if (releaseCheckSucceeded) {
       let releaseNotes = new Map<string, ReleaseNotes>()
       let releaseNotesCheckSucceeded = releaseNotesSource === undefined
       if (releaseNotesSource !== undefined) {
+        attemptedSources.add('github-releases')
         try {
           releaseNotes = await releaseNotesSource.query([...releases.values()])
           releaseNotesCheckSucceeded = true
+          sourceHealth = recordSourceHealth(sourceHealth, 'github-releases', checkedAt, true)
         } catch (error: unknown) {
           const raw = error instanceof Error ? error.message : String(error)
+          const message = raw.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?').slice(0, 2_048)
           sourceErrors.push({
             source: 'github-releases',
-            message: raw.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?').slice(0, 2_048),
+            message,
           })
+          sourceHealth = recordSourceHealth(sourceHealth, 'github-releases', checkedAt, false, message)
         }
       }
       const currentCompatibility = new Map<string, StoredCompatibilityMatch>()
@@ -310,6 +408,34 @@ export async function pollRadar(
       activeCompatibility = Object.fromEntries(currentCompatibility)
     }
   }
+  let activeSourceHealth: Record<string, StoredSourceHealthMatch> = previousState.activeSourceHealth ?? {}
+  const currentSourceHealth = new Map<string, StoredSourceHealthMatch>(Object.entries(activeSourceHealth))
+  for (const inventory of inventories) {
+    for (const sourceName of attemptedSources) {
+      const health = sourceHealth[sourceName]
+      if (health === undefined) continue
+      const key = sourceHealthKey(inventory.project.id, sourceName)
+      const previous = activeSourceHealth[key]
+      if (health.consecutiveFailures >= SOURCE_FAILURE_ALERT_THRESHOLD) {
+        const candidate = createSourceHealthEvent(
+          inventory,
+          sourceName,
+          'degraded',
+          previous === undefined ? 'new' : 'updated',
+          checkedAt,
+          health,
+        )
+        currentSourceHealth.set(key, { key, event: candidate })
+        if (previous === undefined) events.push(candidate)
+        else if (sourceHealthEventChanged(previous.event, candidate)) events.push(candidate)
+      } else if (previous !== undefined) {
+        const recovered = createSourceHealthEvent(inventory, sourceName, 'healthy', 'resolved', checkedAt, health)
+        currentSourceHealth.delete(key)
+        events.push(recovered)
+      }
+    }
+  }
+  activeSourceHealth = Object.fromEntries(currentSourceHealth)
   events.sort((left, right) => left.id.localeCompare(right.id))
 
   const analysisTasks = events
@@ -333,6 +459,8 @@ export async function pollRadar(
       activeVulnerabilities: Object.fromEntries([...current.entries()]),
       activeCompatibility,
       pendingAnalysisTasks: [...pending.values()],
+      sourceHealth,
+      activeSourceHealth,
     },
   }
 }

--- a/test/dsh-plugin.test.ts
+++ b/test/dsh-plugin.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 import { createAnalysisTask } from '../src/dsh-analysis.js'
 import { createDshRadarMessage, deliverPendingAnalysisTasks } from '../src/dsh-plugin.js'
 import { emptyRadarState } from '../src/radar.js'
-import type { CompatibilityEvent } from '../src/radar-types.js'
+import type { CompatibilityEvent, SourceHealthEvent } from '../src/radar-types.js'
 
 const event: CompatibilityEvent = {
   schema: 'upstream-radar.event/v1alpha1',
@@ -18,6 +18,22 @@ const event: CompatibilityEvent = {
   installed: { ecosystem: 'npm', name: 'plugin', version: '1.0.0' },
   candidate: { ecosystem: 'npm', name: 'plugin', version: '2.0.0' },
   signals: [{ code: 'breaking-version-boundary', confidence: 'strong', summary: 'Major update.' }],
+}
+
+const sourceHealthEvent: SourceHealthEvent = {
+  schema: 'upstream-radar.event/v1alpha1',
+  id: 'event-source-health',
+  incidentId: 'project-a\u0000osv',
+  kind: 'source-health',
+  change: 'new',
+  detectedAt: '2026-08-14T04:00:00.000Z',
+  project: { id: 'project-a', name: 'Project A', workspace: '/workspace/project-a' },
+  route: { owner: 'platform', channels: ['stdout'] },
+  source: 'osv',
+  status: 'degraded',
+  failureCount: 3,
+  lastAttemptedAt: '2026-08-14T04:00:00.000Z',
+  error: 'OSV timeout',
 }
 
 describe('DSH radar plugin adapter', () => {
@@ -43,5 +59,11 @@ describe('DSH radar plugin adapter', () => {
       form: 'notice',
       summary: 'Compatibility change for Project A',
     })
+  })
+
+  it('routes a source-health incident as a useful DSH notice', () => {
+    const message = createDshRadarMessage(createAnalysisTask(sourceHealthEvent))
+    assert.equal(message.source.summary, 'Monitoring source degraded for Project A')
+    assert.match(message.content[0]?.text ?? '', /监控源当前不可用/)
   })
 })

--- a/test/radar-state.test.ts
+++ b/test/radar-state.test.ts
@@ -8,6 +8,13 @@ describe('radar state parsing', () => {
     assert.deepEqual(parseRadarState(emptyRadarState()), emptyRadarState())
   })
 
+  it('accepts a state written before source health fields existed', () => {
+    const legacy = structuredClone(emptyRadarState()) as unknown as Record<string, unknown>
+    delete legacy.sourceHealth
+    delete legacy.activeSourceHealth
+    assert.deepEqual(parseRadarState(legacy), legacy)
+  })
+
   it('rejects a queued task without a stable incident identity', () => {
     const state = emptyRadarState() as unknown as Record<string, unknown>
     state.pendingAnalysisTasks = [{
@@ -21,5 +28,17 @@ describe('radar state parsing', () => {
       },
     }]
     assert.throws(() => parseRadarState(state), /invalid pending analysis task/)
+  })
+
+  it('rejects an oversized persisted source error', () => {
+    const state = emptyRadarState() as unknown as Record<string, unknown>
+    state.sourceHealth = {
+      osv: {
+        lastAttemptedAt: '2026-08-14T01:00:00.000Z',
+        consecutiveFailures: 3,
+        lastError: 'x'.repeat(2_049),
+      },
+    }
+    assert.throws(() => parseRadarState(state), /invalid source health status/)
   })
 })

--- a/test/radar.test.ts
+++ b/test/radar.test.ts
@@ -65,7 +65,8 @@ describe('radar polling', () => {
     assert.equal(first.events[0]?.change, 'new')
     assert.equal(first.analysisTasks.length, 1)
     const firstEvent = first.events[0]
-    assert.ok(firstEvent !== undefined && firstEvent.kind !== 'compatibility')
+    assert.ok(firstEvent !== undefined)
+    assert.equal(firstEvent.kind, 'vulnerability')
     assert.deepEqual(firstEvent.paths[0]?.map(item => `${item.name}@${item.version}`), [
       'plugin@1.0.0',
       'logger@4.0.2',
@@ -238,6 +239,55 @@ describe('radar polling', () => {
     assert.equal(Object.keys(result.state.activeVulnerabilities).length, 1)
     assert.equal(result.state.pendingAnalysisTasks.length, 1)
     assert.deepEqual(result.sourceErrors, [{ source: 'osv', message: 'OSV timeout' }])
+  })
+
+  it('creates one DSH source-health incident after three failures and resolves it on recovery', async () => {
+    const unavailable: AdvisorySource = { async query() { throw new Error('OSV timeout') } }
+    const first = await pollRadar(
+      [inventory],
+      emptyRadarState(),
+      unavailable,
+      new Date('2026-08-14T08:00:00.000Z'),
+    )
+    const second = await pollRadar(
+      [inventory],
+      first.state,
+      unavailable,
+      new Date('2026-08-14T08:30:00.000Z'),
+    )
+    const third = await pollRadar(
+      [inventory],
+      second.state,
+      unavailable,
+      new Date('2026-08-14T09:00:00.000Z'),
+    )
+    assert.equal(first.events.length, 0)
+    assert.equal(second.events.length, 0)
+    assert.equal(third.events.length, 1)
+    assert.equal(third.events[0]?.kind, 'source-health')
+    assert.equal(third.events[0]?.change, 'new')
+    assert.equal(third.state.sourceHealth?.osv?.consecutiveFailures, 3)
+    assert.equal(Object.keys(third.state.activeSourceHealth ?? {}).length, 1)
+    assert.equal(third.state.pendingAnalysisTasks.length, 1)
+
+    const fourth = await pollRadar(
+      [inventory],
+      third.state,
+      unavailable,
+      new Date('2026-08-14T09:30:00.000Z'),
+    )
+    assert.equal(fourth.events.length, 0)
+    assert.equal(Object.values(fourth.state.activeSourceHealth ?? {})[0]?.event.failureCount, 4)
+
+    const recovered = await pollRadar(
+      [inventory],
+      fourth.state,
+      source('2026-08-14T01:00:00.000Z', false),
+      new Date('2026-08-14T10:00:00.000Z'),
+    )
+    assert.equal(recovered.events.some(event => event.kind === 'source-health' && event.change === 'resolved'), true)
+    assert.equal(Object.keys(recovered.state.activeSourceHealth ?? {}).length, 0)
+    assert.equal(recovered.state.pendingAnalysisTasks.length, 0)
   })
 
   it('keeps npm compatibility facts when GitHub release notes are unavailable', async () => {


### PR DESCRIPTION
## What changed

- Persist each attempted feed's last attempt, last success, consecutive failures, and bounded error.
- Create one project-routed `source-health` DSH incident after three consecutive failures.
- Avoid repeating the same outage task on every poll; resolve the incident after recovery.
- Preserve confirmed vulnerability matches and pending tasks during source outages.
- Add state validation, deterministic lifecycle evidence, DSH prompt handling, docs, and the v0.8.0 changelog.

## Why

A missing feed response must never look like a clean security result. DSH needs a durable, actionable signal when its monitoring coverage is degraded.

## Validation

- `pnpm run check`
- `pnpm test` — 67 passing tests
- `pnpm run showcase:radar:reports`
- `pnpm run try:dsh:report`
- `pnpm run try:dsh:live` — live OSV + npm feeds
