### PR TITLE
Show dependency origin in vulnerability alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.13.0] - 2026-08-16
+
+### Added
+
+- Preserve the physical origin of affected packages in vulnerability events and DSH analysis tasks.
+- Render whether an alert comes from the plugin profile, the DSH host runtime, or both.
+- Extend the deterministic dependency-graph showcase with origin evidence.
+
+### Fixed
+
+- Avoid losing the profile-versus-host distinction between graph construction and the user-facing alert.
+
 ## [0.12.0] - 2026-08-16
 
 ### Added
@@ -149,6 +161,7 @@ All notable changes to Upstream Radar are documented here.
 - Version matching and compatibility facts are calculated outside the model.
 - Agent analysis is read-only and requires project evidence and explicit uncertainty.
 
+[0.13.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.13.0
 [0.12.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.12.0
 [0.11.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.11.0
 [0.10.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.10.0

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ If an advisory affects only one of two installed `parser` versions, Radar report
 Project: Payments API (payments-api)
 Plugin: plugin@1.0.0
 Affected: parser@2.9.0
+Origin: plugin profile
 Advisory: GHSA-demo-2026-parser / CVE-2026-1234
 Paths:
   plugin@1.0.0 -> logger@4.0.2 -> parser@2.9.0
@@ -237,7 +238,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 ## What works today
 
 - installed DSH `node_modules` graphs and npm lockfile graphs with duplicate versions and bounded dependency paths;
-- DSH shared host-runtime dependency resolution, with profile and `dsh-host` packages kept distinct;
+- DSH shared host-runtime dependency resolution, with profile and `dsh-host` packages kept distinct in both graphs and alerts;
 - exact-version OSV vulnerability and malicious-package matching;
 - npm release monitoring for plugins and DSH/Cordis packages, with public GitHub Release notes attached when an exact candidate tag is available;
 - durable incident state with current-task replacement and resolution;

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -69,6 +69,7 @@ OSV 漏洞公告或 npm 新版本
 Project: Payments API (payments-api)
 Plugin: plugin@1.0.0
 Affected: parser@2.9.0
+Origin: plugin profile
 Advisory: GHSA-demo-2026-parser / CVE-2026-1234
 Paths:
   plugin@1.0.0 -> logger@4.0.2 -> parser@2.9.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ For a real DSH profile, initialization follows the installed `node_modules` reso
 1. Deduplicate all installed npm `name@version` pairs.
 2. Submit them to OSV `querybatch`.
 3. Fetch full details only for returned advisory ids.
-4. Match each result back to physical graph nodes and paths.
+4. Match each result back to physical graph nodes and paths, retaining whether the affected node came from the plugin profile or the DSH host runtime.
 5. Compare the current match set with durable state.
 6. Emit `new`, `updated`, or `resolved` only when state changes.
 7. Add new and updated events to the durable DSH analysis outbox.

--- a/examples/radar/config.json
+++ b/examples/radar/config.json
@@ -46,37 +46,44 @@
               {
                 "id": "plugin",
                 "name": "plugin",
-                "version": "1.0.0"
+                "version": "1.0.0",
+                "source": "profile"
               },
               {
                 "id": "framework",
                 "name": "framework",
-                "version": "2.4.7"
+                "version": "2.4.7",
+                "source": "profile"
               },
               {
                 "id": "framework-parser",
                 "name": "parser",
-                "version": "3.2.1"
+                "version": "3.2.1",
+                "source": "profile"
               },
               {
                 "id": "archive",
                 "name": "archive",
-                "version": "1.8.0"
+                "version": "1.8.0",
+                "source": "profile"
               },
               {
                 "id": "logger",
                 "name": "logger",
-                "version": "4.0.2"
+                "version": "4.0.2",
+                "source": "profile"
               },
               {
                 "id": "logger-parser",
                 "name": "parser",
-                "version": "2.9.0"
+                "version": "2.9.0",
+                "source": "profile"
               },
               {
                 "id": "dsh-agent",
                 "name": "@deepseek-ai/dsh-agent",
-                "version": "0.1.0-rc.5"
+                "version": "0.1.0-rc.5",
+                "source": "dsh-host"
               }
             ],
             "edges": [

--- a/examples/radar/reports/02-vulnerability-alert.json
+++ b/examples/radar/reports/02-vulnerability-alert.json
@@ -36,6 +36,9 @@
         "name": "parser",
         "version": "2.9.0"
       },
+      "affectedSources": [
+        "profile"
+      ],
       "paths": [
         [
           {
@@ -112,6 +115,9 @@
           "name": "parser",
           "version": "2.9.0"
         },
+        "affectedSources": [
+          "profile"
+        ],
         "paths": [
           [
             {
@@ -203,6 +209,9 @@
             "name": "parser",
             "version": "2.9.0"
           },
+          "affectedSources": [
+            "profile"
+          ],
           "paths": [
             [
               {
@@ -281,6 +290,9 @@
             "name": "parser",
             "version": "2.9.0"
           },
+          "affectedSources": [
+            "profile"
+          ],
           "paths": [
             [
               {

--- a/examples/radar/reports/03-vulnerability-dsh-task.txt
+++ b/examples/radar/reports/03-vulnerability-dsh-task.txt
@@ -54,6 +54,9 @@ event_json:
     "name": "parser",
     "version": "2.9.0"
   },
+  "affectedSources": [
+    "profile"
+  ],
   "paths": [
     [
       {

--- a/examples/radar/reports/07-source-outage.json
+++ b/examples/radar/reports/07-source-outage.json
@@ -48,6 +48,9 @@
             "name": "parser",
             "version": "2.9.0"
           },
+          "affectedSources": [
+            "profile"
+          ],
           "paths": [
             [
               {
@@ -126,6 +129,9 @@
             "name": "parser",
             "version": "2.9.0"
           },
+          "affectedSources": [
+            "profile"
+          ],
           "paths": [
             [
               {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Dependency security monitoring for DeepSeek Harness (DSH) plugins: find the exact vulnerable path or breaking update, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ export {
   type DependencyGraph,
   type DependencyKind,
   type DependencyNode,
+  type DependencySource,
   type EventRoute,
   type PackageCoordinate,
   type PackageManifestSnapshot,

--- a/src/radar-render.ts
+++ b/src/radar-render.ts
@@ -1,4 +1,4 @@
-import type { CompatibilityEvent, RadarEvent, VulnerabilityEvent } from './radar-types.js'
+import type { CompatibilityEvent, DependencySource, RadarEvent, VulnerabilityEvent } from './radar-types.js'
 
 function display(value: string, max = 2_048): string {
   const escaped = value.replace(/[\u0000-\u001f\u007f-\u009f]/g, character => (
@@ -11,6 +11,17 @@ function packageLabel(value: { name: string; version: string }): string {
   return `${display(value.name)}@${display(value.version)}`
 }
 
+function dependencySourceLabel(source: 'profile' | 'dsh-host'): string {
+  return source === 'dsh-host' ? 'DSH host runtime' : 'plugin profile'
+}
+
+function dependencySourcesLabel(sources: readonly DependencySource[]): string {
+  return (['profile', 'dsh-host'] as const)
+    .filter(source => sources.includes(source))
+    .map(dependencySourceLabel)
+    .join(' + ')
+}
+
 function renderVulnerability(event: VulnerabilityEvent): string[] {
   const severity = event.kind === 'malware' ? 'CRITICAL' : event.advisory.severity.toUpperCase()
   const lines = [
@@ -18,6 +29,9 @@ function renderVulnerability(event: VulnerabilityEvent): string[] {
     `Project: ${display(event.project.name)} (${display(event.project.id)})`,
     `Plugin: ${packageLabel(event.plugin)}`,
     `Affected: ${packageLabel(event.affected)}`,
+    ...(event.affectedSources === undefined || event.affectedSources.length === 0
+      ? []
+      : [`Origin: ${dependencySourcesLabel(event.affectedSources)}`]),
     `Advisory: ${display(event.advisory.id)}${event.advisory.aliases.length === 0 ? '' : ` / ${event.advisory.aliases.map(item => display(item)).join(', ')}`}`,
     `Summary: ${display(event.advisory.summary)}`,
   ]

--- a/src/radar-state.ts
+++ b/src/radar-state.ts
@@ -14,6 +14,13 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>
 }
 
+function validAffectedSources(value: unknown): boolean {
+  if (value === undefined) return true
+  if (!Array.isArray(value) || value.length === 0 || value.length > 2) return false
+  const allowed = new Set(['profile', 'dsh-host'])
+  return new Set(value).size === value.length && value.every(item => typeof item === 'string' && allowed.has(item))
+}
+
 export function parseRadarState(value: unknown): RadarState {
   const root = asRecord(value)
   if (root?.schema !== RADAR_STATE_SCHEMA) throw new Error('radar state has an unsupported schema')
@@ -54,6 +61,7 @@ export function parseRadarState(value: unknown): RadarState {
       || (event.kind !== 'vulnerability' && event.kind !== 'malware' && event.kind !== 'compatibility' && event.kind !== 'source-health')) {
       throw new Error('radar state contains an invalid pending analysis task')
     }
+    if (!validAffectedSources(event.affectedSources)) throw new Error('radar state contains invalid affected package origins')
   }
   if (Object.keys(active).length > 1_000_000) throw new Error('radar state exceeds the active match limit')
   if (Object.keys(activeCompatibility).length > 1_000_000) {
@@ -65,7 +73,8 @@ export function parseRadarState(value: unknown): RadarState {
     const advisory = asRecord(event?.advisory)
     if (stored?.key !== key || event?.schema !== RADAR_EVENT_SCHEMA || typeof event.incidentId !== 'string'
       || (event.kind !== 'vulnerability' && event.kind !== 'malware')
-      || typeof advisory?.id !== 'string' || typeof advisory.modified !== 'string') {
+      || typeof advisory?.id !== 'string' || typeof advisory.modified !== 'string'
+      || !validAffectedSources(event.affectedSources)) {
       throw new Error(`radar state contains an invalid active match: ${key.slice(0, 256)}`)
     }
   }

--- a/src/radar-types.ts
+++ b/src/radar-types.ts
@@ -14,6 +14,7 @@ export interface PackageCoordinate {
 }
 
 export type DependencyKind = 'runtime' | 'development' | 'optional' | 'peer'
+export type DependencySource = 'profile' | 'dsh-host'
 
 /** One physical package location. Duplicate name/version pairs remain distinct nodes. */
 export interface DependencyNode {
@@ -21,7 +22,7 @@ export interface DependencyNode {
   name: string
   version: string
   /** Where an installed graph found this physical package. */
-  source?: 'profile' | 'dsh-host'
+  source?: DependencySource
 }
 
 export interface DependencyEdge {
@@ -134,6 +135,8 @@ export interface VulnerabilityEvent extends RadarEventBase {
   kind: 'vulnerability' | 'malware'
   plugin: PackageCoordinate
   affected: PackageCoordinate
+  /** Physical origins of the affected package; absent for legacy/npm-lock graphs. */
+  affectedSources?: DependencySource[]
   paths: PackageCoordinate[][]
   advisory: VulnerabilityAdvisory
 }

--- a/src/radar.ts
+++ b/src/radar.ts
@@ -10,6 +10,7 @@ import {
   RADAR_STATE_SCHEMA,
   type AdvisoryMatch,
   type AnalysisTask,
+  type DependencySource,
   type EventRoute,
   type PackageCoordinate,
   type ProjectInventory,
@@ -77,6 +78,7 @@ function eventId(key: string, change: VulnerabilityEvent['change'], detectedAt: 
 function eventChanged(previous: VulnerabilityEvent, current: VulnerabilityEvent): boolean {
   return JSON.stringify(previous.advisory) !== JSON.stringify(current.advisory)
     || JSON.stringify(previous.paths) !== JSON.stringify(current.paths)
+    || JSON.stringify(previous.affectedSources) !== JSON.stringify(current.affectedSources)
     || JSON.stringify(previous.route) !== JSON.stringify(current.route)
 }
 
@@ -224,6 +226,7 @@ export async function pollRadar(
       for (const plugin of inventory.plugins) {
         const groupedPaths = new Map<string, PackageCoordinate[][]>()
         const groupedMatch = new Map<string, AdvisoryMatch>()
+        const groupedSources = new Map<string, Set<DependencySource>>()
         for (const node of plugin.graph.nodes) {
           const affected = coordinate(node.name, node.version)
           for (const match of matches.get(packageKey(affected)) ?? []) {
@@ -243,6 +246,11 @@ export async function pollRadar(
             }
             groupedPaths.set(key, existing)
             groupedMatch.set(key, match)
+            if (node.source !== undefined) {
+              const sources = groupedSources.get(key) ?? new Set<DependencySource>()
+              sources.add(node.source)
+              groupedSources.set(key, sources)
+            }
           }
         }
 
@@ -250,6 +258,9 @@ export async function pollRadar(
           const match = groupedMatch.get(key)
           if (match === undefined) continue
           paths.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)))
+          const sourceSet = groupedSources.get(key)
+          const orderedSources: readonly DependencySource[] = ['profile', 'dsh-host']
+          const affectedSources = orderedSources.filter(source => sourceSet?.has(source) ?? false)
           const event: VulnerabilityEvent = {
             schema: RADAR_EVENT_SCHEMA,
             id: eventId(key, 'new', checkedAt, match.advisory.modified),
@@ -261,6 +272,7 @@ export async function pollRadar(
             route: route(inventory),
             plugin: { ...plugin.package },
             affected: { ...match.package },
+            ...(affectedSources.length === 0 ? {} : { affectedSources }),
             paths,
             advisory: { ...match.advisory },
           }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.12.0'
+export const TOOL_VERSION = '0.13.0'

--- a/test/radar-render.test.ts
+++ b/test/radar-render.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { renderRadarEvent } from '../src/radar-render.js'
+import type { VulnerabilityEvent } from '../src/radar-types.js'
+
+describe('Radar event rendering', () => {
+  it('explains whether an affected package comes from the DSH host runtime', () => {
+    const event: VulnerabilityEvent = {
+      schema: 'upstream-radar.event/v1alpha1',
+      id: 'event-1',
+      incidentId: 'incident-1',
+      kind: 'vulnerability',
+      change: 'new',
+      detectedAt: '2026-08-16T01:00:00.000Z',
+      project: { id: 'demo', name: 'Demo' },
+      route: { channels: ['stdout'] },
+      plugin: { ecosystem: 'npm', name: 'demo-plugin', version: '1.0.0' },
+      affected: { ecosystem: 'npm', name: '@deepseek-ai/dsh-agent', version: '0.1.0-rc.6' },
+      affectedSources: ['dsh-host', 'profile'],
+      paths: [[
+        { ecosystem: 'npm', name: 'demo-plugin', version: '1.0.0' },
+        { ecosystem: 'npm', name: '@deepseek-ai/dsh-agent', version: '0.1.0-rc.6' },
+      ]],
+      advisory: {
+        id: 'GHSA-demo',
+        aliases: [],
+        summary: 'Demo advisory',
+        details: 'Demo details',
+        severity: 'high',
+        modified: '2026-08-16T01:00:00.000Z',
+        fixedVersions: ['0.2.0'],
+        references: [],
+      },
+    }
+
+    const output = renderRadarEvent(event)
+    assert.match(output, /Origin: plugin profile \+ DSH host runtime/)
+  })
+})

--- a/test/radar.test.ts
+++ b/test/radar.test.ts
@@ -22,7 +22,7 @@ const inventory: ProjectInventory = {
       nodes: [
         { id: 'plugin', name: 'plugin', version: '1.0.0' },
         { id: 'logger', name: 'logger', version: '4.0.2' },
-        { id: 'parser-old', name: 'parser', version: '2.9.0' },
+        { id: 'parser-old', name: 'parser', version: '2.9.0', source: 'dsh-host' },
       ],
       edges: [
         { from: 'plugin', to: 'logger', kind: 'runtime' },
@@ -67,6 +67,7 @@ describe('radar polling', () => {
     const firstEvent = first.events[0]
     assert.ok(firstEvent !== undefined)
     assert.equal(firstEvent.kind, 'vulnerability')
+    assert.deepEqual(firstEvent.affectedSources, ['dsh-host'])
     assert.deepEqual(firstEvent.paths[0]?.map(item => `${item.name}@${item.version}`), [
       'plugin@1.0.0',
       'logger@4.0.2',


### PR DESCRIPTION
## What changed

- Preserve whether an affected dependency came from the plugin profile or DSH's shared host runtime.
- Carry that origin into vulnerability events and durable DSH analysis tasks.
- Render `Origin: plugin profile`, `Origin: DSH host runtime`, or both in human alerts.
- Validate the new field when loading durable state.
- Update the deterministic graph fixture and showcase reports so the distinction is visible from the README.

## Why

The dependency graph already knew the physical origin, but the alert discarded it. Users could see the path but could not tell whether they needed to update the plugin or whether the vulnerable package belonged to DSH's host runtime.

## Validation

- `pnpm test` — 80 tests passing
- `pnpm run scan:self` — no implemented static findings
- `pnpm run try:dsh` — real DSH headless delivery passed
- `pnpm run try:dsh:live` — real DSH with live OSV + npm feeds passed
