### PR TITLE
feat: surface the first deterministic upgrade candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.17.0] - 2026-08-16
+
+### Added
+
+- Read newer exact npm manifests from the existing packument and evaluate them in ascending order.
+- Record the first candidate without a confirmed or strong deterministic blocker when the latest release is risky.
+- Show blocked intermediate candidates and their reasons in the compatibility event and DSH analysis task.
+
+### Safety
+
+- The first candidate is explicitly not a safety or compatibility certificate; DSH still has to inspect project evidence.
+- Candidate ranking remains outside the model and does not install or execute any release.
+- Persisted upgrade-path state is bounded and validated before it is accepted.
+
 ## [0.16.0] - 2026-08-16
 
 ### Changed
@@ -194,6 +208,7 @@ All notable changes to Upstream Radar are documented here.
 - Version matching and compatibility facts are calculated outside the model.
 - Agent analysis is read-only and requires project evidence and explicit uncertainty.
 
+[0.17.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.17.0
 [0.16.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.16.0
 [0.15.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.15.0
 [0.14.0]: https://github.com/MicroMilo/upstream-radar/releases/tag/v0.14.0

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ That incident becomes a plugin-originated DSH notice. It is not copied into a ge
 | Upstream signal | Radar proves deterministically | DSH Agent investigates |
 | --- | --- | --- |
 | Vulnerability or malicious package | affected `name@version`, every installed path, fixed versions, incident state | whether project code reaches it, attacker input can reach it, and the least disruptive fix |
-| Candidate npm release | version boundary and Node.js, peer, export, entrypoint, bundle, and dependency changes | which APIs or Cordis configuration would break and what migration is appropriate |
+| Candidate npm release | version boundary and Node.js, peer, export, entrypoint, bundle, and dependency changes; when possible, the first newer version without a deterministic blocker | which APIs or Cordis configuration would break and what migration is appropriate; the first candidate is never treated as a safety certificate |
 
 ## Install in DSH
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@
 - [x] Read the exact public GitHub Release notes for a candidate version; changelogs, comparison diffs, and migration guides remain deferred.
 - [ ] Track DSH package families as one coordinated release rather than unrelated npm packages.
 - [x] Group pending same-project DSH runtime compatibility tasks into one native Agent notice without merging state incidents.
-- [ ] Resolve the lowest clean plugin upgrade, not merely the latest release.
+- [x] Resolve the first newer plugin candidate without a deterministic blocker, while leaving final compatibility to DSH project analysis.
 - [x] Discover a named DSH profile's installed third-party bundles and generate a reviewable inventory.
 - [x] Auto-select the only DSH profile with third-party bundles when `--profile` is omitted.
 - [x] Use the selected profile's installed `node_modules` tree as the source of truth, including unresolved-edge visibility.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -209,7 +209,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
+已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会按历史版本筛出第一个值得交给 DSH 分析的候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
 
 `init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查，但不会替你刷新漏洞源。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,6 +77,8 @@ The release source reads npm metadata; it does not install the candidate. A `lat
 
 These are signals for project analysis. Only an explicit publisher statement or a mathematically incompatible version range is treated as confirmed/strong evidence. Other changes remain `needs-analysis`.
 
+The npm packument also contains older releases. When the latest candidate is blocked, Radar evaluates newer intermediate manifests in ascending order and records the first one without a confirmed/strong blocker. This is a starting point for DSH analysis, not a claim that the version is safe; the Agent still has to inspect the project's code and configuration. The event keeps only a small sample of blocked versions so the notice stays actionable.
+
 Compatibility findings use the same lifecycle as vulnerabilities. A stable `incidentId` identifies the project, installed plugin, and changed package while individual event ids identify each `new`, `updated`, or `resolved` transition. A newer candidate replaces the queued analysis for the same incident; when the project catches up or the signal disappears, the unresolved task is removed.
 
 ## DSH Agent handoff

--- a/docs/checks.zh-CN.md
+++ b/docs/checks.zh-CN.md
@@ -12,7 +12,7 @@
 | 项目路由 | 哪个项目、插件、负责人受影响 | 依赖图反查项目登记 | project、owner、channel |
 | 插件新版本 | npm `latest` 是否出现新候选 | 只读 packument，不安装候选 | 兼容性事件或无变化 |
 | 发布说明 | 候选版本有没有对应的公开 GitHub Release 说明 | 仅接受 npm 元数据中的公开 `github.com` 仓库，按 `v<version>` 或 `<version>` 精确读取；正文限长并作为不可信材料 | 发布说明正文与链接，失败不阻塞 npm/OSV 主链路 |
-| Breaking signals | 新版本是否真的是高于当前安装版本的候选，并且是否跨兼容边界或改变关键声明 | 先比较 npm 精确版本方向；只对更高版本比较入口、exports、Node、DSH bundle 和 peer 范围；`latest` 回退不制造新告警，也不把已有问题误判为已解决 | confirmed/strong/needs-analysis |
+| Breaking signals | 新版本是否真的是高于当前安装版本的候选，并且是否跨兼容边界或改变关键声明 | 先比较 npm 精确版本方向；只对更高版本比较入口、exports、Node、DSH bundle 和 peer 范围；`latest` 回退不制造新告警，也不把已有问题误判为已解决；当最新版本有确定性阻断时，再按版本从低到高筛出第一个没有确定性阻断的候选，但不称为“安全” | confirmed/strong/needs-analysis；最低候选仍需 DSH 项目分析 |
 | DSH 分析入口 | 如何避免“新闻”直接指挥 Agent，以及如何避免一次 DSH 升级刷出多条通知 | 将所有来源文字标记为不可信数据，要求只读和项目证据；同一项目同一轮的 DSH 运行时包更新在投递层合并，底层事件仍逐包保存 | 由 DSH 原生投递；CLI 只用于检查持久 analysis task |
 | 去重与恢复 | 重启、重复轮询是否丢失、刷屏或投递过期任务 | 保存活跃漏洞、活跃兼容性问题和待分析任务；同一 incident 的新任务替换旧任务，resolved 会撤销旧任务 | 至少一次投递，不变不重复，不过期投递 |
 | 源失败与健康 | OSV 暂时查不到时，是否会被误判成“没有漏洞”，以及负责人能否知道源长期不可用 | 保留上一次确认的漏洞状态，不生成假的 `resolved`，仍继续投递已有 DSH 任务；连续 3 次失败生成持久 `source-health` DSH notice，恢复后 `resolved`；CLI/JSON 返回源警告 | `sourceErrors: osv`、源健康状态、source-health 生命周期 |

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -69,6 +69,16 @@ The candidate `plugin@2.0.0` changes:
 
 Radar identifies the mathematically incompatible environment and peer range, labels structural changes as needing analysis, and creates a separate DSH compatibility task.
 
+The same npm metadata also contains `plugin@1.1.0` and `plugin@1.2.0`. Radar evaluates them without installing either package: `1.2.0` is blocked by the Node.js requirement, while `1.1.0` has no deterministic blocker and is shown as the first version worth handing to DSH. That wording is deliberate: it is a candidate for project analysis, not a safety certificate.
+
+```text
+First candidate without a deterministic blocker: plugin@1.1.0 (still requires project analysis)
+Upgrade candidates evaluated: 3; deterministic blockers: 2
+Blocked candidate samples:
+  plugin@1.2.0: node-runtime-incompatible
+  plugin@2.0.0: breaking-version-boundary, publisher-declared-breaking-change, node-runtime-incompatible, dsh-peer-incompatible
+```
+
 ## Scene 5 — one DSH runtime change, one Agent notice
 
 If one DSH runtime release changes several `@deepseek-ai/dsh-*` packages, Radar keeps the package-level incidents separate in durable state but groups the pending native DSH delivery:
@@ -100,7 +110,7 @@ The showcase then simulates an OSV timeout. Radar emits no new or resolved vulne
 
 After three consecutive failed OSV checks, Radar creates one project-routed `source-health` incident and sends it through the same durable DSH outbox. When OSV recovers, the source-health incident resolves and its pending task is removed. The lifecycle is saved as `examples/radar/reports/08-source-health-lifecycle.json`.
 
-## Scene 8 — onboarding without shell state
+## Scene 9 — onboarding without shell state
 
 `init --dsh-patch ./upstream-radar.dsh.yml` writes the exact inventory and a reviewable DSH overlay. The overlay replaces the bundle's environment-derived paths with explicit config and state files, so the profile can start with one visible command:
 
@@ -110,7 +120,7 @@ dsh --profile web --patch ./upstream-radar.dsh.yml
 
 The generated overlay does not install packages or start DSH; the user still reviews both files and installs the Radar bundle explicitly.
 
-## Scene 9 — confirm the first run without another network request
+## Scene 10 — confirm the first run without another network request
 
 After DSH has started, the read-only status command reads the same config and durable state files:
 
@@ -122,7 +132,7 @@ It reports whether monitoring has started, the last successful check for OSV/npm
 
 The status output also shows `Coverage: incomplete` when the installed profile contains a dependency declaration that DSH cannot currently resolve. That is a configuration gap, not a clean result.
 
-## Scene 10 — the graph follows the installed DSH profile
+## Scene 11 — the graph follows the installed DSH profile
 
 For a profile containing `dsh-cloudflare-browser-run@0.1.1`, initialization reports the graph source explicitly:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Dependency security monitoring for DeepSeek Harness (DSH) plugins: find the exact vulnerable path or breaking update, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/scripts/radar-showcase.mjs
+++ b/scripts/radar-showcase.mjs
@@ -111,10 +111,20 @@ await save('03-vulnerability-dsh-task.txt', vulnerabilityPrompt)
 heading(4, 'A plugin update appears: detect compatibility and breaking-change signals')
 const previous = parsePackageManifestSnapshot(await json('plugin-before.json'))
 const candidate = parsePackageManifestSnapshot(await json('plugin-candidate.json'))
+const intermediate = {
+  ...structuredClone(previous),
+  version: '1.1.0',
+}
+const blockedIntermediate = {
+  ...structuredClone(previous),
+  version: '1.2.0',
+  engines: { node: '>=24' },
+}
 const releaseNotes = await readFile(join(fixtureDirectory, 'release-notes.txt'), 'utf8')
 const compatibility = assessCompatibilityChange(config.projects[0], {
   previous,
   candidate,
+  upgradeCandidates: [intermediate, blockedIntermediate, candidate],
   releaseNotes,
   releaseNotesUrl: 'https://github.com/acme/plugin/releases/tag/v2.0.0',
   detectedAt: '2026-08-14T02:00:00.000Z',

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -3,8 +3,11 @@ import { compareSemverValues, crossesBreakingVersionBoundary, satisfiesSemverRan
 import {
   RADAR_EVENT_SCHEMA,
   type CompatibilityEvent,
+  type CompatibilityUpgradeCandidate,
+  type CompatibilityUpgradePath,
   type CompatibilitySignal,
   type PackageManifestSnapshot,
+  type PluginInstallation,
   type ProjectInventory,
 } from './radar-types.js'
 
@@ -13,6 +16,8 @@ export interface CompatibilityChangeInput {
   candidate: PackageManifestSnapshot
   releaseNotes?: string
   releaseNotesUrl?: string
+  /** Exact newer manifests from the same npm packument, used only for deterministic candidate ranking. */
+  upgradeCandidates?: readonly PackageManifestSnapshot[]
   detectedAt: string
 }
 
@@ -48,41 +53,24 @@ function changedSignal(
   signals.push({ code, confidence: 'needs-analysis', summary, before: text(before), after: text(after) })
 }
 
-/** Find deterministic incompatibilities and high-value change signals before asking a model. */
-export function assessCompatibilityChange(
+function collectCompatibilitySignals(
   inventory: ProjectInventory,
-  change: CompatibilityChangeInput,
-): CompatibilityEvent | undefined {
-  return assessCompatibilityChanges(inventory, change)[0]
-}
-
-/** Assess one upstream package update against every installed plugin that contains it. */
-export function assessCompatibilityChanges(
-  inventory: ProjectInventory,
-  change: CompatibilityChangeInput,
-): CompatibilityEvent[] {
-  if (change.previous.name !== change.candidate.name) throw new Error('compatibility comparison requires the same package name')
-  if (!Number.isFinite(Date.parse(change.detectedAt))) throw new Error('compatibility change has an invalid detection time')
-  const versionOrder = compareSemverValues(change.candidate.version, change.previous.version)
-  if (versionOrder !== undefined && versionOrder <= 0) return []
-  const installations = inventory.plugins.filter(plugin => plugin.graph.nodes.some(node => (
-    node.name === change.previous.name && node.version === change.previous.version
-  )))
-  if (installations.length === 0) return []
-
-  return installations.flatMap((installation) => {
-
+  installation: PluginInstallation,
+  previous: PackageManifestSnapshot,
+  candidate: PackageManifestSnapshot,
+  releaseNotes?: string,
+): CompatibilitySignal[] {
   const signals: CompatibilitySignal[] = []
-  if (crossesBreakingVersionBoundary(change.previous.version, change.candidate.version)) {
+  if (crossesBreakingVersionBoundary(previous.version, candidate.version)) {
     signals.push({
       code: 'breaking-version-boundary',
       confidence: 'strong',
-      summary: `Version ${change.previous.version} to ${change.candidate.version} crosses a semantic-version compatibility boundary.`,
-      before: change.previous.version,
-      after: change.candidate.version,
+      summary: `Version ${previous.version} to ${candidate.version} crosses a semantic-version compatibility boundary.`,
+      before: previous.version,
+      after: candidate.version,
     })
   }
-  if (change.releaseNotes !== undefined && /\bbreaking(?:[ _-]change)?\b|不兼容|破坏性变更/i.test(change.releaseNotes)) {
+  if (releaseNotes !== undefined && /\bbreaking(?:[ _-]change)?\b|不兼容|破坏性变更/i.test(releaseNotes)) {
     signals.push({
       code: 'publisher-declared-breaking-change',
       confidence: 'confirmed',
@@ -90,18 +78,18 @@ export function assessCompatibilityChanges(
     })
   }
   changedSignal(signals, 'package-entrypoint-changed', 'The package entrypoint or export map changed.', {
-    type: change.previous.type,
-    main: change.previous.main,
-    exports: change.previous.exports,
+    type: previous.type,
+    main: previous.main,
+    exports: previous.exports,
   }, {
-    type: change.candidate.type,
-    main: change.candidate.main,
-    exports: change.candidate.exports,
+    type: candidate.type,
+    main: candidate.main,
+    exports: candidate.exports,
   })
-  changedSignal(signals, 'dsh-bundle-changed', 'The DSH bundle declaration changed.', change.previous.dsh, change.candidate.dsh)
+  changedSignal(signals, 'dsh-bundle-changed', 'The DSH bundle declaration changed.', previous.dsh, candidate.dsh)
 
-  const previousNodeRange = change.previous.engines?.node
-  const candidateNodeRange = change.candidate.engines?.node
+  const previousNodeRange = previous.engines?.node
+  const candidateNodeRange = candidate.engines?.node
   if (previousNodeRange !== candidateNodeRange) {
     signals.push({
       code: 'node-engine-requirement-changed',
@@ -123,8 +111,8 @@ export function assessCompatibilityChanges(
     })
   }
 
-  const previousPeers = change.previous.peerDependencies ?? {}
-  const candidatePeers = change.candidate.peerDependencies ?? {}
+  const previousPeers = previous.peerDependencies ?? {}
+  const candidatePeers = candidate.peerDependencies ?? {}
   for (const [name, range] of Object.entries(candidatePeers).sort(([left], [right]) => left.localeCompare(right))) {
     if (!(name.startsWith('@deepseek-ai/dsh-') || name === '@deepseek-ai/cordis')) continue
     const installed = installation.graph.nodes
@@ -158,8 +146,8 @@ export function assessCompatibilityChanges(
     }
   }
 
-  const previousDependencies = { ...change.previous.dependencies, ...change.previous.optionalDependencies }
-  const candidateDependencies = { ...change.candidate.dependencies, ...change.candidate.optionalDependencies }
+  const previousDependencies = { ...previous.dependencies, ...previous.optionalDependencies }
+  const candidateDependencies = { ...candidate.dependencies, ...candidate.optionalDependencies }
   for (const [name, range] of Object.entries(previousDependencies)) {
     if (candidateDependencies[name] !== undefined) continue
     signals.push({
@@ -170,61 +158,159 @@ export function assessCompatibilityChanges(
     })
   }
 
-  if (change.candidate.name.startsWith('@deepseek-ai/dsh-')
-    && change.previous.version.startsWith('0.')
-    && change.previous.version !== change.candidate.version) {
+  if (candidate.name.startsWith('@deepseek-ai/dsh-')
+    && previous.version.startsWith('0.')
+    && previous.version !== candidate.version) {
     signals.push({
       code: 'dsh-developer-preview-change',
       confidence: 'strong',
       summary: 'A pre-1.0 DSH package changed; compatibility must be verified against installed plugins.',
-      before: change.previous.version,
-      after: change.candidate.version,
+      before: previous.version,
+      after: candidate.version,
     })
   }
 
-  const pluginDeclaredRange = installation.manifest?.peerDependencies?.[change.candidate.name]
+  const pluginDeclaredRange = installation.manifest?.peerDependencies?.[candidate.name]
   if (pluginDeclaredRange !== undefined
-    && satisfiesSemverRange(change.candidate.version, pluginDeclaredRange) === false) {
+    && satisfiesSemverRange(candidate.version, pluginDeclaredRange) === false) {
     signals.push({
       code: 'plugin-dsh-range-incompatible',
       confidence: 'strong',
-      summary: `${installation.package.name}@${installation.package.version} declares ${change.candidate.name}@${pluginDeclaredRange}, which excludes ${change.candidate.version}.`,
+      summary: `${installation.package.name}@${installation.package.version} declares ${candidate.name}@${pluginDeclaredRange}, which excludes ${candidate.version}.`,
       before: pluginDeclaredRange,
-      after: change.candidate.version,
+      after: candidate.version,
     })
   }
+  return signals
+}
 
-  if (signals.length === 0) return []
-  const eventSeed = [inventory.project.id, installation.package.name, installation.package.version, change.previous.name, change.previous.version, change.candidate.version, change.detectedAt].join('\0')
-  const incidentSeed = [inventory.project.id, installation.package.name, installation.package.version, change.previous.name, change.previous.version].join('\0')
-  return [{
-    schema: RADAR_EVENT_SCHEMA,
-    id: `event-${hash(eventSeed)}`,
-    incidentId: `incident-${hash(incidentSeed)}`,
-    kind: 'compatibility',
-    change: 'new',
-    detectedAt: new Date(change.detectedAt).toISOString(),
-    project: { ...inventory.project },
-    route: {
-      ...(inventory.project.owner === undefined ? {} : { owner: inventory.project.owner }),
-      channels: inventory.project.channels === undefined || inventory.project.channels.length === 0
-        ? ['stdout']
-        : [...inventory.project.channels],
-    },
-    plugin: { ...installation.package },
-    installed: {
-      ecosystem: 'npm',
-      name: change.previous.name,
-      version: change.previous.version,
-    },
-    candidate: {
-      ecosystem: 'npm',
-      name: change.candidate.name,
-      version: change.candidate.version,
-    },
-    signals,
-    ...(change.releaseNotes === undefined ? {} : { releaseNotes: change.releaseNotes.slice(0, 64 * 1_024) }),
-    ...(change.releaseNotesUrl === undefined ? {} : { releaseNotesUrl: change.releaseNotesUrl.slice(0, 4_096) }),
-  }]
+function isDeterministicallyBlocked(signals: readonly CompatibilitySignal[]): boolean {
+  return signals.some(signal => signal.confidence === 'confirmed' || signal.confidence === 'strong')
+}
+
+function assessUpgradePath(
+  inventory: ProjectInventory,
+  installation: PluginInstallation,
+  previous: PackageManifestSnapshot,
+  latestCandidate: PackageManifestSnapshot,
+  candidates: readonly PackageManifestSnapshot[],
+  releaseNotes?: string,
+): CompatibilityUpgradePath | undefined {
+  const unique = new Map<string, PackageManifestSnapshot>()
+  for (const candidate of candidates) {
+    if (candidate.name !== previous.name) continue
+    const order = compareSemverValues(candidate.version, previous.version)
+    if (order === undefined || order <= 0) continue
+    unique.set(candidate.version, candidate)
+  }
+  const ordered = [...unique.values()].sort((left, right) => (
+    compareSemverValues(left.version, right.version) ?? left.version.localeCompare(right.version)
+  ))
+  if (ordered.length === 0) return undefined
+
+  let firstCandidate: CompatibilityUpgradeCandidate | undefined
+  const blocked: CompatibilityUpgradeCandidate[] = []
+  let blockedCount = 0
+  for (const candidate of ordered) {
+    const signals = collectCompatibilitySignals(
+      inventory,
+      installation,
+      previous,
+      candidate,
+      candidate.version === latestCandidate.version ? releaseNotes : undefined,
+    )
+    const assessed: CompatibilityUpgradeCandidate = {
+      candidate: { ecosystem: 'npm', name: candidate.name, version: candidate.version },
+      signals,
+    }
+    if (isDeterministicallyBlocked(signals)) {
+      blockedCount += 1
+      if (blocked.length < 8) blocked.push(assessed)
+    } else if (firstCandidate === undefined) {
+      firstCandidate = assessed
+    }
+  }
+  return {
+    evaluated: ordered.length,
+    blockedCount,
+    ...(firstCandidate === undefined ? {} : { firstCandidate }),
+    blocked,
+  }
+}
+
+/** Find deterministic incompatibilities and high-value change signals before asking a model. */
+export function assessCompatibilityChange(
+  inventory: ProjectInventory,
+  change: CompatibilityChangeInput,
+): CompatibilityEvent | undefined {
+  return assessCompatibilityChanges(inventory, change)[0]
+}
+
+/** Assess one upstream package update against every installed plugin that contains it. */
+export function assessCompatibilityChanges(
+  inventory: ProjectInventory,
+  change: CompatibilityChangeInput,
+): CompatibilityEvent[] {
+  if (change.previous.name !== change.candidate.name) throw new Error('compatibility comparison requires the same package name')
+  if (!Number.isFinite(Date.parse(change.detectedAt))) throw new Error('compatibility change has an invalid detection time')
+  const versionOrder = compareSemverValues(change.candidate.version, change.previous.version)
+  if (versionOrder !== undefined && versionOrder <= 0) return []
+  const installations = inventory.plugins.filter(plugin => plugin.graph.nodes.some(node => (
+    node.name === change.previous.name && node.version === change.previous.version
+  )))
+  if (installations.length === 0) return []
+
+  return installations.flatMap((installation) => {
+    const signals = collectCompatibilitySignals(
+      inventory,
+      installation,
+      change.previous,
+      change.candidate,
+      change.releaseNotes,
+    )
+
+    if (signals.length === 0) return []
+    const upgradePath = change.upgradeCandidates === undefined
+      ? undefined
+      : assessUpgradePath(
+        inventory,
+        installation,
+        change.previous,
+        change.candidate,
+        change.upgradeCandidates,
+        change.releaseNotes,
+      )
+    const eventSeed = [inventory.project.id, installation.package.name, installation.package.version, change.previous.name, change.previous.version, change.candidate.version, change.detectedAt].join('\0')
+    const incidentSeed = [inventory.project.id, installation.package.name, installation.package.version, change.previous.name, change.previous.version].join('\0')
+    return [{
+      schema: RADAR_EVENT_SCHEMA,
+      id: `event-${hash(eventSeed)}`,
+      incidentId: `incident-${hash(incidentSeed)}`,
+      kind: 'compatibility',
+      change: 'new',
+      detectedAt: new Date(change.detectedAt).toISOString(),
+      project: { ...inventory.project },
+      route: {
+        ...(inventory.project.owner === undefined ? {} : { owner: inventory.project.owner }),
+        channels: inventory.project.channels === undefined || inventory.project.channels.length === 0
+          ? ['stdout']
+          : [...inventory.project.channels],
+      },
+      plugin: { ...installation.package },
+      installed: {
+        ecosystem: 'npm',
+        name: change.previous.name,
+        version: change.previous.version,
+      },
+      candidate: {
+        ecosystem: 'npm',
+        name: change.candidate.name,
+        version: change.candidate.version,
+      },
+      signals,
+      ...(upgradePath === undefined ? {} : { upgradePath }),
+      ...(change.releaseNotes === undefined ? {} : { releaseNotes: change.releaseNotes.slice(0, 64 * 1_024) }),
+      ...(change.releaseNotesUrl === undefined ? {} : { releaseNotesUrl: change.releaseNotesUrl.slice(0, 4_096) }),
+    }]
   })
 }

--- a/src/dsh-analysis.ts
+++ b/src/dsh-analysis.ts
@@ -54,7 +54,8 @@ function renderAnalysisPrompt(task: AnalysisTask, events: readonly RadarEvent[])
 3. ${focus}
 4. 每个结论必须引用项目内的文件、符号、配置或明确的运行事实。证据不足时输出 unknown。
 5. 区分“已确认事实”和“模型判断”，不要把推测写成事实。
-6. 返回一个 JSON 对象，字段严格为 project_exposure、confidence、evidence、recommended_action、urgency、reasoning_summary。${groupedInstruction}
+6. 如果 event_json 含有 upgradePath，firstCandidate 只表示“没有发现确定性阻断的第一个版本”，不是“安全”或“已兼容”；必须继续用项目证据判断它是否值得尝试。
+7. 返回一个 JSON 对象，字段严格为 project_exposure、confidence、evidence、recommended_action、urgency、reasoning_summary。${groupedInstruction}
 
 expected_output:
 ${JSON.stringify(task.expectedOutput, null, 2)}

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ export {
   type AdvisoryMatch,
   type AnalysisTask,
   type CompatibilityEvent,
+  type CompatibilityUpgradeCandidate,
+  type CompatibilityUpgradePath,
   type CompatibilitySignal,
   type DependencyEdge,
   type DependencyGraph,

--- a/src/npm-release.ts
+++ b/src/npm-release.ts
@@ -23,6 +23,8 @@ export interface NpmReleaseObservation {
   latestVersion: string
   previous: PackageManifestSnapshot
   candidate: PackageManifestSnapshot
+  /** Exact npm manifests newer than the installed version, sorted ascending. */
+  upgradeCandidates?: PackageManifestSnapshot[]
   /** Whether npm's latest tag is newer than the installed exact version. */
   candidateStatus?: NpmReleaseCandidateStatus
   publishedAt?: string
@@ -35,6 +37,27 @@ function candidateStatus(candidate: string, installed: string): NpmReleaseCandid
   if (comparison > 0) return 'newer'
   if (comparison < 0) return 'older'
   return 'same'
+}
+
+function upgradeCandidates(
+  name: string,
+  versions: Record<string, unknown>,
+  installed: string,
+): PackageManifestSnapshot[] {
+  return Object.entries(versions)
+    .flatMap(([version, raw]) => {
+      const comparison = compareSemverValues(version, installed)
+      return comparison === undefined || comparison <= 0 ? [] : [[version, raw] as const]
+    })
+    .sort(([left], [right]) => (compareSemverValues(left, right) ?? 0))
+    .flatMap(([version, raw]) => {
+      try {
+        const parsed = parsePackageManifestSnapshot(raw)
+        return parsed.name === name && parsed.version === version ? [parsed] : []
+      } catch {
+        return []
+      }
+    })
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -153,12 +176,16 @@ export class NpmReleaseClient {
           throw new Error(`npm installed manifest identity mismatch for ${name}@${installed.version}`)
         }
         const publishedAt = typeof times?.[latestVersion] === 'string' ? times[latestVersion] : undefined
+        const status = candidateStatus(latestVersion, installed.version)
         result.set(packageKey(installed), {
           installed: { ...installed },
           latestVersion,
           previous,
           candidate,
-          candidateStatus: candidateStatus(latestVersion, installed.version),
+          ...(status === 'newer'
+            ? { upgradeCandidates: upgradeCandidates(name, versions, installed.version) }
+            : {}),
+          candidateStatus: status,
           ...(publishedAt === undefined ? {} : { publishedAt }),
           ...(repository === undefined ? {} : { repository }),
         })

--- a/src/radar-render.ts
+++ b/src/radar-render.ts
@@ -56,6 +56,29 @@ function renderCompatibility(event: CompatibilityEvent): string[] {
   for (const signal of event.signals) {
     lines.push(`  [${signal.confidence.toUpperCase()}] ${display(signal.code)}: ${display(signal.summary)}`)
   }
+  if (event.upgradePath !== undefined) {
+    if (event.upgradePath.firstCandidate === undefined) {
+      lines.push(`Upgrade path: no candidate without a deterministic blocker among ${event.upgradePath.evaluated} newer versions.`)
+    } else {
+      lines.push(`First candidate without a deterministic blocker: ${packageLabel(event.upgradePath.firstCandidate.candidate)} (still requires project analysis)`)
+      if (event.upgradePath.firstCandidate.signals.length > 0) {
+        lines.push('First-candidate signals:')
+        for (const signal of event.upgradePath.firstCandidate.signals) {
+          lines.push(`  [${signal.confidence.toUpperCase()}] ${display(signal.code)}: ${display(signal.summary)}`)
+        }
+      }
+    }
+    lines.push(`Upgrade candidates evaluated: ${event.upgradePath.evaluated}; deterministic blockers: ${event.upgradePath.blockedCount}`)
+    if (event.upgradePath.blocked.length > 0) {
+      lines.push('Blocked candidate samples:')
+      for (const blocked of event.upgradePath.blocked) {
+        const reasons = blocked.signals
+          .filter(signal => signal.confidence === 'confirmed' || signal.confidence === 'strong')
+          .map(signal => display(signal.code))
+        lines.push(`  ${packageLabel(blocked.candidate)}: ${reasons.length === 0 ? 'deterministic blocker' : reasons.join(', ')}`)
+      }
+    }
+  }
   if (event.releaseNotesUrl !== undefined) lines.push(`Release notes: ${display(event.releaseNotesUrl)}`)
   lines.push(`Route: ${event.route.owner === undefined ? '(no owner)' : display(event.route.owner)} via ${event.route.channels.map(item => display(item)).join(', ')}`)
   return lines

--- a/src/radar-state.ts
+++ b/src/radar-state.ts
@@ -21,6 +21,37 @@ function validAffectedSources(value: unknown): boolean {
   return new Set(value).size === value.length && value.every(item => typeof item === 'string' && allowed.has(item))
 }
 
+function validCompatibilityUpgradeCandidate(value: unknown): boolean {
+  const candidate = asRecord(value)
+  const coordinate = asRecord(candidate?.candidate)
+  const signals = candidate?.signals
+  if (coordinate?.ecosystem !== 'npm'
+    || typeof coordinate.name !== 'string' || coordinate.name.length === 0 || coordinate.name.length > 512
+    || typeof coordinate.version !== 'string' || coordinate.version.length === 0 || coordinate.version.length > 512
+    || !Array.isArray(signals) || signals.length > 64) return false
+  return signals.every(rawSignal => {
+    const signal = asRecord(rawSignal)
+    return typeof signal?.code === 'string' && signal.code.length > 0 && signal.code.length <= 256
+      && (signal.confidence === 'confirmed' || signal.confidence === 'strong' || signal.confidence === 'needs-analysis')
+      && typeof signal.summary === 'string' && signal.summary.length <= 2_048
+      && (signal.before === undefined || (typeof signal.before === 'string' && signal.before.length <= 2_048))
+      && (signal.after === undefined || (typeof signal.after === 'string' && signal.after.length <= 2_048))
+  })
+}
+
+function validCompatibilityUpgradePath(value: unknown): boolean {
+  if (value === undefined) return true
+  const path = asRecord(value)
+  const evaluated = path?.evaluated
+  const blockedCount = path?.blockedCount
+  const blocked = path?.blocked
+  if (typeof evaluated !== 'number' || !Number.isSafeInteger(evaluated) || evaluated < 0 || evaluated > 1_000_000
+    || typeof blockedCount !== 'number' || !Number.isSafeInteger(blockedCount) || blockedCount < 0 || blockedCount > evaluated
+    || !Array.isArray(blocked) || blocked.length > 8
+    || (path?.firstCandidate !== undefined && !validCompatibilityUpgradeCandidate(path.firstCandidate))) return false
+  return blocked.every(validCompatibilityUpgradeCandidate)
+}
+
 export function parseRadarState(value: unknown): RadarState {
   const root = asRecord(value)
   if (root?.schema !== RADAR_STATE_SCHEMA) throw new Error('radar state has an unsupported schema')
@@ -62,6 +93,7 @@ export function parseRadarState(value: unknown): RadarState {
       throw new Error('radar state contains an invalid pending analysis task')
     }
     if (!validAffectedSources(event.affectedSources)) throw new Error('radar state contains invalid affected package origins')
+    if (!validCompatibilityUpgradePath(event.upgradePath)) throw new Error('radar state contains an invalid compatibility upgrade path')
   }
   if (Object.keys(active).length > 1_000_000) throw new Error('radar state exceeds the active match limit')
   if (Object.keys(activeCompatibility).length > 1_000_000) {
@@ -82,7 +114,8 @@ export function parseRadarState(value: unknown): RadarState {
     const stored = asRecord(rawStored)
     const event = asRecord(stored?.event)
     if (stored?.key !== key || event?.schema !== RADAR_EVENT_SCHEMA
-      || event.kind !== 'compatibility' || event.incidentId !== key) {
+      || event.kind !== 'compatibility' || event.incidentId !== key
+      || !validCompatibilityUpgradePath(event.upgradePath)) {
       throw new Error(`radar state contains an invalid compatibility match: ${key.slice(0, 256)}`)
     }
   }

--- a/src/radar-types.ts
+++ b/src/radar-types.ts
@@ -155,12 +155,30 @@ export interface CompatibilitySignal {
   after?: string
 }
 
+export interface CompatibilityUpgradeCandidate {
+  candidate: PackageCoordinate
+  signals: CompatibilitySignal[]
+}
+
+/** A bounded explanation of which intermediate release is worth analyzing first. */
+export interface CompatibilityUpgradePath {
+  /** Number of newer manifests considered from the npm packument. */
+  evaluated: number
+  /** Number of considered candidates with a confirmed or strong blocker. */
+  blockedCount: number
+  /** The first candidate without a deterministic blocker; this is not a safety verdict. */
+  firstCandidate?: CompatibilityUpgradeCandidate
+  /** A small sample of blocked candidates, kept for an actionable alert. */
+  blocked: CompatibilityUpgradeCandidate[]
+}
+
 export interface CompatibilityEvent extends RadarEventBase {
   kind: 'compatibility'
   plugin: PackageCoordinate
   installed: PackageCoordinate
   candidate: PackageCoordinate
   signals: CompatibilitySignal[]
+  upgradePath?: CompatibilityUpgradePath
   releaseNotes?: string
   releaseNotesUrl?: string
 }

--- a/src/radar.ts
+++ b/src/radar.ts
@@ -91,6 +91,7 @@ function compatibilityEventChanged(previous: RadarEvent, current: RadarEvent): b
     || JSON.stringify(previous.installed) !== JSON.stringify(current.installed)
     || JSON.stringify(previous.candidate) !== JSON.stringify(current.candidate)
     || JSON.stringify(previous.signals) !== JSON.stringify(current.signals)
+    || JSON.stringify(previous.upgradePath) !== JSON.stringify(current.upgradePath)
     || previous.releaseNotes !== current.releaseNotes
     || previous.releaseNotesUrl !== current.releaseNotesUrl
 }
@@ -403,6 +404,7 @@ export async function pollRadar(
             previous: observation.previous,
             candidate: observation.candidate,
             detectedAt: checkedAt,
+            ...(observation.upgradeCandidates === undefined ? {} : { upgradeCandidates: observation.upgradeCandidates }),
             ...releaseNotesInput,
             ...releaseNotesUrlInput,
           })

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.16.0'
+export const TOOL_VERSION = '0.17.0'

--- a/test/compatibility.test.ts
+++ b/test/compatibility.test.ts
@@ -72,6 +72,36 @@ describe('compatibility change assessment', () => {
     assert.ok(result.signals.some(signal => signal.code === 'dsh-bundle-changed'))
   })
 
+  it('finds the first intermediate candidate without a deterministic blocker', () => {
+    const result = assessCompatibilityChange(inventory, {
+      previous: {
+        name: 'plugin',
+        version: '1.0.0',
+        main: './dist/index.js',
+        engines: { node: '>=22' },
+      },
+      candidate: {
+        name: 'plugin',
+        version: '2.0.0',
+        main: './dist/plugin.js',
+        engines: { node: '>=24' },
+      },
+      upgradeCandidates: [
+        { name: 'plugin', version: '1.1.0', main: './dist/index.js', engines: { node: '>=22' } },
+        { name: 'plugin', version: '1.2.0', main: './dist/index.js', engines: { node: '>=24' } },
+        { name: 'plugin', version: '2.0.0', main: './dist/plugin.js', engines: { node: '>=24' } },
+      ],
+      detectedAt: '2026-08-14T04:00:00.000Z',
+    })
+
+    assert.ok(result?.upgradePath)
+    assert.equal(result.upgradePath.evaluated, 3)
+    assert.equal(result.upgradePath.blockedCount, 2)
+    assert.equal(result.upgradePath.firstCandidate?.candidate.version, '1.1.0')
+    assert.deepEqual(result.upgradePath.blocked.map(item => item.candidate.version), ['1.2.0', '2.0.0'])
+    assert.equal(result.upgradePath.firstCandidate?.signals.length, 0)
+  })
+
   it('does not treat an equal or older semantic version as a candidate upgrade', () => {
     const result = assessCompatibilityChange(inventory, {
       previous: { name: 'plugin', version: '2.0.0', main: './current.js' },

--- a/test/npm-release.test.ts
+++ b/test/npm-release.test.ts
@@ -26,6 +26,26 @@ describe('npm release source', () => {
     assert.equal(change?.publishedAt, '2026-08-14T02:00:00.000Z')
     assert.equal(change?.repository, 'git+https://github.com/acme/plugin.git')
     assert.equal(change?.candidateStatus, 'newer')
+    assert.deepEqual(change?.upgradeCandidates?.map(item => item.version), ['2.0.0'])
+  })
+
+  it('returns newer exact manifests in ascending order without installing them', async () => {
+    const fetcher = async (): Promise<Response> => Response.json({
+      'dist-tags': { latest: '2.0.0' },
+      versions: {
+        '1.0.0': { name: 'plugin', version: '1.0.0' },
+        '1.2.0': { name: 'plugin', version: '1.2.0' },
+        '1.1.0': { name: 'plugin', version: '1.1.0' },
+        '2.0.0': { name: 'plugin', version: '2.0.0' },
+      },
+    })
+    const client = new NpmReleaseClient({ fetch: fetcher })
+    const result = await client.query([{ ecosystem: 'npm', name: 'plugin', version: '1.0.0' }])
+    assert.deepEqual(result.get('npm:plugin@1.0.0')?.upgradeCandidates?.map(item => item.version), [
+      '1.1.0',
+      '1.2.0',
+      '2.0.0',
+    ])
   })
 
   it('marks a regressed npm latest tag as older instead of an upgrade', async () => {

--- a/test/radar.test.ts
+++ b/test/radar.test.ts
@@ -99,6 +99,10 @@ describe('radar polling', () => {
           latestVersion: '2.0.0',
           previous: { name: 'plugin', version: '1.0.0', main: './old.js' },
           candidate: { name: 'plugin', version: '2.0.0', main: './new.js' },
+          upgradeCandidates: [
+            { name: 'plugin', version: '1.5.0', main: './old.js' },
+            { name: 'plugin', version: '2.0.0', main: './new.js' },
+          ],
         }]])
       },
     }
@@ -126,6 +130,9 @@ describe('radar polling', () => {
     )
     assert.equal(first.events.length, 1)
     assert.equal(first.events[0]?.kind, 'compatibility')
+    assert.equal(first.events[0]?.kind === 'compatibility'
+      ? first.events[0].upgradePath?.firstCandidate?.candidate.version
+      : undefined, '1.5.0')
     const unchanged = await pollRadar(
       [inventory],
       first.state,


### PR DESCRIPTION
## Summary

- read newer exact npm manifests already present in the packument
- evaluate intermediate versions in ascending order and keep the first without a confirmed/strong deterministic blocker
- render blocked candidate samples and preserve the path in DSH analysis tasks
- update the deterministic showcase and release documentation

The first candidate is deliberately not called safe; DSH still has to inspect project evidence.

## Verification

- `pnpm test` (91 passing)
- `pnpm run scan:self` (no implemented static findings; coverage remains incomplete by design)
- `pnpm run showcase:radar`
- `pnpm run try:dsh`
- `pnpm run try:dsh:live`
- real npm packument query for `@deepseek-ai/dsh-agent@0.1.0-rc.6` and `upstream-radar@0.16.0`
