### PR TITLE
Use installed DSH dependency graphs for monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.11.0] - 2026-08-16
+
+### Added
+
+- Build the default DSH inventory from the profile's installed `node_modules` resolution tree, so duplicate versions, overrides, and local package-manager choices match what DSH can actually load.
+- Preserve unresolved dependency declarations as incomplete coverage instead of dropping them from the config.
+- Add graph source and coverage details to JSON and `radar status` output.
+- Keep explicit `--registry` initialization available for public npm graph comparisons.
+
+### Security
+
+- Refuse DSH bundle manifests and dependency manifests whose symlinks escape the reviewed profile.
+
 ## [0.10.0] - 2026-08-16
 
 ### Added
@@ -124,6 +137,7 @@ All notable changes to Upstream Radar are documented here.
 - Version matching and compatibility facts are calculated outside the model.
 - Agent analysis is read-only and requires project evidence and explicit uncertainty.
 
+[0.11.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.11.0
 [0.10.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.10.0
 [0.9.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.9.0
 [0.8.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.8.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ pnpm dlx upstream-radar@latest init \
   --output ./upstream-radar.config.json
 ```
 
-The generated graph is a reviewable view of each exact public npm artifact. A profile that applies package-manager overrides or patches still needs an explicit review before it is used as the monitoring source.
+The default generated graph is a reviewable view of the profile's installed `node_modules` tree. A profile that has unresolved declarations keeps them as incomplete coverage; this includes peer packages supplied by a DSH host outside the profile. Pass `--registry <url>` only when you intentionally want to compare against public npm resolution.
 
 The repository intentionally denies dependency lifecycle scripts through `.npmrc` and keeps zero runtime dependencies. A proposal to add a runtime dependency should explain why a small audited implementation or platform primitive is insufficient.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pnpm dlx --package=upstream-radar@latest upstream-radar init \
   --dsh-patch ./upstream-radar.dsh.yml
 ```
 
-The initializer reads the profile's actual third-party bundles, resolves each exact npm artifact with lifecycle scripts disabled, and writes a reviewable config plus a self-contained DSH overlay. It never starts DSH or enables polling by itself. Review both generated files, then run:
+The initializer reads the profile's actual third-party bundles and follows the installed `node_modules` tree exposed by that profile, including duplicate versions, overrides, and local package-manager choices. It reads manifests only: it does not import plugin code, run lifecycle scripts, start DSH, or enable polling. Review both generated files, then run:
 
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml --dump-config
@@ -118,9 +118,9 @@ dsh --profile web --patch ./upstream-radar.dsh.yml
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-The generated overlay points DSH at the config and state files explicitly. `radar status` is read-only and reports whether a check has completed, which source is unhealthy, active incidents, and pending DSH tasks. If you prefer environment variables or need to override the polling interval, omit `--dsh-patch` and use `UPSTREAM_RADAR_CONFIG`, `UPSTREAM_RADAR_STATE`, and `UPSTREAM_RADAR_INTERVAL_SECONDS` as before.
+The generated overlay points DSH at the config and state files explicitly. `radar status` is read-only and reports whether a check has completed, which source is unhealthy, whether dependency coverage is complete, active incidents, and pending DSH tasks. If you prefer environment variables or need to override the polling interval, omit `--dsh-patch` and use `UPSTREAM_RADAR_CONFIG`, `UPSTREAM_RADAR_STATE`, and `UPSTREAM_RADAR_INTERVAL_SECONDS` as before.
 
-The generated graph is the exact public npm artifact graph for the installed bundle versions. If your DSH profile applies package-manager overrides, patches, or unusual peer resolution, review those differences before enabling continuous monitoring.
+The generated graph is the actual installed profile graph. If a dependency is declared but cannot be resolved from the profile, it remains visible as incomplete coverage instead of being treated as absent. Passing `--registry <url>` explicitly selects the older public npm artifact graph path, which is useful for comparing a profile against registry resolution but is not the default.
 
 For a hand-written or CI fixture, use [the example inventory](examples/radar/config.json). If neither a generated `--patch` overlay nor `UPSTREAM_RADAR_CONFIG` is provided, the bundle stays dormant and performs no polling.
 
@@ -236,7 +236,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 
 ## What works today
 
-- npm lockfile graphs with duplicate versions and bounded dependency paths;
+- installed DSH `node_modules` graphs and npm lockfile graphs with duplicate versions and bounded dependency paths;
 - exact-version OSV vulnerability and malicious-package matching;
 - npm release monitoring for plugins and DSH/Cordis packages, with public GitHub Release notes attached when an exact candidate tag is available;
 - durable incident state with current-task replacement and resolution;
@@ -254,7 +254,8 @@ pnpm dlx --package=upstream-radar@latest upstream-radar inspect npm:dsh-cloudfla
 
 ## Current boundaries
 
-- `init` discovers the only DSH profile with third-party bundles when `--profile` is omitted; multiple candidates still require an explicit profile. `--dsh-patch <path>` writes an explicit DSH overlay so first startup needs no environment variables. Native pnpm override/peer resolution is not implemented yet.
+- `init` discovers the only DSH profile with third-party bundles when `--profile` is omitted; multiple candidates still require an explicit profile. By default it follows the installed DSH `node_modules` tree, so pnpm overrides and local resolution choices are included. `--dsh-patch <path>` writes an explicit DSH overlay so first startup needs no environment variables. A native pnpm lockfile parser for pre-install/CI inspection is still deferred.
+- A graph with unresolved dependency declarations is marked as incomplete coverage; Radar does not claim that those packages are clean.
 - `radar status` is a local snapshot only: it does not refresh OSV/npm/GitHub data, and it cannot prove that a source is current until a check has completed.
 - npm lock graphs are supported; pnpm and Yarn graph adapters are not implemented.
 - OSV, npm `latest`, and public GitHub Release notes are live sources; changelog, comparison-diff, and migration-guide ingestion are deferred.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,8 @@
 - [ ] Resolve the lowest clean plugin upgrade, not merely the latest release.
 - [x] Discover a named DSH profile's installed third-party bundles and generate a reviewable inventory.
 - [x] Auto-select the only DSH profile with third-party bundles when `--profile` is omitted.
-- [ ] Use the selected profile's native pnpm lock graph as the source of truth.
+- [x] Use the selected profile's installed `node_modules` tree as the source of truth, including unresolved-edge visibility.
+- [ ] Parse the native pnpm lockfile for pre-install and CI inspection.
 - [ ] Run plugin load and representative compatibility probes in a disposable DSH profile.
 - [ ] Record `compatible`, `incompatible`, and `unknown` against an explicit DSH version matrix.
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -101,7 +101,7 @@ pnpm dlx --package=upstream-radar@latest upstream-radar init \
   --dsh-patch ./upstream-radar.dsh.yml
 ```
 
-初始化命令会读取 profile 中实际安装的第三方 bundle，用禁用 lifecycle scripts 的方式解析每个精确 npm artifact，然后写出可审查的配置和自包含 DSH overlay。它不会自行启动 DSH，也不会自行开启轮询。检查生成文件后，直接运行：
+初始化命令会读取 profile 中实际安装的第三方 bundle，并沿着该 profile 暴露的 `node_modules` 目录构建依赖图，包括重复版本、override 和本地 package-manager 选择。它只读取 manifest，不会导入插件代码、运行 lifecycle scripts、启动 DSH 或开启轮询。检查生成文件后，直接运行：
 
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml --dump-config
@@ -109,9 +109,9 @@ dsh --profile web --patch ./upstream-radar.dsh.yml
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-`radar status` 只读取本地配置和状态，不会刷新 OSV/npm/GitHub；它会告诉你是否已经完成检查、哪个数据源异常、当前事件和待处理的 DSH 任务。如果不使用 `--dsh-patch`，仍可以使用原来的 `UPSTREAM_RADAR_CONFIG`、`UPSTREAM_RADAR_STATE` 和 `UPSTREAM_RADAR_INTERVAL_SECONDS` 环境变量方式。
+`radar status` 只读取本地配置和状态，不会刷新 OSV/npm/GitHub；它会告诉你是否已经完成检查、依赖覆盖是否完整、哪个数据源异常、当前事件和待处理的 DSH 任务。如果不使用 `--dsh-patch`，仍可以使用原来的 `UPSTREAM_RADAR_CONFIG`、`UPSTREAM_RADAR_STATE` 和 `UPSTREAM_RADAR_INTERVAL_SECONDS` 环境变量方式。
 
-生成的依赖图对应已安装 bundle 版本的精确公共 npm artifact。如果你的 DSH profile 使用了 package-manager override、patch 或特殊的 peer 解析规则，开启持续监控前仍需要人工检查这些差异。
+生成的依赖图对应 profile 当前实际安装的树。如果依赖声明存在但 profile 中无法解析，它会保留为“覆盖不完整”，不会被当成安全或不存在。显式传入 `--registry <url>` 才会使用公共 npm artifact 图，适合和 registry 解析结果做比较，但不是默认路径。
 
 如果需要手写配置或制作 CI fixture，可以参考[示例清单](../examples/radar/config.json)。如果既没有 `--patch` overlay，也没有设置 `UPSTREAM_RADAR_CONFIG`，插件会保持休眠，不发起轮询。
 
@@ -206,9 +206,9 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：npm lock 依赖图、重复版本路径、OSV 精确版本匹配、恶意包记录、npm release 监听、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
+已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
 
-`init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查，但不会替你刷新漏洞源。暂未支持原生解析 pnpm override/peer 规则、Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
+`init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查，但不会替你刷新漏洞源。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 
 `radar watch` 是 CLI 监控入口，本身不会把任务投递给 DSH；需要 Agent 分析时应使用原生 DSH bundle。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ plugin@1.0.0
 
 Edges retain whether they are runtime, development, optional, or peer dependencies. A vulnerability event contains every bounded root-to-node path, so the alert explains which plugin introduced the package.
 
-The npm deep collector resolves in a temporary project with lifecycle scripts disabled and parses `package-lock.json`. An unresolved edge stays explicit; it is never silently counted as checked.
+For a real DSH profile, initialization follows the installed `node_modules` resolution tree exposed by that profile without importing package code or running lifecycle scripts. This captures duplicate versions and profile-local overrides. Peer packages supplied outside the profile remain explicit unresolved edges until a host-runtime resolver is added. The public npm deep collector remains available for explicit registry comparisons; it resolves in a temporary project with lifecycle scripts disabled and parses `package-lock.json`. In both paths, an unresolved edge stays explicit; it is never silently counted as checked.
 
 ## Vulnerability cycle
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -109,6 +109,24 @@ pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-
 
 It reports whether monitoring has started, the last successful check for OSV/npm/GitHub Releases, active vulnerability and compatibility incidents, source-health incidents, and pending DSH analysis tasks. It does not poll any upstream source, so it is safe to use for a quick local diagnosis.
 
+The status output also shows `Coverage: incomplete` when the installed profile contains a dependency declaration that DSH cannot currently resolve. That is a configuration gap, not a clean result.
+
+## Scene 10 — the graph follows the installed DSH profile
+
+For a profile containing `dsh-cloudflare-browser-run@0.1.1`, initialization reports the graph source explicitly:
+
+```json
+{
+  "name": "dsh-cloudflare-browser-run",
+  "version": "0.1.1",
+  "nodes": 6,
+  "edges": 9,
+  "source": "installed-node-modules"
+}
+```
+
+This is intentionally different from resolving the same package in a fresh npm project. A DSH profile may provide peer packages from its host, apply overrides, or leave a declaration unresolved; Radar keeps that difference visible instead of silently replacing it with a registry-generated graph.
+
 ## Live sources
 
 The fixture isolates behavior from network timing. Production cycles use:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Dependency security monitoring for DeepSeek Harness (DSH) plugins: find the exact vulnerable path or breaking update, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,12 +53,12 @@ Commands:
   init     discover third-party bundles in a DSH profile and write a reviewable inventory
   scan     bounded, read-only inspection of a local package directory
   inspect  fetch and verify the exact npm artifact before inspecting its contents
-  radar    monitor vulnerability changes, watch continuously, or assess a candidate compatibility change
+  radar    monitor vulnerability changes, watch continuously, inspect status, or assess a candidate compatibility change
   task     inspect or acknowledge the durable DSH analysis outbox
 
 Options:
   --deep               resolve the dependency graph with scripts disabled and ask npm to verify signatures/provenance
-  --registry <url>     HTTPS npm registry (default: https://registry.npmjs.org/)
+  --registry <url>     HTTPS npm registry for inspect or explicit public-graph init
   --state <path>       persistent radar state (default: <config.json>.state.json)
   --osv-base-url <url> alternate HTTPS OSV API base URL
   --interval <seconds> watch interval from 300 to 86400 seconds (default: 1800)
@@ -224,7 +224,7 @@ async function runRadar(args: readonly string[]): Promise<number> {
       stateExists,
     })
     process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderRadarStatus(report))
-    return report.monitoring === 'degraded' ? 1 : 0
+    return report.monitoring === 'degraded' || report.coverage === 'incomplete' ? 1 : 0
   }
   const osv = new OsvClient({
     ...(osvBaseUrl === undefined ? {} : { baseUrl: osvBaseUrl }),
@@ -411,11 +411,16 @@ async function runInit(args: readonly string[]): Promise<number> {
       version: plugin.package.version,
       nodes: plugin.graph.nodes.length,
       edges: plugin.graph.edges.length,
+      ...(plugin.graph.source === undefined ? {} : { source: plugin.graph.source }),
+      ...(plugin.graph.unresolved === undefined ? {} : { unresolved: plugin.graph.unresolved.length }),
     })), state: statePath, ...(patchPath === undefined ? {} : { patch: patchPath }) }, null, 2)}\n`)
   } else {
     if (autoSelected) process.stdout.write(`Auto-selected DSH profile: ${resolvedProfile}\n`)
     process.stdout.write(`Created ${outputPath}\nDiscovered ${plugins.length} DSH plugin bundle(s):\n`)
-    for (const plugin of plugins) process.stdout.write(`  ${plugin.package.name}@${plugin.package.version} (${plugin.graph.nodes.length} dependency nodes)\n`)
+    for (const plugin of plugins) {
+      const unresolved = plugin.graph.unresolved?.length ?? 0
+      process.stdout.write(`  ${plugin.package.name}@${plugin.package.version} (${plugin.graph.nodes.length} dependency nodes${plugin.graph.source === undefined ? '' : `, ${plugin.graph.source}`}${unresolved === 0 ? '' : `, ${unresolved} unresolved`})\n`)
+    }
     if (patchPath === undefined) {
       process.stdout.write(`\nReview the generated inventory, then run:\n  export UPSTREAM_RADAR_CONFIG=${shellQuote(outputPath)}\n  export UPSTREAM_RADAR_STATE=${shellQuote(statePath)}\n  dsh --profile ${shellQuote(resolvedProfile)}\n`)
     } else {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -64,7 +64,7 @@ function dependencyEntries(item: Record<string, unknown>): Array<{ name: string;
   return [...selected.entries()].map(([name, value]) => ({ name, ...value }))
 }
 
-function graphDigest(nodes: readonly DependencyNode[], edges: readonly DependencyEdge[]): string {
+export function dependencyGraphDigest(nodes: readonly DependencyNode[], edges: readonly DependencyEdge[]): string {
   const hash = createHash('sha256')
   for (const node of [...nodes].sort((left, right) => left.id.localeCompare(right.id))) {
     hash.update(`node\0${node.id}\0${node.name}\0${node.version}\n`)
@@ -153,7 +153,8 @@ export function parseNpmLockGraph(lockfile: unknown, rootPackage: RootPackage): 
     rootNodeId: rootNode.id,
     nodes,
     edges,
-    digest: graphDigest(nodes, edges),
+    source: 'npm-lock',
+    digest: dependencyGraphDigest(nodes, edges),
     ...(reachableUnresolved.length === 0 ? {} : { unresolved: reachableUnresolved }),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ export {
   type ParsedNpmSpec,
 } from './npm.js'
 export { renderTextReport } from './render.js'
-export { findDependencyPaths, parseNpmLockGraph } from './graph.js'
+export { dependencyGraphDigest, findDependencyPaths, parseNpmLockGraph } from './graph.js'
+export { parseInstalledNodeModulesGraph } from './installed-graph.js'
 export { OsvClient, packageKey, type OsvClientOptions } from './osv.js'
 export { NpmReleaseClient, type NpmReleaseClientOptions, type NpmReleaseObservation } from './npm-release.js'
 export { GitHubReleaseClient, type GitHubReleaseClientOptions, type ReleaseNotes, type ReleaseNotesSource } from './github-release.js'
@@ -35,6 +36,7 @@ export {
   RADAR_STATUS_SCHEMA,
   type CreateRadarStatusOptions,
   type RadarMonitoringStatus,
+  type RadarCoverageStatus,
   type RadarSourceStatus,
   type RadarStatusReport,
   type RadarStatusSource,

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,8 @@
-import { access, readFile, readdir, writeFile } from 'node:fs/promises'
+import { access, readFile, readdir, realpath, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, isAbsolute, join, relative, resolve } from 'node:path'
 import { inspectNpmPackage, type InspectNpmOptions } from './npm.js'
+import { parseInstalledNodeModulesGraph } from './installed-graph.js'
 import { parsePackageManifestSnapshot, parseRadarConfig } from './inventory.js'
 import {
   INVENTORY_SCHEMA,
@@ -79,7 +80,18 @@ async function readPackageManifest(profileDirectory: string, packageName: string
   if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
     throw new Error(`DSH bundle name escapes the profile node_modules directory: ${packageName}`)
   }
-  return parsePackageManifestSnapshot(await readJson(path))
+  const realProfileDirectory = await realpath(profileDirectory)
+  const realNodeModulesDirectory = await realpath(nodeModulesDirectory)
+  const realManifest = await realpath(path)
+  const profileRelativePath = relative(realProfileDirectory, realManifest)
+  if (profileRelativePath.startsWith('..') || isAbsolute(profileRelativePath)) {
+    throw new Error(`DSH bundle manifest escapes the DSH profile: ${packageName}`)
+  }
+  const realRelativePath = relative(realNodeModulesDirectory, realManifest)
+  if (realRelativePath.startsWith('..') || isAbsolute(realRelativePath)) {
+    throw new Error(`DSH bundle manifest escapes the profile node_modules directory: ${packageName}`)
+  }
+  return parsePackageManifestSnapshot(await readJson(realManifest))
 }
 
 function isDshInfrastructure(packageName: string): boolean {
@@ -167,14 +179,16 @@ export async function createRadarConfigFromDshProfile(options: DshInitOptions): 
     if (manifest.name !== packageName) {
       throw new Error(`installed manifest name ${manifest.name} does not match DSH bundle ${packageName}`)
     }
-    const report = await inspect(`npm:${manifest.name}@${manifest.version}`, {
-      deep: true,
-      ...(options.registry === undefined ? {} : { registry: options.registry }),
-    })
-    const graph = report.evidence.npm?.dependencyAudit.graph
-    if (graph === undefined) {
-      throw new Error(`could not resolve the exact dependency graph for ${manifest.name}@${manifest.version}`)
-    }
+    const graph = options.inspect !== undefined || options.registry !== undefined
+      ? (await inspect(`npm:${manifest.name}@${manifest.version}`, {
+          deep: true,
+          ...(options.registry === undefined ? {} : { registry: options.registry }),
+        })).evidence.npm?.dependencyAudit.graph
+      : await parseInstalledNodeModulesGraph(profileDirectory, {
+          name: manifest.name,
+          version: manifest.version,
+        })
+    if (graph === undefined) throw new Error(`could not resolve the exact dependency graph for ${manifest.name}@${manifest.version}`)
     plugins.push({
       package: { ecosystem: 'npm', name: manifest.name, version: manifest.version },
       manifest,

--- a/src/installed-graph.ts
+++ b/src/installed-graph.ts
@@ -1,0 +1,179 @@
+import { readFile, realpath } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { parsePackageManifestSnapshot } from './inventory.js'
+import { dependencyGraphDigest } from './graph.js'
+import {
+  DEPENDENCY_GRAPH_SCHEMA,
+  type DependencyEdge,
+  type DependencyGraph,
+  type DependencyKind,
+  type DependencyNode,
+  type PackageManifestSnapshot,
+} from './radar-types.js'
+
+const MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+const MAX_NODES = 100_000
+const MAX_EDGES = 250_000
+
+interface RootPackage {
+  name: string
+  version: string
+}
+
+interface InstalledPackage {
+  id: string
+  directory: string
+  manifest: PackageManifestSnapshot
+}
+
+function asStringRecord(value: unknown): Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return {}
+  const result: Record<string, string> = {}
+  for (const [name, spec] of Object.entries(value)) {
+    if (typeof spec === 'string') result[name] = spec
+  }
+  return result
+}
+
+function dependencyEntries(item: PackageManifestSnapshot): Array<{ name: string; spec: string; kind: DependencyKind }> {
+  const selected = new Map<string, { spec: string; kind: DependencyKind }>()
+  const add = (value: unknown, kind: DependencyKind): void => {
+    for (const [name, spec] of Object.entries(asStringRecord(value))) selected.set(name, { spec, kind })
+  }
+  add(item.dependencies, 'runtime')
+  add(item.peerDependencies, 'peer')
+  add(item.optionalDependencies, 'optional')
+  return [...selected.entries()].map(([name, value]) => ({ name, ...value }))
+}
+
+function isLexicallyInside(root: string, candidate: string): boolean {
+  const child = relative(root, candidate)
+  return child === '' || (!child.startsWith(`..${sep}`) && child !== '..' && !isAbsolute(child))
+}
+
+function isPackageName(value: string): boolean {
+  return /^(?:@[^/\\]+\/[^/\\]+|[^/\\/]+)$/.test(value)
+    && !value.includes('..')
+    && value !== '.'
+}
+
+function nodeId(rootDirectory: string, packageDirectory: string): string {
+  const value = relative(rootDirectory, resolve(packageDirectory))
+  if (value === '' || value.startsWith(`..${sep}`) || value === '..' || isAbsolute(value)) {
+    throw new Error(`installed package path escapes the DSH profile: ${packageDirectory}`)
+  }
+  return value.split(sep).join('/')
+}
+
+async function readInstalledManifest(
+  packageDirectory: string,
+  profileRoot: string,
+  profileRootReal: string,
+): Promise<InstalledPackage> {
+  const realDirectory = await realpath(packageDirectory)
+  if (!isLexicallyInside(profileRootReal, realDirectory)) {
+    throw new Error(`installed package path escapes the DSH profile: ${packageDirectory}`)
+  }
+  const manifestPath = await realpath(join(packageDirectory, 'package.json'))
+  if (!isLexicallyInside(profileRootReal, manifestPath)) {
+    throw new Error(`installed package manifest escapes the DSH profile: ${packageDirectory}`)
+  }
+  const contents = await readFile(manifestPath, 'utf8')
+  if (Buffer.byteLength(contents) > MAX_MANIFEST_BYTES) {
+    throw new Error(`installed package manifest exceeds the ${MAX_MANIFEST_BYTES} byte limit: ${packageDirectory}`)
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(contents) as unknown
+  } catch {
+    throw new Error(`installed package manifest is not valid JSON: ${packageDirectory}`)
+  }
+  const manifest = parsePackageManifestSnapshot(parsed)
+  return { id: nodeId(profileRoot, packageDirectory), directory: packageDirectory, manifest }
+}
+
+async function findInstalledPackage(
+  parentDirectory: string,
+  dependencyName: string,
+  profileRoot: string,
+  profileRootReal: string,
+): Promise<InstalledPackage | undefined> {
+  if (!isPackageName(dependencyName)) return undefined
+  let cursor = resolve(parentDirectory)
+  while (isLexicallyInside(profileRoot, cursor)) {
+    const dependencyDirectory = resolve(cursor, 'node_modules', ...dependencyName.split('/'))
+    if (!isLexicallyInside(profileRoot, dependencyDirectory)) return undefined
+    try {
+      return await readInstalledManifest(dependencyDirectory, profileRoot, profileRootReal)
+    } catch (error: unknown) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') throw error
+    }
+    if (cursor === profileRoot) break
+    const next = dirname(cursor)
+    if (next === cursor) break
+    cursor = next
+  }
+  return undefined
+}
+
+/** Read the package tree that DSH can actually resolve from its installed profile. */
+export async function parseInstalledNodeModulesGraph(
+  profileDirectory: string,
+  rootPackage: RootPackage,
+): Promise<DependencyGraph> {
+  const profileRoot = resolve(profileDirectory)
+  const profileRootReal = await realpath(profileRoot)
+  if (!isPackageName(rootPackage.name)) throw new Error(`invalid installed root package name: ${rootPackage.name}`)
+  const root = await findInstalledPackage(profileRoot, rootPackage.name, profileRoot, profileRootReal)
+  if (root === undefined) {
+    throw new Error(`installed root package is not present in the DSH profile: ${rootPackage.name}@${rootPackage.version}`)
+  }
+  if (root.manifest.name !== rootPackage.name || root.manifest.version !== rootPackage.version) {
+    throw new Error(`installed root package does not match requested coordinate: ${rootPackage.name}@${rootPackage.version}`)
+  }
+
+  const packages = new Map<string, InstalledPackage>([[root.id, root]])
+  const edges: DependencyEdge[] = []
+  const unresolved: NonNullable<DependencyGraph['unresolved']> = []
+  const queue = [root.id]
+  for (let index = 0; index < queue.length; index += 1) {
+    const currentId = queue[index]
+    if (currentId === undefined) break
+    const current = packages.get(currentId)
+    if (current === undefined) continue
+    for (const dependency of dependencyEntries(current.manifest)) {
+      const target = await findInstalledPackage(current.directory, dependency.name, profileRoot, profileRootReal)
+      if (target === undefined) {
+        unresolved.push({ from: current.id, ...dependency })
+        if (unresolved.length > MAX_EDGES) throw new Error(`installed dependency graph exceeds the ${MAX_EDGES} edge limit`)
+        continue
+      }
+      if (edges.length >= MAX_EDGES) throw new Error(`installed dependency graph exceeds the ${MAX_EDGES} edge limit`)
+      edges.push({ from: current.id, to: target.id, kind: dependency.kind })
+      if (packages.has(target.id)) continue
+      if (packages.size >= MAX_NODES) throw new Error(`installed dependency graph exceeds the ${MAX_NODES} node limit`)
+      packages.set(target.id, target)
+      queue.push(target.id)
+    }
+  }
+
+  const nodes: DependencyNode[] = [...packages.values()]
+    .map(item => ({ id: item.id, name: item.manifest.name, version: item.manifest.version }))
+    .sort((left, right) => left.id === root.id ? -1 : right.id === root.id ? 1 : left.id.localeCompare(right.id))
+  const sortedEdges = edges.sort((left, right) => (
+    left.from.localeCompare(right.from) || left.to.localeCompare(right.to) || left.kind.localeCompare(right.kind)
+  ))
+  const reachableUnresolved = unresolved
+    .sort((left, right) => left.from.localeCompare(right.from) || left.name.localeCompare(right.name))
+
+  return {
+    schema: DEPENDENCY_GRAPH_SCHEMA,
+    rootNodeId: root.id,
+    nodes,
+    edges: sortedEdges,
+    source: 'installed-node-modules',
+    digest: dependencyGraphDigest(nodes, sortedEdges),
+    ...(reachableUnresolved.length === 0 ? {} : { unresolved: reachableUnresolved }),
+  }
+}

--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -116,13 +116,36 @@ function graph(value: unknown, label: string): DependencyGraph {
   })
   const rootNodeId = string(source.rootNodeId, `${label}.rootNodeId`, 4_096)
   if (!ids.has(rootNodeId)) throw new Error(`${label} root references a missing node`)
+  const graphSource = source.source === undefined ? undefined : string(source.source, `${label}.source`, 64)
+  if (graphSource !== undefined && graphSource !== 'npm-lock' && graphSource !== 'installed-node-modules') {
+    throw new Error(`${label}.source has an unsupported value`)
+  }
+  const unresolvedValue = source.unresolved
+  if (unresolvedValue !== undefined && (!Array.isArray(unresolvedValue) || unresolvedValue.length > MAX_EDGES_PER_GRAPH)) {
+    throw new Error(`${label}.unresolved must contain at most ${MAX_EDGES_PER_GRAPH} entries`)
+  }
+  const unresolved = unresolvedValue === undefined ? undefined : unresolvedValue.map((rawItem, index) => {
+    const item = record(rawItem, `${label}.unresolved[${index}]`)
+    const from = string(item.from, `${label}.unresolved[${index}].from`, 4_096)
+    if (!ids.has(from)) throw new Error(`${label}.unresolved[${index}] references a missing node`)
+    const kind = string(item.kind, `${label}.unresolved[${index}].kind`, 32) as DependencyKind
+    if (!kinds.has(kind)) throw new Error(`${label}.unresolved[${index}] has an invalid dependency kind`)
+    return {
+      from,
+      name: string(item.name, `${label}.unresolved[${index}].name`, 512),
+      kind,
+      spec: string(item.spec, `${label}.unresolved[${index}].spec`, 2_048),
+    }
+  })
   const digest = optionalString(source.digest, `${label}.digest`, 512)
   return {
     schema: DEPENDENCY_GRAPH_SCHEMA,
     rootNodeId,
     nodes,
     edges,
+    ...(graphSource === undefined ? {} : { source: graphSource }),
     ...(digest === undefined ? {} : { digest }),
+    ...(unresolved === undefined || unresolved.length === 0 ? {} : { unresolved }),
   }
 }
 

--- a/src/radar-status.ts
+++ b/src/radar-status.ts
@@ -6,6 +6,7 @@ const RADAR_SOURCES: readonly RadarSource[] = ['osv', 'npm-releases', 'github-re
 
 export type RadarMonitoringStatus = 'not-started' | 'healthy' | 'degraded'
 export type RadarSourceStatus = 'not-run' | 'healthy' | 'degraded'
+export type RadarCoverageStatus = 'complete' | 'incomplete'
 
 export interface RadarStatusSource {
   source: RadarSource
@@ -22,8 +23,10 @@ export interface RadarStatusReport {
   stateFile: string
   stateExists: boolean
   monitoring: RadarMonitoringStatus
+  coverage: RadarCoverageStatus
   projects: number
   pluginBundles: number
+  unresolvedDependencies: number
   lastCheckedAt?: string
   sources: RadarStatusSource[]
   activeVulnerabilities: number
@@ -71,14 +74,20 @@ export function createRadarStatus(
     ? 'not-started'
     : observedSources.some(source => source.status === 'degraded') ? 'degraded' : 'healthy'
   const lastCheckedAt = latestTimestamp(sources)
+  const unresolvedDependencies = config.projects.reduce(
+    (total, project) => total + project.plugins.reduce((count, plugin) => count + (plugin.graph.unresolved?.length ?? 0), 0),
+    0,
+  )
   return {
     schema: RADAR_STATUS_SCHEMA,
     configFile: options.configFile,
     stateFile: options.stateFile,
     stateExists: options.stateExists,
     monitoring,
+    coverage: unresolvedDependencies === 0 ? 'complete' : 'incomplete',
     projects: config.projects.length,
     pluginBundles: config.projects.reduce((total, project) => total + project.plugins.length, 0),
+    unresolvedDependencies,
     ...(lastCheckedAt === undefined ? {} : { lastCheckedAt }),
     sources,
     activeVulnerabilities: Object.keys(state.activeVulnerabilities).length,
@@ -112,6 +121,7 @@ export function renderRadarStatus(report: RadarStatusReport): string {
     `Monitoring: ${report.monitoring.replace('-', ' ')}`,
     `Config: ${display(report.configFile)} (${plural(report.projects, 'project')}, ${plural(report.pluginBundles, 'DSH plugin bundle')})`,
     `State: ${display(report.stateFile)}${report.stateExists ? '' : ' (not created yet)'}`,
+    `Coverage: ${report.coverage}${report.unresolvedDependencies === 0 ? '' : ` (${plural(report.unresolvedDependencies, 'unresolved dependency')})`}`,
     `Last check: ${report.lastCheckedAt === undefined ? 'never' : display(report.lastCheckedAt)}`,
     '',
     'Sources:',

--- a/src/radar-types.ts
+++ b/src/radar-types.ts
@@ -33,6 +33,8 @@ export interface DependencyGraph {
   rootNodeId: string
   nodes: DependencyNode[]
   edges: DependencyEdge[]
+  /** How the physical graph was obtained. Older configs may omit this field. */
+  source?: 'npm-lock' | 'installed-node-modules'
   digest?: string
   unresolved?: Array<{
     from: string

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.10.0'
+export const TOOL_VERSION = '0.11.0'

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -25,6 +25,7 @@ describe('dependency graph', () => {
 
     assert.equal(graph.nodes.length, 6)
     assert.equal(graph.edges.length, 5)
+    assert.equal(graph.source, 'npm-lock')
     const vulnerable = graph.nodes.find(node => node.name === 'parser' && node.version === '2.9.0')
     assert.ok(vulnerable)
     assert.deepEqual(

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
@@ -143,6 +143,34 @@ describe('DSH profile initialization', () => {
     }
   })
 
+  it('uses the installed profile tree by default', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-init-installed-'))
+    const profile = join(root, 'profiles', 'web')
+    try {
+      await mkdir(join(profile, 'node_modules', 'demo-plugin'), { recursive: true })
+      await writeFile(join(profile, 'package.json'), JSON.stringify({
+        name: 'dsh-profile-web',
+        dsh: { profile: { bundles: ['demo-plugin'] } },
+      }))
+      await writeFile(join(profile, 'node_modules', 'demo-plugin', 'package.json'), JSON.stringify({
+        name: 'demo-plugin',
+        version: '1.2.3',
+        dependencies: { parser: '2.9.0' },
+      }))
+      await mkdir(join(profile, 'node_modules', 'parser'), { recursive: true })
+      await writeFile(join(profile, 'node_modules', 'parser', 'package.json'), JSON.stringify({
+        name: 'parser',
+        version: '2.9.0',
+      }))
+
+      const config = await createRadarConfigFromDshProfile({ profileDirectory: profile })
+      assert.equal(config.projects[0]?.plugins[0]?.graph.source, 'installed-node-modules')
+      assert.equal(config.projects[0]?.plugins[0]?.graph.nodes.length, 2)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('does not follow a bundle path outside the profile', async () => {
     const root = await mkdtemp(join(tmpdir(), 'upstream-radar-init-'))
     const profile = join(root, 'profiles', 'web')
@@ -158,6 +186,28 @@ describe('DSH profile initialization', () => {
       )
     } finally {
       await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not read a symlinked bundle manifest outside the profile', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-init-symlink-'))
+    const outside = await mkdtemp(join(tmpdir(), 'upstream-radar-init-outside-'))
+    const profile = join(root, 'profiles', 'web')
+    try {
+      await mkdir(join(profile, 'node_modules'), { recursive: true })
+      await writeFile(join(profile, 'package.json'), JSON.stringify({
+        name: 'dsh-profile-web',
+        dsh: { profile: { bundles: ['demo-plugin'] } },
+      }))
+      await writeFile(join(outside, 'package.json'), JSON.stringify({ name: 'demo-plugin', version: '1.0.0' }))
+      await symlink(outside, join(profile, 'node_modules', 'demo-plugin'), 'junction')
+      await assert.rejects(
+        createRadarConfigFromDshProfile({ profileDirectory: profile }),
+        /manifest escapes the DSH profile/,
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(outside, { recursive: true, force: true })
     }
   })
 })

--- a/test/installed-graph.test.ts
+++ b/test/installed-graph.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { describe, it } from 'node:test'
+import { findDependencyPaths } from '../src/graph.js'
+import { parseInstalledNodeModulesGraph } from '../src/installed-graph.js'
+
+async function writeManifest(path: string, value: Record<string, unknown>): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(value)}\n`)
+}
+
+describe('installed DSH dependency graph', () => {
+  it('follows the profile node_modules tree and preserves duplicate versions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-installed-graph-'))
+    try {
+      await writeManifest(join(root, 'node_modules', 'plugin', 'package.json'), {
+        name: 'plugin',
+        version: '1.0.0',
+        dependencies: { framework: '2.4.7', logger: '4.0.2' },
+      })
+      await writeManifest(join(root, 'node_modules', 'framework', 'package.json'), {
+        name: 'framework',
+        version: '2.4.7',
+        dependencies: { parser: '3.2.1', archive: '1.8.0' },
+      })
+      await writeManifest(join(root, 'node_modules', 'framework', 'node_modules', 'parser', 'package.json'), {
+        name: 'parser',
+        version: '3.2.1',
+      })
+      await writeManifest(join(root, 'node_modules', 'archive', 'package.json'), {
+        name: 'archive',
+        version: '1.8.0',
+      })
+      await writeManifest(join(root, 'node_modules', 'logger', 'package.json'), {
+        name: 'logger',
+        version: '4.0.2',
+        dependencies: { parser: '2.9.0' },
+      })
+      await writeManifest(join(root, 'node_modules', 'parser', 'package.json'), {
+        name: 'parser',
+        version: '2.9.0',
+      })
+
+      const graph = await parseInstalledNodeModulesGraph(root, { name: 'plugin', version: '1.0.0' })
+      assert.equal(graph.source, 'installed-node-modules')
+      assert.equal(graph.nodes.length, 6)
+      assert.equal(graph.edges.length, 5)
+      const vulnerable = graph.nodes.find(node => node.name === 'parser' && node.version === '2.9.0')
+      assert.ok(vulnerable)
+      assert.deepEqual(
+        findDependencyPaths(graph, vulnerable.id).map(path => path.map(node => `${node.name}@${node.version}`)),
+        [['plugin@1.0.0', 'logger@4.0.2', 'parser@2.9.0']],
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps an absent installed dependency explicit instead of inventing a version', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-installed-graph-'))
+    try {
+      await writeManifest(join(root, 'node_modules', 'plugin', 'package.json'), {
+        name: 'plugin',
+        version: '1.0.0',
+        dependencies: { missing: '1.0.0' },
+      })
+      const graph = await parseInstalledNodeModulesGraph(root, { name: 'plugin', version: '1.0.0' })
+      assert.equal(graph.nodes.length, 1)
+      assert.deepEqual(graph.unresolved, [{ from: 'node_modules/plugin', name: 'missing', kind: 'runtime', spec: '1.0.0' }])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/inventory.test.ts
+++ b/test/inventory.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { parseRadarConfig } from '../src/inventory.js'
+import type { RadarConfig } from '../src/radar-types.js'
 
-const valid = {
+const valid: RadarConfig = {
   schema: 'upstream-radar.radar-config/v1alpha1',
   projects: [{
     schema: 'upstream-radar.inventory/v1alpha1',
@@ -26,6 +27,20 @@ describe('radar inventory parsing', () => {
   it('accepts a bounded project and dependency graph', () => {
     const parsed = parseRadarConfig(valid)
     assert.equal(parsed.projects[0]?.plugins[0]?.graph.nodes[1]?.version, '2.9.0')
+  })
+
+  it('preserves the graph source and unresolved dependencies as incomplete coverage', () => {
+    const candidate = structuredClone(valid)
+    candidate.projects[0]!.plugins[0]!.graph.source = 'installed-node-modules'
+    candidate.projects[0]!.plugins[0]!.graph.unresolved = [{
+      from: 'plugin',
+      name: 'optional-parser',
+      kind: 'optional',
+      spec: '^1.0.0',
+    }]
+    const parsed = parseRadarConfig(candidate)
+    assert.equal(parsed.projects[0]?.plugins[0]?.graph.source, 'installed-node-modules')
+    assert.deepEqual(parsed.projects[0]?.plugins[0]?.graph.unresolved, candidate.projects[0]!.plugins[0]!.graph.unresolved)
   })
 
   it('rejects edges to missing nodes', () => {

--- a/test/radar-status.test.ts
+++ b/test/radar-status.test.ts
@@ -30,6 +30,8 @@ describe('Radar status', () => {
     })
 
     assert.equal(report.monitoring, 'not-started')
+    assert.equal(report.coverage, 'complete')
+    assert.equal(report.unresolvedDependencies, 0)
     assert.equal(report.projects, 1)
     assert.equal(report.pluginBundles, 1)
     assert.equal(report.lastCheckedAt, undefined)
@@ -63,6 +65,7 @@ describe('Radar status', () => {
     })
 
     assert.equal(report.monitoring, 'degraded')
+    assert.equal(report.coverage, 'complete')
     assert.equal(report.lastCheckedAt, '2026-08-16T01:01:00.000Z')
     assert.equal(report.activeVulnerabilities, 1)
     assert.equal(report.activeCompatibility, 1)


### PR DESCRIPTION
## What changed

- build the default DSH inventory from the profile's installed `node_modules` resolution tree
- preserve duplicate versions and profile-local overrides instead of re-resolving through a fresh npm project
- keep unresolved declarations explicit and surface incomplete dependency coverage in `radar status`
- reject bundle or dependency manifests whose symlinks escape the DSH profile
- retain `--registry` as an explicit public npm graph comparison path
- update the English/Chinese docs, architecture notes, roadmap, showcase, and release metadata for v0.11.0

## Why

The profile's installed tree is the closest deterministic evidence of what that DSH profile can resolve. A registry-generated graph can hide local overrides or host-provided peers. The new default follows the installed profile and reports gaps instead of silently treating them as clean.

## Validation

- `pnpm run check`
- `pnpm test` — 77 tests passed
- `pnpm run showcase:radar:reports`
- `pnpm run try:dsh:report`
- `pnpm run try:dsh:live`
- real DSH profile init proof with `dsh-cloudflare-browser-run@0.1.1`
- `pnpm pack` — v0.11.0 artifact contains `installed-graph`
