### PR TITLE
feat: add local DSH wiring doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.19.2] - 2026-08-16
+
+### Added
+
+- Add a network-free `upstream-radar doctor` command for first-run DSH diagnosis.
+- Check local config parsing, DSH profile bundle registration, generated overlay alignment, state-file readability, monitoring status, and required dependency coverage.
+- Support human-readable and `--json` doctor output; only blocked wiring returns a non-zero exit code.
+
+### Safety
+
+- Doctor never contacts OSV, npm, or GitHub and never imports or executes plugin code.
+- A missing first-run state or incomplete coverage remains visible as a warning; neither is described as safe.
+
 ## [0.19.1] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ dsh --profile web --patch ./upstream-radar.dsh.yml
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
+If startup does not behave as expected, run the local wiring check before looking at upstream feeds:
+
+```bash
+pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
+  --profile web \
+  --patch ./upstream-radar.dsh.yml
+```
+
+`doctor` does not contact OSV, npm, GitHub, or execute plugin code. It checks that the config parses, the selected DSH profile actually registers `upstream-radar`, the overlay points to the same config and state files, the dependency coverage is complete, and the durable state can be read. It exits non-zero only for a blocked setup; a missing first-run state is shown as a warning with the next command to run. Add `--json` when another tool needs the result.
+
 The generated overlay points DSH at the config and state files explicitly and records the selected profile. If `--registry <url>` was used during initialization, the same registry is carried into the running DSH monitor; otherwise release and candidate checks use the public npm registry. Before each native DSH polling cycle, and before each CLI `radar check` or `radar watch` cycle, it re-reads that profile's installed graph, so later plugin installs, upgrades, removals, and host-runtime changes are not silently missed. If the refresh fails, that cycle stops without replacing the last durable state. `radar status` remains read-only and reports whether a check has completed, which source is unhealthy, whether dependency coverage is complete, active incidents, and pending DSH tasks. `radar compare` remains a manual comparison of the files you provide. If you prefer environment variables or need to override the polling interval, omit `--dsh-patch` and use `UPSTREAM_RADAR_CONFIG`, `UPSTREAM_RADAR_STATE`, `UPSTREAM_RADAR_INTERVAL_SECONDS`, `UPSTREAM_RADAR_REGISTRY`, and `UPSTREAM_RADAR_DEEP_CANDIDATES` as before.
 
 The generated graph is the actual installed profile graph. DSH also maintains a shared `profiles/node_modules` host plane for built-in runtime packages; Radar includes packages resolved from that plane, marks them as `dsh-host`, and still checks their exact versions for advisories. If a required dependency is declared but cannot be resolved from either place, it remains visible as incomplete coverage instead of being treated as absent. Missing optional platform packages are retained as evidence but do not make coverage incomplete. Passing `--registry <url>` explicitly selects the older public npm artifact graph path, which is useful for comparing a profile against registry resolution but is not the default.
@@ -261,6 +271,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 - durable incident state with current-task replacement and resolution;
 - native DSH bundle installation, startup polling, `agent/created` retry, and plugin-source attribution;
 - automatic selection of the only DSH profile with third-party bundles, plus a network-free `radar status` snapshot;
+- a network-free `doctor` command that checks local DSH registration, overlay/config alignment, state readability, and dependency coverage;
 - compatibility signals for Node.js, peers, exports, entrypoints, bundle paths, dependencies, and version boundaries;
 - network-free Radar and real DSH runtime showcases.
 
@@ -277,6 +288,7 @@ pnpm dlx --package=upstream-radar@latest upstream-radar inspect npm:dsh-cloudfla
 - A graph with unresolved required dependency declarations is marked as incomplete coverage; optional packages that are not installed for the current platform remain visible but do not create a false required-dependency alert.
 - Candidate upgrade graphs are resolved only for a bounded earliest prefix. A candidate with an incomplete or unavailable graph is not recommended; later unqueried candidates remain visibly unchecked. Pass `--no-deep-candidates` to opt out of this extra registry work.
 - `radar status` is a local snapshot only: it does not refresh OSV/npm/GitHub data, and it cannot prove that a source is current until a check has completed.
+- `doctor` checks local wiring only; it cannot prove that a running DSH process has delivered a task to a model or that upstream feeds are current.
 - npm lock graphs are supported; pnpm and Yarn graph adapters are not implemented.
 - OSV, npm `latest`, and public GitHub Release notes are live sources; changelog, comparison-diff, and migration-guide ingestion are deferred.
 - A failed OSV check preserves confirmed matches and returns a visible source warning; source health is durable and routed through DSH after three consecutive failures, while source-claim conflict handling and external health destinations are not implemented yet.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,6 +14,7 @@
 - [x] Prove bundle installation, plugin-source attribution, Session persistence, and Agent delivery in a real DSH headless profile.
 - [x] Generate an explicit DSH `--patch` overlay so first use does not require environment variables.
 - [x] Auto-select the only DSH profile with third-party bundles and provide a network-free first-run status snapshot.
+- [x] Provide a network-free doctor command for DSH bundle registration, overlay/config alignment, state readability, and dependency coverage.
 
 ## Milestone 1 — compatibility radar
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -122,6 +122,16 @@ dsh --profile web --patch ./upstream-radar.dsh.yml
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
+如果启动结果不对，先运行本地接线检查，不需要访问漏洞源：
+
+```bash
+pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
+  --profile web \
+  --patch ./upstream-radar.dsh.yml
+```
+
+`doctor` 不访问 OSV、npm 或 GitHub，也不执行插件代码。它检查配置是否能解析、选中的 DSH profile 是否真的登记了 `upstream-radar`、overlay 是否指向同一份配置和状态文件、依赖覆盖是否完整，以及状态文件是否可读。只有接线被阻断时才返回非零；第一次还没有状态文件会显示为警告，并给出下一条命令。需要给其他工具读取时加上 `--json`。
+
 生成的 overlay 会记录选中的 profile；如果初始化时传入了 `--registry <url>`，它也会被带入 DSH 运行时，避免后续 release 和候选依赖检查悄悄切回公共 npm。原生 DSH 每次轮询前，以及 CLI 的 `radar check/watch` 每次轮询前，都会重新读取这个 profile 的实际依赖图，因此之后安装、升级、卸载插件，或 DSH 宿主运行时发生变化时，不会继续悄悄监控旧快照；如果重读失败，本轮会停止，不会替换最后一次持久化状态。`radar status` 仍然只读取本地配置和状态，不会刷新 OSV/npm/GitHub；`radar compare` 也只比较你明确提供的文件。如果不使用 `--dsh-patch`，仍可以使用 `UPSTREAM_RADAR_CONFIG`、`UPSTREAM_RADAR_STATE`、`UPSTREAM_RADAR_INTERVAL_SECONDS`、`UPSTREAM_RADAR_REGISTRY` 和 `UPSTREAM_RADAR_DEEP_CANDIDATES` 环境变量方式。
 
 生成的依赖图对应 profile 当前实际安装的树。DSH 还会在 `profiles/node_modules` 维护一层共享的宿主运行时依赖；Radar 会把从这里解析到的包纳入漏洞查询，并明确标成 `dsh-host`，不会和插件自己带的依赖混在一起。如果一个必需依赖在 profile 和宿主依赖平面中都找不到，它会保留为“覆盖不完整”，不会被当成安全或不存在。当前平台没有安装的可选原生包仍会记录，但不会制造“必需依赖缺失”的假警报。显式传入 `--registry <url>` 才会使用公共 npm artifact 图，适合和 registry 解析结果做比较，但不是默认路径。
@@ -223,11 +233,13 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查。
+已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查。
 
 `init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查，但不会替你刷新漏洞源。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 
 `radar watch` 是 CLI 监控入口，本身不会把任务投递给 DSH；需要 Agent 分析时应使用原生 DSH bundle。
+
+`doctor` 只检查本地接线，不能证明 DSH 进程已经把任务交给模型，也不能证明漏洞源当前可用。
 
 候选依赖图默认只覆盖按版本排序的有限前缀，后续未查询版本会在事件中显示为未完整检查。遇到 registry 或 OSV 不可用时，Radar 保留不确定性并发出告警，不会生成“已安全”的结论。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,6 +106,8 @@ When a generated inventory is used, the native DSH adapter and CLI `radar check/
 
 The delivery boundary is intentionally at-least-once. A crash after follow-up admission but before the second state write can repeat a task; it cannot silently erase it. Event and task ids allow later delivery adapters to deduplicate.
 
+The `doctor` command is a separate local diagnosis plane. It parses the config and state, reads the selected DSH profile manifest, checks the generated overlay's paths, and reuses the network-free status snapshot. It never polls an upstream source and never loads a plugin, so a `READY` result means “the wiring is locally coherent,” not “the feeds are current” or “the model has completed an analysis.”
+
 ## Failure isolation
 
 - Target plugin code is never imported to build a graph.

--- a/docs/checks.zh-CN.md
+++ b/docs/checks.zh-CN.md
@@ -18,6 +18,7 @@
 | DSH 分析入口 | 如何避免“新闻”直接指挥 Agent，以及如何避免一次 DSH 升级刷出多条通知 | 将所有来源文字标记为不可信数据，要求只读和项目证据；同一项目同一轮的 DSH 运行时包更新在投递层合并，底层事件仍逐包保存 | 由 DSH 原生投递；CLI 只用于检查持久 analysis task |
 | 去重与恢复 | 重启、重复轮询是否丢失、刷屏或投递过期任务 | 保存活跃漏洞、活跃兼容性问题和待分析任务；同一 incident 的新任务替换旧任务，resolved 会撤销旧任务 | 至少一次投递，不变不重复，不过期投递 |
 | 源失败与健康 | OSV、npm release 或候选依赖图暂时查不到时，是否会被误判成“没有漏洞”，以及负责人能否知道源长期不可用 | 保留上一次确认的漏洞状态，不生成假的 `resolved`，仍继续投递已有 DSH 任务；连续 3 次失败生成持久 `source-health` DSH notice，恢复后 `resolved`；CLI/JSON 返回源警告 | `sourceErrors: osv/npm-releases/npm-candidate-graphs`、源健康状态、source-health 生命周期 |
+| 本地接线 | DSH profile 是否登记 Radar、overlay 是否指向同一份配置和状态、状态是否可读、必需依赖是否完整 | `doctor` 只读本地 manifest、配置、overlay 和状态，不访问 OSV/npm/GitHub，也不执行插件代码 | `READY`、`READY WITH WARNINGS` 或 `BLOCKED` |
 
 ## 支持性的安装前检查
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -135,7 +135,19 @@ It reports whether monitoring has started, the last successful check for OSV/npm
 
 The status output also shows `Coverage: incomplete` when the installed profile contains a dependency declaration that DSH cannot currently resolve. That is a configuration gap, not a clean result.
 
-## Scene 11 — the graph follows the installed DSH profile
+## Scene 11 — diagnose the wiring before blaming the feeds
+
+The local doctor checks the reviewed config, the selected DSH profile, the generated overlay, the durable state file, and required dependency coverage without contacting OSV, npm, or GitHub:
+
+```bash
+pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
+  --profile web \
+  --patch ./upstream-radar.dsh.yml
+```
+
+It reports `READY`, `READY WITH WARNINGS`, or `BLOCKED`. A missing first-run state is a warning; a profile without the Radar bundle, a mismatched overlay, an invalid config, or a corrupt state file is blocked. The same report can be emitted as JSON for CI or a future DSH status surface.
+
+## Scene 12 — the graph follows the installed DSH profile
 
 For a profile containing `dsh-cloudflare-browser-run@0.1.1`, initialization reports the graph source explicitly:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { access, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { assessCompatibilityChange } from './compatibility.js'
 import { createAnalysisTask, renderAgentAnalysisPrompt } from './dsh-analysis.js'
+import { createDoctorReport, renderDoctorReport } from './doctor.js'
 import { GitHubReleaseClient } from './github-release.js'
 import { createRadarConfigFromDshProfile, discoverDshProfiles, refreshRadarConfigFromConfiguredProfile, resolveDshProfileDirectory, writeDshPatch, writeRadarConfig } from './init.js'
 import { parsePackageManifestSnapshot, parseRadarConfig } from './inventory.js'
@@ -39,6 +40,7 @@ function usage(): string {
 
 Usage:
   upstream-radar init [--profile <name>] [options]
+  upstream-radar doctor [config.json] [options]
   upstream-radar scan <directory> [--json] [--fail-on <warn|review|block|never>]
   upstream-radar inspect npm:<package>@<exact-version> [--deep] [--json] [--fail-on <warn|review|block|never>]
   upstream-radar radar check <config.json> [--state <state.json>] [--json]
@@ -52,6 +54,7 @@ Usage:
 
 Commands:
   init     discover third-party bundles in a DSH profile and write a reviewable inventory
+  doctor   check local Radar/DSH wiring without polling upstream sources
   scan     bounded, read-only inspection of a local package directory
   inspect  fetch and verify the exact npm artifact before inspecting its contents
   radar    monitor vulnerability changes, watch continuously, inspect status, or assess a candidate compatibility change
@@ -66,9 +69,10 @@ Options:
   --interval <seconds> watch interval from 300 to 86400 seconds (default: 1800)
   --once               run one watch cycle and exit (useful for CI and demos)
   --notes <path>       release notes used as untrusted compatibility evidence
-  --profile <name>     DSH profile to inspect for init (auto-selects the only candidate when omitted)
+  --profile <name>     DSH profile for init or doctor (init auto-selects the only candidate when omitted)
   --output <path>      init output path (default: ./upstream-radar.config.json)
   --dsh-patch <path>   write a self-contained DSH --patch overlay (optional)
+  --patch <path>       DSH overlay to verify with doctor
   --force              allow init to replace an existing output file
   --json               emit the canonical JSON report
   --fail-on <verdict>  CI threshold; default is review
@@ -449,6 +453,44 @@ async function runInit(args: readonly string[]): Promise<number> {
   return 0
 }
 
+async function runDoctor(args: readonly string[]): Promise<number> {
+  let configFile = 'upstream-radar.config.json'
+  let stateFile: string | undefined
+  let profile: string | undefined
+  let patchFile: string | undefined
+  let json = false
+  let positionalConfig = false
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === undefined) throw new Error('doctor received an empty argument')
+    if (argument === '--json') {
+      json = true
+    } else if (argument === '--state' || argument === '--profile' || argument === '--patch') {
+      const value = args[index + 1]
+      if (value === undefined || value.startsWith('-')) throw new Error(`${argument} requires a value`)
+      if (argument === '--state') stateFile = value
+      else if (argument === '--profile') profile = value
+      else patchFile = value
+      index += 1
+    } else if (argument.startsWith('-')) {
+      throw new Error(`unknown option for doctor: ${argument}`)
+    } else if (!positionalConfig) {
+      configFile = argument
+      positionalConfig = true
+    } else {
+      throw new Error(`doctor received unexpected argument: ${argument}`)
+    }
+  }
+  const report = await createDoctorReport({
+    configFile,
+    ...(stateFile === undefined ? {} : { stateFile }),
+    ...(profile === undefined ? {} : { profile }),
+    ...(patchFile === undefined ? {} : { patchFile }),
+  })
+  process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderDoctorReport(report))
+  return report.status === 'blocked' ? 1 : 0
+}
+
 async function main(args: readonly string[]): Promise<number> {
   const command = args[0]
   if (command === undefined || command === '--help' || command === '-h' || command === 'help') {
@@ -460,6 +502,7 @@ async function main(args: readonly string[]): Promise<number> {
     return 0
   }
   if (command === 'init') return runInit(args.slice(1))
+  if (command === 'doctor') return runDoctor(args.slice(1))
   if (command === 'radar') return runRadar(args.slice(1))
   if (command === 'task') return runTask(args.slice(1))
   if (command !== 'scan' && command !== 'inspect') throw new Error(`unknown command: ${command}`)

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,347 @@
+import { access, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { resolveDshProfileDirectory } from './init.js'
+import { parseRadarConfig } from './inventory.js'
+import { emptyRadarState } from './radar.js'
+import { loadRadarState } from './radar-state.js'
+import {
+  createRadarStatus,
+  renderRadarStatus,
+  type RadarStatusReport,
+} from './radar-status.js'
+import type { RadarConfig, RadarState } from './radar-types.js'
+
+export const DOCTOR_SCHEMA = 'upstream-radar.doctor/v1alpha1' as const
+
+export type DoctorCheckStatus = 'pass' | 'warn' | 'fail'
+export type DoctorOverallStatus = 'ready' | 'ready-with-warnings' | 'blocked'
+
+export interface DoctorCheck {
+  id: string
+  status: DoctorCheckStatus
+  summary: string
+  detail?: string
+  action?: string
+}
+
+export interface DoctorReport {
+  schema: typeof DOCTOR_SCHEMA
+  status: DoctorOverallStatus
+  configFile: string
+  stateFile: string
+  profile?: string
+  checks: DoctorCheck[]
+  radarStatus?: RadarStatusReport
+}
+
+export interface DoctorOptions {
+  configFile: string
+  stateFile?: string
+  profile?: string
+  patchFile?: string
+  dshHome?: string
+}
+
+const MAX_CONFIG_BYTES = 8 * 1024 * 1024
+const MAX_PATCH_BYTES = 1 * 1024 * 1024
+
+function safeText(value: string, max = 2_048): string {
+  const escaped = value.replace(/[\u0000-\u001f\u007f-\u009f]/g, character => (
+    `\\u${character.codePointAt(0)?.toString(16).padStart(4, '0') ?? '0000'}`
+  ))
+  return escaped.length <= max ? escaped : `${escaped.slice(0, max - 1)}…`
+}
+
+function errorText(error: unknown): string {
+  return safeText(error instanceof Error ? error.message : String(error))
+}
+
+function addCheck(
+  checks: DoctorCheck[],
+  id: string,
+  status: DoctorCheckStatus,
+  summary: string,
+  detail?: string,
+  action?: string,
+): void {
+  checks.push({
+    id,
+    status,
+    summary,
+    ...(detail === undefined ? {} : { detail: safeText(detail) }),
+    ...(action === undefined ? {} : { action: safeText(action) }),
+  })
+}
+
+async function readBounded(path: string, maxBytes: number): Promise<string> {
+  const contents = await readFile(path, 'utf8')
+  if (Buffer.byteLength(contents) > maxBytes) throw new Error(`${path} exceeds the ${maxBytes} byte limit`)
+  return contents
+}
+
+async function readJson(path: string, maxBytes: number): Promise<unknown> {
+  const contents = await readBounded(path, maxBytes)
+  try {
+    return JSON.parse(contents) as unknown
+  } catch {
+    throw new Error(`${path} is not valid JSON`)
+  }
+}
+
+function profileBundles(value: unknown): string[] {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('DSH profile package.json must be an object')
+  }
+  const dsh = (value as Record<string, unknown>).dsh
+  if (typeof dsh !== 'object' || dsh === null || Array.isArray(dsh)) {
+    throw new Error('DSH profile package.json has no dsh section')
+  }
+  const profile = (dsh as Record<string, unknown>).profile
+  if (typeof profile !== 'object' || profile === null || Array.isArray(profile)) {
+    throw new Error('DSH profile package.json has no dsh.profile section')
+  }
+  const bundles = (profile as Record<string, unknown>).bundles
+  if (!Array.isArray(bundles) || !bundles.every(item => typeof item === 'string')) {
+    throw new Error('DSH profile package.json has no valid dsh.profile.bundles list')
+  }
+  return bundles
+}
+
+async function inspectDshProfile(
+  checks: DoctorCheck[],
+  profile: string | undefined,
+  dshHome: string | undefined,
+): Promise<void> {
+  if (profile === undefined) {
+    addCheck(
+      checks,
+      'dsh-profile',
+      'warn',
+      '没有提供 DSH profile，无法确认原生 DSH 是否加载了 Radar',
+      'doctor 只能检查配置文件，不能凭空证明某个 DSH 进程已经加载插件。',
+      '使用 init 生成的配置，或传入 --profile <name>。',
+    )
+    return
+  }
+
+  try {
+    const profileDirectory = resolveDshProfileDirectory(profile, dshHome)
+    const manifestPath = resolve(profileDirectory, 'package.json')
+    const bundles = profileBundles(await readJson(manifestPath, MAX_CONFIG_BYTES))
+    if (!bundles.includes('upstream-radar')) {
+      addCheck(
+        checks,
+        'dsh-profile',
+        'fail',
+        `DSH profile ${profile} 没有 upstream-radar bundle`,
+        `当前 profile 声明了 ${bundles.length} 个 bundle，但没有 upstream-radar。`,
+        `运行 dsh plugin --profile ${profile} add upstream-radar@latest 后再检查。`,
+      )
+      return
+    }
+    addCheck(
+      checks,
+      'dsh-profile',
+      'pass',
+      `DSH profile ${profile} 已登记 upstream-radar bundle`,
+      manifestPath,
+    )
+  } catch (error: unknown) {
+    addCheck(
+      checks,
+      'dsh-profile',
+      'fail',
+      `无法读取 DSH profile ${profile}`,
+      errorText(error),
+      `确认 DSH_HOME 和 profile 名称正确，或运行 dsh plugin --profile ${profile} add upstream-radar@latest。`,
+    )
+  }
+}
+
+async function inspectPatch(
+  checks: DoctorCheck[],
+  patchFile: string | undefined,
+  configFile: string,
+  stateFile: string,
+  profile: string | undefined,
+): Promise<void> {
+  if (patchFile === undefined) {
+    addCheck(
+      checks,
+      'dsh-overlay',
+      'warn',
+      '没有提供 DSH overlay，启动时将依赖 UPSTREAM_RADAR_* 环境变量',
+      '这不是错误，但环境变量缺失时 Radar 会保持休眠。',
+      `推荐重新运行 init --dsh-patch ./upstream-radar.dsh.yml，或显式设置 UPSTREAM_RADAR_CONFIG=${configFile}。`,
+    )
+    return
+  }
+
+  const output = resolve(patchFile)
+  try {
+    const contents = await readBounded(output, MAX_PATCH_BYTES)
+    const hasBundle = contents.includes("name: 'upstream-radar/dsh'")
+    const hasConfig = contents.includes(JSON.stringify(configFile))
+    const hasState = contents.includes(JSON.stringify(stateFile))
+    const hasProfile = profile === undefined || contents.includes(JSON.stringify(profile))
+    if (!hasBundle || !hasConfig || !hasState || !hasProfile) {
+      const missing = [
+        ...(!hasBundle ? ['upstream-radar bundle'] : []),
+        ...(!hasConfig ? ['config path'] : []),
+        ...(!hasState ? ['state path'] : []),
+        ...(!hasProfile ? ['profile name'] : []),
+      ]
+      addCheck(
+        checks,
+        'dsh-overlay',
+        'fail',
+        'DSH overlay 存在，但没有指向当前 Radar 配置',
+        `缺少或不匹配：${missing.join('、')}。`,
+        `用 upstream-radar init --profile ${profile ?? '<name>'} --dsh-patch ${output} --force 重新生成。`,
+      )
+      return
+    }
+    addCheck(checks, 'dsh-overlay', 'pass', 'DSH overlay 已指向当前配置、状态和 profile', output)
+  } catch (error: unknown) {
+    addCheck(checks, 'dsh-overlay', 'fail', '无法读取 DSH overlay', errorText(error), `确认文件存在且可读：${output}`)
+  }
+}
+
+function reportStatus(checks: readonly DoctorCheck[]): DoctorOverallStatus {
+  if (checks.some(check => check.status === 'fail')) return 'blocked'
+  if (checks.some(check => check.status === 'warn')) return 'ready-with-warnings'
+  return 'ready'
+}
+
+/** Check local Radar/DSH wiring without polling any upstream source or executing plugin code. */
+export async function createDoctorReport(options: DoctorOptions): Promise<DoctorReport> {
+  const configFile = resolve(options.configFile)
+  const stateFile = resolve(options.stateFile ?? `${configFile}.state.json`)
+  const checks: DoctorCheck[] = []
+  let config: RadarConfig | undefined
+  let state: RadarState = emptyRadarState()
+  let stateExists = false
+  const configuredProfile = options.profile
+
+  const nodeMajor = Number(process.versions.node.split('.')[0])
+  if (Number.isSafeInteger(nodeMajor) && nodeMajor >= 22) {
+    addCheck(checks, 'node-runtime', 'pass', `Node.js ${process.versions.node} 满足 >=22 要求`)
+  } else {
+    addCheck(checks, 'node-runtime', 'fail', `Node.js ${process.versions.node} 不满足 >=22 要求`, undefined, '使用 Node.js 22 或更高版本后再启动 DSH。')
+  }
+
+  try {
+    config = parseRadarConfig(await readJson(configFile, MAX_CONFIG_BYTES))
+    addCheck(checks, 'config', 'pass', 'Radar 配置文件有效', configFile)
+  } catch (error: unknown) {
+    addCheck(checks, 'config', 'fail', 'Radar 配置文件不可用', errorText(error), `重新运行 upstream-radar init，或修复 ${configFile}。`)
+  }
+
+  const profile = configuredProfile ?? config?.dshProfile?.name
+  if (configuredProfile !== undefined && config?.dshProfile?.name !== undefined && configuredProfile !== config.dshProfile.name) {
+    addCheck(
+      checks,
+      'profile-match',
+      'fail',
+      '命令行 profile 与配置文件不一致',
+      `命令行是 ${configuredProfile}，配置文件记录的是 ${config.dshProfile.name}。`,
+      '使用同一个 profile 重新运行 doctor 或重新生成配置。',
+    )
+  }
+
+  if (config !== undefined) {
+    try {
+      await access(stateFile)
+      stateExists = true
+      state = await loadRadarState(stateFile)
+      addCheck(checks, 'state', 'pass', '状态文件有效', stateFile)
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        addCheck(
+          checks,
+          'state',
+          'warn',
+          '状态文件尚未创建，监控还没有完成过一次检查',
+          stateFile,
+          `启动 DSH，或运行 upstream-radar radar check ${configFile} --state ${stateFile}。`,
+        )
+      } else {
+        addCheck(checks, 'state', 'fail', '状态文件不可用', errorText(error), '修复或移走损坏的状态文件后再运行一次检查。')
+      }
+    }
+
+    const radarStatus = createRadarStatus(config, state, { configFile, stateFile, stateExists })
+    if (radarStatus.coverage === 'complete') {
+      addCheck(checks, 'coverage', 'pass', '必需依赖覆盖完整', `已记录 ${radarStatus.pluginBundles} 个 DSH plugin bundle。`)
+    } else {
+      addCheck(
+        checks,
+        'coverage',
+        'warn',
+        '依赖覆盖不完整，不能把当前结果理解成安全',
+        `${radarStatus.requiredUnresolvedDependencies} 个必需依赖没有解析到。`,
+        '检查 DSH profile 的 node_modules、peer 依赖或重新运行 init。',
+      )
+    }
+    if (radarStatus.monitoring === 'healthy') {
+      addCheck(checks, 'monitoring', 'pass', '至少一个监控源最近成功返回')
+    } else if (radarStatus.monitoring === 'degraded') {
+      addCheck(checks, 'monitoring', 'warn', '监控源存在连续失败', '保留的漏洞状态仍有效，但当前数据可能不完整。', '先检查状态输出中的具体 source error。')
+    } else {
+      addCheck(checks, 'monitoring', 'warn', '尚未完成第一次监控', undefined, `启动 DSH 或运行 upstream-radar radar check ${configFile} --state ${stateFile}。`)
+    }
+    await inspectPatch(checks, options.patchFile, configFile, stateFile, profile)
+
+    const report: DoctorReport = {
+      schema: DOCTOR_SCHEMA,
+      status: reportStatus(checks),
+      configFile,
+      stateFile,
+      ...(profile === undefined ? {} : { profile }),
+      checks,
+      radarStatus,
+    }
+    await inspectDshProfile(checks, profile, options.dshHome)
+    report.status = reportStatus(checks)
+    return report
+  }
+
+  await inspectPatch(checks, options.patchFile, configFile, stateFile, profile)
+  await inspectDshProfile(checks, profile, options.dshHome)
+  return {
+    schema: DOCTOR_SCHEMA,
+    status: reportStatus(checks),
+    configFile,
+    stateFile,
+    ...(profile === undefined ? {} : { profile }),
+    checks,
+  }
+}
+
+function statusLabel(status: DoctorOverallStatus): string {
+  if (status === 'ready') return 'READY'
+  if (status === 'ready-with-warnings') return 'READY WITH WARNINGS'
+  return 'BLOCKED'
+}
+
+/** Render a short, actionable local diagnosis for a human. */
+export function renderDoctorReport(report: DoctorReport): string {
+  const lines = [
+    'Upstream Radar doctor',
+    `Status: ${statusLabel(report.status)}`,
+    `Config: ${safeText(report.configFile)}`,
+    `State: ${safeText(report.stateFile)}`,
+    ...(report.profile === undefined ? [] : [`DSH profile: ${safeText(report.profile)}`]),
+    '',
+  ]
+  for (const check of report.checks) {
+    const label = check.status === 'pass' ? 'PASS' : check.status === 'warn' ? 'WARN' : 'FAIL'
+    lines.push(`[${label}] ${check.summary}`)
+    if (check.detail !== undefined) lines.push(`       ${check.detail}`)
+    if (check.action !== undefined) lines.push(`       下一步：${check.action}`)
+  }
+  if (report.radarStatus !== undefined) {
+    lines.push('', renderRadarStatus(report.radarStatus).trimEnd())
+  }
+  return `${lines.join('\n')}\n`
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,16 @@ export {
   type RadarStatusSource,
 } from './radar-status.js'
 export { renderRadarEvent, renderRadarEvents } from './radar-render.js'
+export {
+  createDoctorReport,
+  renderDoctorReport,
+  DOCTOR_SCHEMA,
+  type DoctorCheck,
+  type DoctorCheckStatus,
+  type DoctorOptions,
+  type DoctorOverallStatus,
+  type DoctorReport,
+} from './doctor.js'
 export { compareSemverValues, crossesBreakingVersionBoundary, parseSemver, satisfiesSemverRange } from './semver.js'
 export { scanDirectory, type ScanOptions } from './scan.js'
 export { parseNpmTarball, type ParsedNpmTarball, type TarEntry, type TarOptions } from './tar.js'

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.19.1'
+export const TOOL_VERSION = '0.19.2'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -18,10 +18,15 @@ describe('CLI option parsing', () => {
   it('advertises a one-command watch loop and validates its safety interval', () => {
     const help = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8' })
     assert.equal(help.status, 0)
+    assert.match(help.stdout, /doctor \[config\.json\]/)
     assert.match(help.stdout, /radar watch <config\.json>/)
     assert.match(help.stdout, /radar status <config\.json>/)
     assert.match(help.stdout, /--once\s+run one watch cycle and exit/)
     assert.match(help.stdout, /--dsh-patch <path>\s+write a self-contained DSH --patch overlay/)
+
+    const blockedDoctor = spawnSync(process.execPath, [cli, 'doctor', resolve(tmpdir(), `upstream-radar-missing-${process.pid}.json`)], { encoding: 'utf8' })
+    assert.equal(blockedDoctor.status, 1)
+    assert.match(blockedDoctor.stdout, /Status: BLOCKED/)
 
     const invalid = spawnSync(process.execPath, [cli, 'radar', 'watch', 'missing.json', '--interval', '299'], { encoding: 'utf8' })
     assert.equal(invalid.status, 1)

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import { createDoctorReport, renderDoctorReport } from '../src/doctor.js'
+import { writeDshPatch } from '../src/init.js'
+import type { RadarConfig } from '../src/radar-types.js'
+
+function config(profile?: string): RadarConfig {
+  return {
+    schema: 'upstream-radar.radar-config/v1alpha1',
+    ...(profile === undefined ? {} : { dshProfile: { name: profile } }),
+    projects: [{
+      schema: 'upstream-radar.inventory/v1alpha1',
+      project: { id: 'demo', name: 'Demo project' },
+      plugins: [{
+        package: { ecosystem: 'npm', name: 'demo-plugin', version: '1.0.0' },
+        graph: {
+          schema: 'upstream-radar.dependency-graph/v1alpha1',
+          rootNodeId: 'demo-plugin',
+          nodes: [{ id: 'demo-plugin', name: 'demo-plugin', version: '1.0.0' }],
+          edges: [],
+        },
+      }],
+    }],
+  }
+}
+
+async function writeProfile(root: string, bundles: string[]): Promise<string> {
+  const profile = join(root, 'profiles', 'web')
+  await mkdir(profile, { recursive: true })
+  await writeFile(join(profile, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web',
+    dsh: { profile: { bundles } },
+  }))
+  return profile
+}
+
+describe('upstream-radar doctor', () => {
+  it('confirms the local DSH wiring without creating a state file or making a network request', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-doctor-'))
+    try {
+      const dshHome = join(root, 'dsh-home')
+      await writeProfile(dshHome, ['@deepseek-ai/dsh-base', 'upstream-radar', 'demo-plugin'])
+      const configFile = join(root, 'upstream-radar.config.json')
+      const stateFile = join(root, 'upstream-radar.state.json')
+      const patchFile = join(root, 'upstream-radar.dsh.yml')
+      await writeFile(configFile, `${JSON.stringify(config('web'), null, 2)}\n`)
+      await writeDshPatch({ output: patchFile, configFile, stateFile, profile: 'web' })
+
+      const report = await createDoctorReport({ configFile, stateFile, patchFile, dshHome })
+      assert.equal(report.status, 'ready-with-warnings')
+      assert.equal(report.radarStatus?.monitoring, 'not-started')
+      assert.equal(report.radarStatus?.stateExists, false)
+      assert.equal(report.checks.find(check => check.id === 'config')?.status, 'pass')
+      assert.equal(report.checks.find(check => check.id === 'dsh-profile')?.status, 'pass')
+      assert.equal(report.checks.find(check => check.id === 'dsh-overlay')?.status, 'pass')
+      assert.equal(report.checks.find(check => check.id === 'state')?.status, 'warn')
+      assert.match(renderDoctorReport(report), /状态文件尚未创建/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('blocks when the selected DSH profile does not contain Radar or the state is corrupt', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-doctor-blocked-'))
+    try {
+      const dshHome = join(root, 'dsh-home')
+      await writeProfile(dshHome, ['@deepseek-ai/dsh-base', 'demo-plugin'])
+      const configFile = join(root, 'upstream-radar.config.json')
+      const stateFile = join(root, 'upstream-radar.state.json')
+      await writeFile(configFile, `${JSON.stringify(config('web'), null, 2)}\n`)
+      await writeFile(stateFile, '{not-json}\n')
+
+      const report = await createDoctorReport({ configFile, stateFile, dshHome })
+      assert.equal(report.status, 'blocked')
+      assert.equal(report.checks.find(check => check.id === 'dsh-profile')?.status, 'fail')
+      assert.equal(report.checks.find(check => check.id === 'state')?.status, 'fail')
+      assert.match(renderDoctorReport(report), /没有 upstream-radar bundle/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the legacy environment-variable setup visible as a warning', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-doctor-legacy-'))
+    try {
+      const configFile = join(root, 'upstream-radar.config.json')
+      await writeFile(configFile, `${JSON.stringify(config(), null, 2)}\n`)
+      const report = await createDoctorReport({ configFile })
+      assert.equal(report.status, 'ready-with-warnings')
+      assert.equal(report.checks.find(check => check.id === 'dsh-profile')?.status, 'warn')
+      assert.equal(report.checks.find(check => check.id === 'dsh-overlay')?.status, 'warn')
+      assert.match(renderDoctorReport(report), /UPSTREAM_RADAR_\* 环境变量/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## What changed

- add `upstream-radar doctor` for local first-run DSH diagnosis
- verify config parsing, DSH bundle registration, overlay alignment, state readability, monitoring state, and dependency coverage
- keep the command network-free and plugin-code-free; support human-readable and `--json` output
- document the new onboarding path and release it as `0.19.2`

## Validation

- `pnpm test` (103 passing)
- `pnpm run scan:self`
- `pnpm run showcase:radar`
- `pnpm run try:dsh`
- `pnpm pack --pack-destination /tmp` and verified `dist/src/doctor.js` is included

The command returns a non-zero status only when local wiring is blocked; missing first-run state and incomplete coverage remain warnings.
