### PR TITLE
fix: make DSH onboarding commands copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.19.3] - 2026-08-16
+
+### Fixed
+
+- Make the first-run README commands explicit about the DSH profile and separate the long-running DSH process from the read-only status check.
+- Make `init` print a version-pinned `doctor` command before the DSH start command, so the next local verification step is visible immediately.
+
 ## [0.19.2] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,20 +26,31 @@
 
 ## Try it in 60 seconds
 
-Use a DSH profile that already contains at least one third-party bundle. If DSH has only one such profile, `init` can find it for you:
+Use a DSH profile that already contains at least one third-party bundle. Replace `web` with your profile name. The commands below are split between two terminals because DSH normally stays running:
 
 ```bash
+# Terminal 1
 dsh plugin --profile web add upstream-radar@latest
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
+  --profile web \
   --project-name "My DSH project" \
   --workspace "$PWD" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
+pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
+  --profile web \
+  --patch ./upstream-radar.dsh.yml
 dsh --profile web --patch ./upstream-radar.dsh.yml
+```
+
+After DSH is running, use a second terminal for the read-only status check:
+
+```bash
+# Terminal 2
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-The initializer writes a reviewable inventory and an explicit DSH overlay. Review both files, start the same profile with `--patch`, then use `radar status` to confirm the first run without another network request. If more than one DSH profile has third-party bundles, pass `--profile <name>` explicitly. Read the [full DSH setup](#install-in-dsh) for the legacy environment-variable path, profile boundaries, and the real runtime proof.
+The initializer writes a reviewable inventory and an explicit DSH overlay. `doctor` verifies the local wiring before DSH starts; `radar status` confirms the first completed check without another network request. Read the [full DSH setup](#install-in-dsh) for the legacy environment-variable path, profile boundaries, and the real runtime proof.
 
 If you want to try the monitoring loop without booting a DSH profile, run one cycle from a reviewed inventory:
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -17,20 +17,31 @@
 
 ## 60 秒开始
 
-使用一个已经安装至少一个第三方 bundle 的 DSH profile。如果 DSH 中只有一个这样的 profile，初始化命令可以自动找到它：
+使用一个已经安装至少一个第三方 bundle 的 DSH profile，把 `web` 换成你的 profile 名称。下面的命令分成两个终端，因为 DSH 通常会持续运行：
 
 ```bash
+# 终端 1
 dsh plugin --profile web add upstream-radar@latest
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
+  --profile web \
   --project-name "我的 DSH 项目" \
   --workspace "$PWD" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
+pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
+  --profile web \
+  --patch ./upstream-radar.dsh.yml
 dsh --profile web --patch ./upstream-radar.dsh.yml
+```
+
+DSH 启动后，在第二个终端执行只读状态检查：
+
+```bash
+# 终端 2
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-初始化命令会写出可审查的清单和 DSH overlay。检查两个文件后，用 `--patch` 启动，再用 `radar status` 在不重新请求网络的情况下确认第一次运行。如果有多个 DSH profile 含第三方 bundle，就显式传入 `--profile <name>`。完整的状态文件、兼容的旧环境变量方式、profile 边界和真实运行证明见[完整 DSH 配置](#安装到-dsh)。
+初始化命令会写出可审查的清单和 DSH overlay。`doctor` 会在 DSH 启动前检查本地接线；`radar status` 会在不重新请求网络的情况下确认第一次完整检查。完整的状态文件、兼容的旧环境变量方式、profile 边界和真实运行证明见[完整 DSH 配置](#安装到-dsh)。
 
 如果只想先试跑一次监控，而不启动 DSH profile，可以使用同一份清单：
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -420,6 +420,10 @@ async function runInit(args: readonly string[]): Promise<number> {
     force,
   })
   const plugins = config.projects[0]?.plugins ?? []
+  const doctorCommand = `pnpm dlx --package=upstream-radar@${TOOL_VERSION} upstream-radar doctor ${shellQuote(outputPath)} --profile ${shellQuote(resolvedProfile)}${patchPath === undefined ? '' : ` --patch ${shellQuote(patchPath)}`}`
+  const startCommand = patchPath === undefined
+    ? `dsh --profile ${shellQuote(resolvedProfile)}`
+    : `dsh --profile ${shellQuote(resolvedProfile)} --patch ${shellQuote(patchPath)}`
   if (json) {
     process.stdout.write(`${JSON.stringify({ output: outputPath, profile: resolvedProfile, plugins: plugins.map(plugin => ({
       name: plugin.package.name,
@@ -445,9 +449,9 @@ async function runInit(args: readonly string[]): Promise<number> {
       process.stdout.write(`  ${plugin.package.name}@${plugin.package.version} (${plugin.graph.nodes.length} dependency nodes${plugin.graph.source === undefined ? '' : `, ${plugin.graph.source}`}${hostRuntime === 0 ? '' : `, ${hostRuntime} DSH host`}${requiredUnresolved === 0 ? '' : `, ${requiredUnresolved} required unresolved`}${optionalUnresolved === 0 ? '' : `, ${optionalUnresolved} optional absent`})\n`)
     }
     if (patchPath === undefined) {
-      process.stdout.write(`\nReview the generated inventory, then run:\n  export UPSTREAM_RADAR_CONFIG=${shellQuote(outputPath)}\n  export UPSTREAM_RADAR_STATE=${shellQuote(statePath)}\n  dsh --profile ${shellQuote(resolvedProfile)}\n`)
+      process.stdout.write(`\nReview the generated inventory, then verify the wiring:\n  ${doctorCommand}\n\nStart DSH (keep it running):\n  export UPSTREAM_RADAR_CONFIG=${shellQuote(outputPath)}\n  export UPSTREAM_RADAR_STATE=${shellQuote(statePath)}\n  ${startCommand}\n`)
     } else {
-      process.stdout.write(`Created ${patchPath}\n\nReview the generated inventory and DSH overlay, then run:\n  dsh --profile ${shellQuote(resolvedProfile)} --patch ${shellQuote(patchPath)}\n`)
+      process.stdout.write(`Created ${patchPath}\n\nReview the generated inventory and DSH overlay, then verify the wiring:\n  ${doctorCommand}\n\nStart DSH (keep it running):\n  ${startCommand}\n`)
     }
   }
   return 0

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.19.2'
+export const TOOL_VERSION = '0.19.3'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -52,6 +52,48 @@ describe('CLI option parsing', () => {
     assert.equal(report.schema, 'upstream-radar.radar-status/v1alpha1')
     assert.equal(report.stateExists, false)
     assert.equal(report.monitoring, 'not-started')
+  })
+
+  it('prints the local doctor command before the long-running DSH start command', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-init-cli-'))
+    try {
+      const dshHome = join(root, 'dsh-home')
+      const profile = join(dshHome, 'profiles', 'web')
+      await mkdir(join(profile, 'node_modules', 'demo-plugin'), { recursive: true })
+      await writeFile(join(profile, 'package.json'), JSON.stringify({
+        name: 'dsh-profile-web',
+        dsh: { profile: { bundles: ['demo-plugin'] } },
+      }))
+      await writeFile(join(profile, 'node_modules', 'demo-plugin', 'package.json'), JSON.stringify({
+        name: 'demo-plugin',
+        version: '1.0.0',
+        main: './index.js',
+      }))
+
+      const config = join(root, 'upstream-radar.config.json')
+      const patch = join(root, 'upstream-radar.dsh.yml')
+      const result = spawnSync(process.execPath, [
+        cli,
+        'init',
+        '--profile',
+        'web',
+        '--output',
+        config,
+        '--dsh-patch',
+        patch,
+      ], {
+        encoding: 'utf8',
+        env: { ...process.env, DSH_HOME: dshHome },
+      })
+      assert.equal(result.status, 0)
+      const doctorAt = result.stdout.indexOf(' doctor ')
+      const dshAt = result.stdout.indexOf('dsh --profile')
+      assert.ok(doctorAt >= 0)
+      assert.ok(dshAt > doctorAt)
+      assert.match(result.stdout, /--patch .*upstream-radar\.dsh\.yml/)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('rejects unknown options instead of silently weakening a scan', () => {


### PR DESCRIPTION
## What changed

- make the 60-second English and Chinese quickstarts explicit about the DSH profile
- separate the long-running DSH process from the second-terminal status check
- make `init` print a version-pinned `doctor` command before the DSH start command
- release as `0.19.3`

## Validation

- `pnpm test` (104 passing)
- `pnpm run scan:self`
- `pnpm run try:dsh`

This is an onboarding-only follow-up to v0.19.2; it does not change monitoring or alert semantics.
