### PR TITLE
Add first-run DSH profile and status checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.10.0] - 2026-08-16
+
+### Added
+
+- Auto-select the only DSH profile with third-party bundles when `init --profile` is omitted; multiple candidates still require an explicit profile.
+- Add read-only `radar status` for first-run diagnosis without refreshing upstream sources.
+- Report source health, last completed check, active vulnerability/compatibility incidents, source-health incidents, and pending DSH analysis tasks in human-readable and JSON forms.
+
 ## [0.9.0] - 2026-08-16
 
 ### Added
@@ -116,16 +124,17 @@ All notable changes to Upstream Radar are documented here.
 - Version matching and compatibility facts are calculated outside the model.
 - Agent analysis is read-only and requires project evidence and explicit uncertainty.
 
+[0.10.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.10.0
+[0.9.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.9.0
+[0.8.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.8.0
+[0.7.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.7.1
+[0.7.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.7.0
+[0.6.2]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.2
+[0.6.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.1
+[0.6.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.0
+[0.5.3]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.3
+[0.5.2]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.2
+[0.5.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.1
+[0.5.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.0
 [0.4.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.4.1
 [0.4.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.4.0
-[0.5.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.0
-[0.5.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.1
-[0.5.2]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.2
-[0.5.3]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.5.3
-[0.6.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.0
-[0.6.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.1
-[0.6.2]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.6.2
-[0.7.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.7.0
-[0.7.1]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.7.1
-[0.8.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.8.0
-[0.9.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.9.0

--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@
 
 ## Try it in 60 seconds
 
-Use a DSH profile that already contains at least one third-party bundle. Replace `web` with your profile name:
+Use a DSH profile that already contains at least one third-party bundle. If DSH has only one such profile, `init` can find it for you:
 
 ```bash
 dsh plugin --profile web add upstream-radar@latest
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
-  --profile web \
   --project-name "My DSH project" \
   --workspace "$PWD" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
 dsh --profile web --patch ./upstream-radar.dsh.yml
+pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-The initializer writes a reviewable inventory and an explicit DSH overlay. Review both files, then start the same profile with `--patch`; no shell environment variables are required. Read the [full DSH setup](#install-in-dsh) for the legacy environment-variable path, profile boundaries, and the real runtime proof.
+The initializer writes a reviewable inventory and an explicit DSH overlay. Review both files, start the same profile with `--patch`, then use `radar status` to confirm the first run without another network request. If more than one DSH profile has third-party bundles, pass `--profile <name>` explicitly. Read the [full DSH setup](#install-in-dsh) for the legacy environment-variable path, profile boundaries, and the real runtime proof.
 
 If you want to try the monitoring loop without booting a DSH profile, run one cycle from a reviewed inventory:
 
@@ -104,7 +104,6 @@ Generate the inventory from the DSH profile instead of writing the dependency gr
 
 ```bash
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
-  --profile web \
   --project-name "My DSH project" \
   --workspace "$PWD" \
   --output ./upstream-radar.config.json \
@@ -116,9 +115,10 @@ The initializer reads the profile's actual third-party bundles, resolves each ex
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml --dump-config
 dsh --profile web --patch ./upstream-radar.dsh.yml
+pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-The generated overlay points DSH at the config and state files explicitly. If you prefer environment variables or need to override the polling interval, omit `--dsh-patch` and use `UPSTREAM_RADAR_CONFIG`, `UPSTREAM_RADAR_STATE`, and `UPSTREAM_RADAR_INTERVAL_SECONDS` as before.
+The generated overlay points DSH at the config and state files explicitly. `radar status` is read-only and reports whether a check has completed, which source is unhealthy, active incidents, and pending DSH tasks. If you prefer environment variables or need to override the polling interval, omit `--dsh-patch` and use `UPSTREAM_RADAR_CONFIG`, `UPSTREAM_RADAR_STATE`, and `UPSTREAM_RADAR_INTERVAL_SECONDS` as before.
 
 The generated graph is the exact public npm artifact graph for the installed bundle versions. If your DSH profile applies package-manager overrides, patches, or unusual peer resolution, review those differences before enabling continuous monitoring.
 
@@ -241,6 +241,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 - npm release monitoring for plugins and DSH/Cordis packages, with public GitHub Release notes attached when an exact candidate tag is available;
 - durable incident state with current-task replacement and resolution;
 - native DSH bundle installation, startup polling, `agent/created` retry, and plugin-source attribution;
+- automatic selection of the only DSH profile with third-party bundles, plus a network-free `radar status` snapshot;
 - compatibility signals for Node.js, peers, exports, entrypoints, bundle paths, dependencies, and version boundaries;
 - network-free Radar and real DSH runtime showcases.
 
@@ -253,7 +254,8 @@ pnpm dlx --package=upstream-radar@latest upstream-radar inspect npm:dsh-cloudfla
 
 ## Current boundaries
 
-- `init --profile <name>` discovers a named DSH profile and generates a reviewable inventory; `--dsh-patch <path>` also writes an explicit DSH overlay so first startup needs no environment variables. Automatic active-profile selection and native pnpm override/peer resolution are not implemented yet.
+- `init` discovers the only DSH profile with third-party bundles when `--profile` is omitted; multiple candidates still require an explicit profile. `--dsh-patch <path>` writes an explicit DSH overlay so first startup needs no environment variables. Native pnpm override/peer resolution is not implemented yet.
+- `radar status` is a local snapshot only: it does not refresh OSV/npm/GitHub data, and it cannot prove that a source is current until a check has completed.
 - npm lock graphs are supported; pnpm and Yarn graph adapters are not implemented.
 - OSV, npm `latest`, and public GitHub Release notes are live sources; changelog, comparison-diff, and migration-guide ingestion are deferred.
 - A failed OSV check preserves confirmed matches and returns a visible source warning; source health is durable and routed through DSH after three consecutive failures, while source-claim conflict handling and external health destinations are not implemented yet.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,7 @@
 - [x] Provide a deterministic vulnerability and breaking-change showcase.
 - [x] Prove bundle installation, plugin-source attribution, Session persistence, and Agent delivery in a real DSH headless profile.
 - [x] Generate an explicit DSH `--patch` overlay so first use does not require environment variables.
+- [x] Auto-select the only DSH profile with third-party bundles and provide a network-free first-run status snapshot.
 
 ## Milestone 1 — compatibility radar
 
@@ -26,7 +27,8 @@
 - [ ] Track DSH package families as one coordinated release rather than unrelated npm packages.
 - [ ] Resolve the lowest clean plugin upgrade, not merely the latest release.
 - [x] Discover a named DSH profile's installed third-party bundles and generate a reviewable inventory.
-- [ ] Discover the active DSH profile without `--profile` and use its native pnpm lock graph as the source of truth.
+- [x] Auto-select the only DSH profile with third-party bundles when `--profile` is omitted.
+- [ ] Use the selected profile's native pnpm lock graph as the source of truth.
 - [ ] Run plugin load and representative compatibility probes in a disposable DSH profile.
 - [ ] Record `compatible`, `incompatible`, and `unknown` against an explicit DSH version matrix.
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -17,20 +17,20 @@
 
 ## 60 秒开始
 
-使用一个已经安装至少一个第三方 bundle 的 DSH profile，把 `web` 换成你的 profile 名称：
+使用一个已经安装至少一个第三方 bundle 的 DSH profile。如果 DSH 中只有一个这样的 profile，初始化命令可以自动找到它：
 
 ```bash
 dsh plugin --profile web add upstream-radar@latest
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
-  --profile web \
   --project-name "我的 DSH 项目" \
   --workspace "$PWD" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
 dsh --profile web --patch ./upstream-radar.dsh.yml
+pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-初始化命令会写出可审查的清单和 DSH overlay。检查两个文件后，用 `--patch` 启动即可，不需要手动导出环境变量。完整的状态文件、兼容的旧环境变量方式、profile 边界和真实运行证明见[完整 DSH 配置](#安装到-dsh)。
+初始化命令会写出可审查的清单和 DSH overlay。检查两个文件后，用 `--patch` 启动，再用 `radar status` 在不重新请求网络的情况下确认第一次运行。如果有多个 DSH profile 含第三方 bundle，就显式传入 `--profile <name>`。完整的状态文件、兼容的旧环境变量方式、profile 边界和真实运行证明见[完整 DSH 配置](#安装到-dsh)。
 
 如果只想先试跑一次监控，而不启动 DSH profile，可以使用同一份清单：
 
@@ -95,7 +95,6 @@ dsh plugin --profile web add upstream-radar@latest
 
 ```bash
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
-  --profile web \
   --project-name "我的 DSH 项目" \
   --workspace "$PWD" \
   --output ./upstream-radar.config.json \
@@ -107,9 +106,10 @@ pnpm dlx --package=upstream-radar@latest upstream-radar init \
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml --dump-config
 dsh --profile web --patch ./upstream-radar.dsh.yml
+pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-如果不使用 `--dsh-patch`，仍可以使用原来的 `UPSTREAM_RADAR_CONFIG`、`UPSTREAM_RADAR_STATE` 和 `UPSTREAM_RADAR_INTERVAL_SECONDS` 环境变量方式。
+`radar status` 只读取本地配置和状态，不会刷新 OSV/npm/GitHub；它会告诉你是否已经完成检查、哪个数据源异常、当前事件和待处理的 DSH 任务。如果不使用 `--dsh-patch`，仍可以使用原来的 `UPSTREAM_RADAR_CONFIG`、`UPSTREAM_RADAR_STATE` 和 `UPSTREAM_RADAR_INTERVAL_SECONDS` 环境变量方式。
 
 生成的依赖图对应已安装 bundle 版本的精确公共 npm artifact。如果你的 DSH profile 使用了 package-manager override、patch 或特殊的 peer 解析规则，开启持续监控前仍需要人工检查这些差异。
 
@@ -208,7 +208,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 已经支持：npm lock 依赖图、重复版本路径、OSV 精确版本匹配、恶意包记录、npm release 监听、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
 
-`init --profile <name>` 已经可以发现指定的 DSH profile 并生成可审查清单；加上 `--dsh-patch <path>` 还可以生成不依赖环境变量的 DSH overlay。暂未支持自动选择当前 active profile、原生解析 pnpm override/peer 规则、Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
+`init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查，但不会替你刷新漏洞源。暂未支持原生解析 pnpm override/peer 规则、Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 
 `radar watch` 是 CLI 监控入口，本身不会把任务投递给 DSH；需要 Agent 分析时应使用原生 DSH bundle。
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -99,6 +99,16 @@ dsh --profile web --patch ./upstream-radar.dsh.yml
 
 The generated overlay does not install packages or start DSH; the user still reviews both files and installs the Radar bundle explicitly.
 
+## Scene 9 — confirm the first run without another network request
+
+After DSH has started, the read-only status command reads the same config and durable state files:
+
+```bash
+pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
+```
+
+It reports whether monitoring has started, the last successful check for OSV/npm/GitHub Releases, active vulnerability and compatibility incidents, source-health incidents, and pending DSH analysis tasks. It does not poll any upstream source, so it is safe to use for a quick local diagnosis.
+
 ## Live sources
 
 The fixture isolates behavior from network timing. Production cycles use:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Dependency security monitoring for DeepSeek Harness (DSH) plugins: find the exact vulnerable path or breaking update, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { resolve } from 'node:path'
 import { assessCompatibilityChange } from './compatibility.js'
 import { createAnalysisTask, renderAgentAnalysisPrompt } from './dsh-analysis.js'
 import { GitHubReleaseClient } from './github-release.js'
-import { createRadarConfigFromDshProfile, resolveDshProfileDirectory, writeDshPatch, writeRadarConfig } from './init.js'
+import { createRadarConfigFromDshProfile, discoverDshProfiles, resolveDshProfileDirectory, writeDshPatch, writeRadarConfig } from './init.js'
 import { parsePackageManifestSnapshot, parseRadarConfig } from './inventory.js'
 import { inspectNpmPackage } from './npm.js'
 import { NpmReleaseClient } from './npm-release.js'
@@ -15,6 +15,7 @@ import { verdictAtLeast } from './policy.js'
 import { emptyRadarState, pollRadar } from './radar.js'
 import { renderRadarEvents } from './radar-render.js'
 import { loadRadarState, saveRadarState } from './radar-state.js'
+import { createRadarStatus, renderRadarStatus } from './radar-status.js'
 import { renderTextReport } from './render.js'
 import { scanDirectory } from './scan.js'
 import type { Verdict } from './types.js'
@@ -36,11 +37,12 @@ function usage(): string {
   return `Upstream Radar — always-on dependency and compatibility monitoring for DSH plugins
 
 Usage:
-  upstream-radar init --profile <name> [options]
+  upstream-radar init [--profile <name>] [options]
   upstream-radar scan <directory> [--json] [--fail-on <warn|review|block|never>]
   upstream-radar inspect npm:<package>@<exact-version> [--deep] [--json] [--fail-on <warn|review|block|never>]
   upstream-radar radar check <config.json> [--state <state.json>] [--json]
   upstream-radar radar watch <config.json> [--state <state.json>] [--interval <seconds>] [--once] [--json]
+  upstream-radar radar status <config.json> [--state <state.json>] [--json]
   upstream-radar radar compare <config.json> <before.json> <candidate.json> [--notes <release-notes.txt>] [--json]
   upstream-radar task list <state.json> [--json]
   upstream-radar task show <state.json> [task-id] [--json]
@@ -62,7 +64,7 @@ Options:
   --interval <seconds> watch interval from 300 to 86400 seconds (default: 1800)
   --once               run one watch cycle and exit (useful for CI and demos)
   --notes <path>       release notes used as untrusted compatibility evidence
-  --profile <name>     DSH profile to inspect for init (default DSH_HOME/profiles/<name>)
+  --profile <name>     DSH profile to inspect for init (auto-selects the only candidate when omitted)
   --output <path>      init output path (default: ./upstream-radar.config.json)
   --dsh-patch <path>   write a self-contained DSH --patch overlay (optional)
   --force              allow init to replace an existing output file
@@ -150,10 +152,20 @@ async function readJson(path: string): Promise<unknown> {
   }
 }
 
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(resolve(path))
+    return true
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
+
 async function runRadar(args: readonly string[]): Promise<number> {
   const subcommand = args[0]
-  if (subcommand !== 'check' && subcommand !== 'watch' && subcommand !== 'compare') {
-    throw new Error('radar requires check, watch or compare')
+  if (subcommand !== 'check' && subcommand !== 'watch' && subcommand !== 'status' && subcommand !== 'compare') {
+    throw new Error('radar requires check, watch, status or compare')
   }
   const configPath = args[1]
   if (configPath === undefined || configPath.startsWith('-')) throw new Error(`radar ${subcommand} requires a config file`)
@@ -197,6 +209,23 @@ async function runRadar(args: readonly string[]): Promise<number> {
   }
 
   const readConfig = async () => parseRadarConfig(await readJson(configPath))
+  if (subcommand === 'status') {
+    if (positional.length > 0 || notesPath !== undefined || once || intervalProvided
+      || osvBaseUrl !== undefined || registry !== undefined || statePath === ':memory:') {
+      throw new Error('radar status only accepts --state and --json options')
+    }
+    const config = await readConfig()
+    const stateFile = statePath ?? `${resolve(configPath)}.state.json`
+    const stateExists = await fileExists(stateFile)
+    const state = stateExists ? await loadRadarState(stateFile) : emptyRadarState()
+    const report = createRadarStatus(config, state, {
+      configFile: resolve(configPath),
+      stateFile: resolve(stateFile),
+      stateExists,
+    })
+    process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderRadarStatus(report))
+    return report.monitoring === 'degraded' ? 1 : 0
+  }
   const osv = new OsvClient({
     ...(osvBaseUrl === undefined ? {} : { baseUrl: osvBaseUrl }),
   })
@@ -326,7 +355,20 @@ async function runInit(args: readonly string[]): Promise<number> {
       throw new Error(`unknown option for init: ${argument}`)
     }
   }
-  if (profile === undefined) throw new Error('init requires --profile <name>')
+  let autoSelected = false
+  let resolvedProfile = profile
+  if (resolvedProfile === undefined) {
+    const candidates = await discoverDshProfiles()
+    if (candidates.length === 0) {
+      throw new Error('init could not find a DSH profile with third-party bundles; pass --profile <name>')
+    }
+    if (candidates.length > 1) {
+      throw new Error(`init found multiple DSH profiles with third-party bundles (${candidates.join(', ')}); pass --profile <name>`)
+    }
+    resolvedProfile = candidates[0]
+    autoSelected = true
+  }
+  if (resolvedProfile === undefined) throw new Error('init could not select a DSH profile')
   const plannedOutputPath = resolve(output)
   const plannedStatePath = `${plannedOutputPath}.state.json`
   if (dshPatch !== undefined) {
@@ -345,7 +387,7 @@ async function runInit(args: readonly string[]): Promise<number> {
     }
   }
   const config = await createRadarConfigFromDshProfile({
-    profileDirectory: resolveDshProfileDirectory(profile),
+    profileDirectory: resolveDshProfileDirectory(resolvedProfile),
     ...(projectId === undefined ? {} : { projectId }),
     ...(projectName === undefined ? {} : { projectName }),
     ...(repository === undefined ? {} : { repository }),
@@ -359,24 +401,25 @@ async function runInit(args: readonly string[]): Promise<number> {
     output: dshPatch,
     configFile: outputPath,
     stateFile: statePath,
-    profile,
+    profile: resolvedProfile,
     force,
   })
   const plugins = config.projects[0]?.plugins ?? []
   if (json) {
-    process.stdout.write(`${JSON.stringify({ output: outputPath, profile, plugins: plugins.map(plugin => ({
+    process.stdout.write(`${JSON.stringify({ output: outputPath, profile: resolvedProfile, plugins: plugins.map(plugin => ({
       name: plugin.package.name,
       version: plugin.package.version,
       nodes: plugin.graph.nodes.length,
       edges: plugin.graph.edges.length,
     })), state: statePath, ...(patchPath === undefined ? {} : { patch: patchPath }) }, null, 2)}\n`)
   } else {
+    if (autoSelected) process.stdout.write(`Auto-selected DSH profile: ${resolvedProfile}\n`)
     process.stdout.write(`Created ${outputPath}\nDiscovered ${plugins.length} DSH plugin bundle(s):\n`)
     for (const plugin of plugins) process.stdout.write(`  ${plugin.package.name}@${plugin.package.version} (${plugin.graph.nodes.length} dependency nodes)\n`)
     if (patchPath === undefined) {
-      process.stdout.write(`\nReview the generated inventory, then run:\n  export UPSTREAM_RADAR_CONFIG=${shellQuote(outputPath)}\n  export UPSTREAM_RADAR_STATE=${shellQuote(statePath)}\n  dsh --profile ${shellQuote(profile)}\n`)
+      process.stdout.write(`\nReview the generated inventory, then run:\n  export UPSTREAM_RADAR_CONFIG=${shellQuote(outputPath)}\n  export UPSTREAM_RADAR_STATE=${shellQuote(statePath)}\n  dsh --profile ${shellQuote(resolvedProfile)}\n`)
     } else {
-      process.stdout.write(`Created ${patchPath}\n\nReview the generated inventory and DSH overlay, then run:\n  dsh --profile ${shellQuote(profile)} --patch ${shellQuote(patchPath)}\n`)
+      process.stdout.write(`Created ${patchPath}\n\nReview the generated inventory and DSH overlay, then run:\n  dsh --profile ${shellQuote(resolvedProfile)} --patch ${shellQuote(patchPath)}\n`)
     }
   }
   return 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export { createAnalysisTask, renderAgentAnalysisPrompt, renderDshAnalysisPrompt 
 export { parsePackageManifestSnapshot, parseRadarConfig } from './inventory.js'
 export {
   createRadarConfigFromDshProfile,
+  discoverDshProfiles,
   resolveDshProfileDirectory,
   writeDshPatch,
   writeRadarConfig,
@@ -28,6 +29,16 @@ export {
   type WriteRadarConfigOptions,
 } from './init.js'
 export { loadRadarState, parseRadarState, saveRadarState } from './radar-state.js'
+export {
+  createRadarStatus,
+  renderRadarStatus,
+  RADAR_STATUS_SCHEMA,
+  type CreateRadarStatusOptions,
+  type RadarMonitoringStatus,
+  type RadarSourceStatus,
+  type RadarStatusReport,
+  type RadarStatusSource,
+} from './radar-status.js'
 export { renderRadarEvent, renderRadarEvents } from './radar-render.js'
 export { crossesBreakingVersionBoundary, parseSemver, satisfiesSemverRange } from './semver.js'
 export { scanDirectory, type ScanOptions } from './scan.js'

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,4 @@
-import { access, readFile, writeFile } from 'node:fs/promises'
+import { access, readFile, readdir, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, isAbsolute, join, relative, resolve } from 'node:path'
 import { inspectNpmPackage, type InspectNpmOptions } from './npm.js'
@@ -89,6 +89,21 @@ function isDshInfrastructure(packageName: string): boolean {
     || packageName.startsWith('@cordis/')
 }
 
+function resolveDshHome(dshHome = process.env.DSH_HOME): string {
+  return dshHome?.trim() === '' || dshHome === undefined ? join(homedir(), '.dsh') : dshHome
+}
+
+async function readDshProfileBundles(profileDirectory: string): Promise<string[]> {
+  const profileManifest = asRecord(await readJson(join(profileDirectory, 'package.json')), 'DSH profile package.json')
+  const dsh = asRecord(profileManifest.dsh, 'DSH profile dsh')
+  const profile = asRecord(dsh.profile, 'DSH profile dsh.profile')
+  const bundles = profile.bundles
+  if (!Array.isArray(bundles) || bundles.length === 0 || !bundles.every(item => typeof item === 'string')) {
+    throw new Error('DSH profile package.json does not contain dsh.profile.bundles')
+  }
+  return bundles
+}
+
 function defaultProjectId(workspace: string): string {
   const name = basename(resolve(workspace)).toLowerCase().replace(/[^a-z0-9._-]+/g, '-')
   return name.replace(/^-+|-+$/g, '').slice(0, 512) || 'dsh-project'
@@ -100,7 +115,7 @@ function defaultProjectName(workspace: string): string {
 
 /** Resolve a DSH profile using the same DSH_HOME convention as the launcher. */
 export function resolveDshProfileDirectory(profile: string, dshHome = process.env.DSH_HOME): string {
-  const home = dshHome?.trim() === '' || dshHome === undefined ? join(homedir(), '.dsh') : dshHome
+  const home = resolveDshHome(dshHome)
   const profileName = requiredString(profile, 'profile')
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(profileName)) {
     throw new Error('profile must be a simple DSH profile name (letters, numbers, ., _, and -)')
@@ -108,16 +123,38 @@ export function resolveDshProfileDirectory(profile: string, dshHome = process.en
   return resolve(home, 'profiles', profileName)
 }
 
+/** Find DSH profiles that contain at least one installed third-party bundle. */
+export async function discoverDshProfiles(dshHome = process.env.DSH_HOME): Promise<string[]> {
+  const profilesDirectory = resolve(resolveDshHome(dshHome), 'profiles')
+  let entries
+  try {
+    entries = await readdir(profilesDirectory, { withFileTypes: true })
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+
+  const candidates: string[] = []
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(entry.name)) continue
+    const profileDirectory = resolveDshProfileDirectory(entry.name, dshHome)
+    let bundles: string[]
+    try {
+      bundles = await readDshProfileBundles(profileDirectory)
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`could not inspect DSH profile ${entry.name}: ${message}`)
+    }
+    if (bundles.some(bundle => !isDshInfrastructure(bundle))) candidates.push(entry.name)
+  }
+  return candidates.sort()
+}
+
 /** Build a reviewable Radar inventory from the third-party bundles in a DSH profile. */
 export async function createRadarConfigFromDshProfile(options: DshInitOptions): Promise<RadarConfig> {
   const profileDirectory = resolve(options.profileDirectory)
-  const profileManifest = asRecord(await readJson(join(profileDirectory, 'package.json')), 'DSH profile package.json')
-  const dsh = asRecord(profileManifest.dsh, 'DSH profile dsh')
-  const profile = asRecord(dsh.profile, 'DSH profile dsh.profile')
-  const bundles = profile.bundles
-  if (!Array.isArray(bundles) || bundles.length === 0 || !bundles.every(item => typeof item === 'string')) {
-    throw new Error('DSH profile package.json does not contain dsh.profile.bundles')
-  }
+  const bundles = await readDshProfileBundles(profileDirectory)
 
   const workspace = options.workspace ?? process.cwd()
   const projectId = options.projectId ?? defaultProjectId(workspace)

--- a/src/radar-status.ts
+++ b/src/radar-status.ts
@@ -1,0 +1,137 @@
+import type { RadarConfig, RadarSource, RadarState, SourceHealthStatus } from './radar-types.js'
+
+export const RADAR_STATUS_SCHEMA = 'upstream-radar.radar-status/v1alpha1' as const
+
+const RADAR_SOURCES: readonly RadarSource[] = ['osv', 'npm-releases', 'github-releases']
+
+export type RadarMonitoringStatus = 'not-started' | 'healthy' | 'degraded'
+export type RadarSourceStatus = 'not-run' | 'healthy' | 'degraded'
+
+export interface RadarStatusSource {
+  source: RadarSource
+  status: RadarSourceStatus
+  consecutiveFailures: number
+  lastAttemptedAt?: string
+  lastSucceededAt?: string
+  lastError?: string
+}
+
+export interface RadarStatusReport {
+  schema: typeof RADAR_STATUS_SCHEMA
+  configFile: string
+  stateFile: string
+  stateExists: boolean
+  monitoring: RadarMonitoringStatus
+  projects: number
+  pluginBundles: number
+  lastCheckedAt?: string
+  sources: RadarStatusSource[]
+  activeVulnerabilities: number
+  activeCompatibility: number
+  activeSourceHealth: number
+  pendingAnalysisTasks: number
+}
+
+export interface CreateRadarStatusOptions {
+  configFile: string
+  stateFile: string
+  stateExists: boolean
+}
+
+function sourceStatus(source: RadarSource, status: SourceHealthStatus | undefined): RadarStatusSource {
+  if (status === undefined) {
+    return { source, status: 'not-run', consecutiveFailures: 0 }
+  }
+  return {
+    source,
+    status: status.consecutiveFailures === 0 ? 'healthy' : 'degraded',
+    consecutiveFailures: status.consecutiveFailures,
+    lastAttemptedAt: status.lastAttemptedAt,
+    ...(status.lastSucceededAt === undefined ? {} : { lastSucceededAt: status.lastSucceededAt }),
+    ...(status.lastError === undefined ? {} : { lastError: status.lastError }),
+  }
+}
+
+function latestTimestamp(sources: readonly RadarStatusSource[]): string | undefined {
+  return sources
+    .flatMap(source => source.lastAttemptedAt === undefined ? [] : [source.lastAttemptedAt])
+    .sort()
+    .at(-1)
+}
+
+/** Build a network-free snapshot from the reviewed config and durable Radar state. */
+export function createRadarStatus(
+  config: RadarConfig,
+  state: RadarState,
+  options: CreateRadarStatusOptions,
+): RadarStatusReport {
+  const sources = RADAR_SOURCES.map(source => sourceStatus(source, state.sourceHealth?.[source]))
+  const observedSources = sources.filter(source => source.status !== 'not-run')
+  const monitoring: RadarMonitoringStatus = observedSources.length === 0
+    ? 'not-started'
+    : observedSources.some(source => source.status === 'degraded') ? 'degraded' : 'healthy'
+  const lastCheckedAt = latestTimestamp(sources)
+  return {
+    schema: RADAR_STATUS_SCHEMA,
+    configFile: options.configFile,
+    stateFile: options.stateFile,
+    stateExists: options.stateExists,
+    monitoring,
+    projects: config.projects.length,
+    pluginBundles: config.projects.reduce((total, project) => total + project.plugins.length, 0),
+    ...(lastCheckedAt === undefined ? {} : { lastCheckedAt }),
+    sources,
+    activeVulnerabilities: Object.keys(state.activeVulnerabilities).length,
+    activeCompatibility: Object.keys(state.activeCompatibility).length,
+    activeSourceHealth: Object.keys(state.activeSourceHealth ?? {}).length,
+    pendingAnalysisTasks: state.pendingAnalysisTasks.length,
+  }
+}
+
+function display(value: string, maxLength = 512): string {
+  const escaped = value.replace(/[\u0000-\u001f\u007f-\u009f]/g, character => (
+    `\\u${character.codePointAt(0)?.toString(16).padStart(4, '0') ?? '0000'}`
+  ))
+  return escaped.length <= maxLength ? escaped : `${escaped.slice(0, maxLength)}…`
+}
+
+function sourceLabel(source: RadarSource): string {
+  if (source === 'osv') return 'OSV'
+  if (source === 'npm-releases') return 'npm releases'
+  return 'GitHub releases'
+}
+
+function plural(value: number, singular: string, multiple = `${singular}s`): string {
+  return `${value} ${value === 1 ? singular : multiple}`
+}
+
+/** Render the status snapshot for a human checking the first run. */
+export function renderRadarStatus(report: RadarStatusReport): string {
+  const lines = [
+    'Upstream Radar status',
+    `Monitoring: ${report.monitoring.replace('-', ' ')}`,
+    `Config: ${display(report.configFile)} (${plural(report.projects, 'project')}, ${plural(report.pluginBundles, 'DSH plugin bundle')})`,
+    `State: ${display(report.stateFile)}${report.stateExists ? '' : ' (not created yet)'}`,
+    `Last check: ${report.lastCheckedAt === undefined ? 'never' : display(report.lastCheckedAt)}`,
+    '',
+    'Sources:',
+  ]
+  for (const source of report.sources) {
+    const detail = source.status === 'not-run'
+      ? 'not run'
+      : `${source.status}${source.lastSucceededAt === undefined ? '' : `, last success ${display(source.lastSucceededAt)}`}`
+    lines.push(`  ${sourceLabel(source.source)}: ${detail}`)
+    if (source.lastError !== undefined) lines.push(`    error: ${display(source.lastError, 2_048)}`)
+  }
+  lines.push(
+    '',
+    `Active vulnerabilities: ${report.activeVulnerabilities}`,
+    `Active compatibility incidents: ${report.activeCompatibility}`,
+    `Source-health incidents: ${report.activeSourceHealth}`,
+    `Pending DSH analysis tasks: ${report.pendingAnalysisTasks}`,
+  )
+  if (report.monitoring === 'not-started') {
+    lines.push('', 'No completed check is recorded yet. Start DSH or run `radar check` once.')
+  }
+  return `${lines.join('\n')}\n`
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.9.0'
+export const TOOL_VERSION = '0.10.0'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -19,6 +19,7 @@ describe('CLI option parsing', () => {
     const help = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8' })
     assert.equal(help.status, 0)
     assert.match(help.stdout, /radar watch <config\.json>/)
+    assert.match(help.stdout, /radar status <config\.json>/)
     assert.match(help.stdout, /--once\s+run one watch cycle and exit/)
     assert.match(help.stdout, /--dsh-patch <path>\s+write a self-contained DSH --patch overlay/)
 
@@ -29,6 +30,23 @@ describe('CLI option parsing', () => {
     const misplaced = spawnSync(process.execPath, [cli, 'radar', 'compare', 'missing.json', 'before.json', 'candidate.json', '--interval', '1800'], { encoding: 'utf8' })
     assert.equal(misplaced.status, 1)
     assert.match(misplaced.stderr, /radar compare does not accept check or watch options/)
+  })
+
+  it('shows a network-free first-run status snapshot', () => {
+    const config = resolve(repository, 'examples/radar/config.json')
+    const missingState = resolve(tmpdir(), `upstream-radar-status-${process.pid}-${Date.now()}.json`)
+    const result = spawnSync(process.execPath, [cli, 'radar', 'status', config, '--state', missingState], { encoding: 'utf8' })
+    assert.equal(result.status, 0)
+    assert.match(result.stdout, /Monitoring: not started/)
+    assert.match(result.stdout, /Active vulnerabilities: 0/)
+    assert.match(result.stdout, /No completed check is recorded yet/)
+
+    const json = spawnSync(process.execPath, [cli, 'radar', 'status', config, '--state', missingState, '--json'], { encoding: 'utf8' })
+    assert.equal(json.status, 0)
+    const report = JSON.parse(json.stdout) as { schema: string; stateExists: boolean; monitoring: string }
+    assert.equal(report.schema, 'upstream-radar.radar-status/v1alpha1')
+    assert.equal(report.stateExists, false)
+    assert.equal(report.monitoring, 'not-started')
   })
 
   it('rejects unknown options instead of silently weakening a scan', () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
-import { createRadarConfigFromDshProfile, resolveDshProfileDirectory, writeDshPatch, writeRadarConfig } from '../src/init.js'
+import { createRadarConfigFromDshProfile, discoverDshProfiles, resolveDshProfileDirectory, writeDshPatch, writeRadarConfig } from '../src/init.js'
 
 const graph = {
   schema: 'upstream-radar.dependency-graph/v1alpha1' as const,
@@ -114,6 +114,33 @@ describe('DSH profile initialization', () => {
       () => resolveDshProfileDirectory('../outside', '/tmp/dsh-home'),
       /simple DSH profile name/,
     )
+  })
+
+  it('auto-discovery returns only profiles with third-party bundles', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-discovery-'))
+    try {
+      await mkdir(join(root, 'profiles', 'headless'), { recursive: true })
+      await writeFile(join(root, 'profiles', 'headless', 'package.json'), JSON.stringify({
+        name: 'dsh-profile-headless',
+        dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'cordis'] } },
+      }))
+      await mkdir(join(root, 'profiles', 'web'), { recursive: true })
+      await writeFile(join(root, 'profiles', 'web', 'package.json'), JSON.stringify({
+        name: 'dsh-profile-web',
+        dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', 'demo-plugin'] } },
+      }))
+      await mkdir(join(root, 'profiles', 'api'), { recursive: true })
+      await writeFile(join(root, 'profiles', 'api', 'package.json'), JSON.stringify({
+        name: 'dsh-profile-api',
+        dsh: { profile: { bundles: ['api-plugin'] } },
+      }))
+
+      assert.deepEqual(await discoverDshProfiles(root), ['api', 'web'])
+      await rm(join(root, 'profiles', 'api'), { recursive: true, force: true })
+      assert.deepEqual(await discoverDshProfiles(root), ['web'])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('does not follow a bundle path outside the profile', async () => {

--- a/test/radar-status.test.ts
+++ b/test/radar-status.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { createRadarStatus, renderRadarStatus } from '../src/radar-status.js'
+import { emptyRadarState } from '../src/radar.js'
+import type { RadarConfig } from '../src/radar-types.js'
+
+const config: RadarConfig = {
+  schema: 'upstream-radar.radar-config/v1alpha1',
+  projects: [{
+    schema: 'upstream-radar.inventory/v1alpha1',
+    project: { id: 'demo', name: 'Demo project' },
+    plugins: [{
+      package: { ecosystem: 'npm', name: 'demo-plugin', version: '1.0.0' },
+      graph: {
+        schema: 'upstream-radar.dependency-graph/v1alpha1',
+        rootNodeId: 'demo-plugin',
+        nodes: [{ id: 'demo-plugin', name: 'demo-plugin', version: '1.0.0' }],
+        edges: [],
+      },
+    }],
+  }],
+}
+
+describe('Radar status', () => {
+  it('reports a clear first-run snapshot without state or network calls', () => {
+    const report = createRadarStatus(config, emptyRadarState(), {
+      configFile: '/tmp/radar.json',
+      stateFile: '/tmp/radar.json.state.json',
+      stateExists: false,
+    })
+
+    assert.equal(report.monitoring, 'not-started')
+    assert.equal(report.projects, 1)
+    assert.equal(report.pluginBundles, 1)
+    assert.equal(report.lastCheckedAt, undefined)
+    assert.deepEqual(report.sources.map(source => source.status), ['not-run', 'not-run', 'not-run'])
+    assert.match(renderRadarStatus(report), /No completed check is recorded yet/)
+  })
+
+  it('counts active incidents and distinguishes a failed source from a healthy run', () => {
+    const state = emptyRadarState()
+    state.sourceHealth = {
+      osv: {
+        lastAttemptedAt: '2026-08-16T01:00:00.000Z',
+        lastSucceededAt: '2026-08-16T01:00:00.000Z',
+        consecutiveFailures: 0,
+      },
+      'npm-releases': {
+        lastAttemptedAt: '2026-08-16T01:01:00.000Z',
+        consecutiveFailures: 2,
+        lastError: 'temporary registry timeout',
+      },
+    }
+    Object.assign(state.activeVulnerabilities, { vulnerability: {} })
+    Object.assign(state.activeCompatibility, { compatibility: {} })
+    Object.assign(state.activeSourceHealth ?? (state.activeSourceHealth = {}), { source: {} })
+    state.pendingAnalysisTasks.push({} as never)
+
+    const report = createRadarStatus(config, state, {
+      configFile: '/tmp/radar.json',
+      stateFile: '/tmp/radar.json.state.json',
+      stateExists: true,
+    })
+
+    assert.equal(report.monitoring, 'degraded')
+    assert.equal(report.lastCheckedAt, '2026-08-16T01:01:00.000Z')
+    assert.equal(report.activeVulnerabilities, 1)
+    assert.equal(report.activeCompatibility, 1)
+    assert.equal(report.activeSourceHealth, 1)
+    assert.equal(report.pendingAnalysisTasks, 1)
+    assert.equal(report.sources[0]?.status, 'healthy')
+    assert.equal(report.sources[1]?.status, 'degraded')
+    assert.match(renderRadarStatus(report), /temporary registry timeout/)
+  })
+})


### PR DESCRIPTION
## What changed

- auto-select the only DSH profile with third-party bundles when `init --profile` is omitted
- keep multiple candidate profiles explicit instead of guessing
- add a read-only `radar status` snapshot for first-run diagnosis
- report monitoring state, source health, last check, active incidents, and pending DSH analysis tasks
- update English/Chinese onboarding docs, showcase, roadmap, and release metadata for v0.10.0

## Why

The first-use path should be short and verifiable: users should not have to discover a profile name manually, and they should be able to confirm local Radar state without triggering another upstream request.

## Validation

- `pnpm run check`
- `pnpm test` — 72 tests passed
- `pnpm run showcase:radar:reports`
- `pnpm run try:dsh:report`
- `pnpm run try:dsh:live`
- `pnpm pack` — tarball contains the new CLI/status modules at v0.10.0
