### PR TITLE
Add a frozen CI gate for DSH dependency radar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.20.0] - 2026-08-16
+
+### Added
+
+- Add `radar check/status/watch --fail-on <severity>` for a machine-enforced active-vulnerability threshold; malware is treated as critical.
+- Add `radar check/watch --frozen` so CI can use a reviewed config graph without requiring a local DSH profile.
+- Add a copyable GitHub Actions workflow using a memory-only state file and an explicit high-severity gate.
+
+### Safety
+
+- `--frozen` does not claim the checked-in graph is current; it makes the graph source explicit and still queries the configured upstream sources.
+- `--fail-on` changes only the exit code and report policy; it never upgrades packages, runs plugin code, or creates a branch.
+
 ## [0.19.4] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="#see-one-incident">See one incident</a> ·
   <a href="#install-in-dsh">Install in DSH</a> ·
   <a href="#run-the-proof">Run the proof</a> ·
+  <a href="#run-it-in-github-actions">Run in GitHub Actions</a> ·
   <a href="#how-the-loop-works">How it works</a> ·
   <a href="ROADMAP.md">Roadmap</a>
 </p>
@@ -189,6 +190,21 @@ The command fails unless DSH proves all four facts:
 
 This proof runs in CI on Node.js 22. See the executable [showcase contract](examples/dsh/README.md) and its checked-in [result](examples/dsh/reports/headless-smoke.json). Run `pnpm run try:dsh:live` to include a current OSV and npm poll before the DSH handoff.
 
+## Run it in GitHub Actions
+
+If your team wants a scheduled CI gate before wiring a machine to a live DSH profile, commit the reviewed `upstream-radar.config.json` and copy [the example workflow](examples/github-actions/upstream-radar.yml). It runs the same exact dependency and OSV checks without needing DSH installed in the runner:
+
+```yaml
+run: >-
+  pnpm dlx --package=upstream-radar@0.20.0 upstream-radar
+  radar check ./upstream-radar.config.json
+  --frozen --state :memory: --fail-on high --json
+```
+
+`--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. `--state :memory:` makes each run independent. The command exits `2` when an active vulnerability meets the threshold, and exits `1` for an operational or source error. It does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path.
+
+For a local or self-hosted DSH machine, omit `--frozen` so Radar refreshes the selected profile before each cycle. Use `--fail-on` only with `radar check`, `radar status`, or `radar watch --once`; a long-running watch should continue routing incidents instead of terminating on the first one.
+
 ## How the loop works
 
 1. Read the project inventory and exact installed npm graph.
@@ -205,7 +221,7 @@ For a local process or a scheduled runner, the same loop is available as:
 pnpm dlx --package=upstream-radar@latest upstream-radar radar watch ./upstream-radar.config.json --interval 1800
 ```
 
-Use `--once --json` for a machine-readable CI check. The command persists the same state file and emits only new, changed, or resolved incidents.
+Use `radar check --frozen --state :memory: --fail-on high --json` for a machine-enforced CI check against a reviewed graph. The local DSH path continues to use `radar watch`, which refreshes the selected profile before each cycle.
 
 The handoff uses `ctx.agents.roots()[0].followup(...)` with:
 
@@ -299,6 +315,7 @@ pnpm dlx --package=upstream-radar@latest upstream-radar inspect npm:dsh-cloudfla
 - `init` discovers the only DSH profile with third-party bundles when `--profile` is omitted; multiple candidates still require an explicit profile. By default it follows the installed DSH `node_modules` tree, so pnpm overrides and local resolution choices are included. `--dsh-patch <path>` writes an explicit DSH overlay so first startup needs no environment variables and preserves an explicitly selected registry. A native pnpm lockfile parser for pre-install/CI inspection is still deferred.
 - A graph with unresolved required dependency declarations is marked as incomplete coverage; optional packages that are not installed for the current platform remain visible but do not create a false required-dependency alert.
 - Candidate upgrade graphs are resolved only for a bounded earliest prefix. A candidate with an incomplete or unavailable graph is not recommended; later unqueried candidates remain visibly unchecked. Pass `--no-deep-candidates` to opt out of this extra registry work.
+- `radar check/watch --frozen` intentionally uses the graph committed in the config for CI; it does not prove that the installed DSH profile has not changed. Without `--frozen`, native DSH and CLI polling refresh the selected profile first.
 - `radar status` is a local snapshot only: it does not refresh OSV/npm/GitHub data, and it cannot prove that a source is current until a check has completed. Its next steps are guidance, not an automatic upgrade or safety decision.
 - `doctor` checks local wiring only; it cannot prove that a running DSH process has delivered a task to a model or that upstream feeds are current.
 - npm lock graphs are supported; pnpm and Yarn graph adapters are not implemented.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,6 +61,7 @@
 
 ## Milestone 4 — GitHub execution arm
 
+- [x] Provide a frozen one-shot CI check with severity exit codes and a copyable GitHub Actions workflow.
 - [ ] Re-check the installed and proposed graph in GitHub Actions.
 - [ ] Attach project evidence to a GitHub Issue only after routing policy permits it.
 - [ ] Generate an upgrade branch or Pull Request behind explicit approval.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -178,6 +178,21 @@ pnpm run try:dsh
 
 运行 `pnpm run try:dsh:live`，可以在 DSH 投递前加入一次当前 OSV 与 npm 数据轮询。
 
+## 在 GitHub Actions 中运行
+
+如果团队想先用定时 CI 检查，而不是马上在 runner 里安装 DSH，可以把审查过的 `upstream-radar.config.json` 提交到仓库，然后复制[示例 workflow](../examples/github-actions/upstream-radar.yml)：
+
+```yaml
+run: >-
+  pnpm dlx --package=upstream-radar@0.20.0 upstream-radar
+  radar check ./upstream-radar.config.json
+  --frozen --state :memory: --fail-on high --json
+```
+
+`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。`--state :memory:` 让每次运行彼此独立。达到阈值时返回 `2`；运行或漏洞源出错时返回 `1`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。
+
+在本地或自托管 DSH 机器上不要加 `--frozen`，这样 Radar 会在每轮检查前刷新选中的 profile。`--fail-on` 适用于一次性 `radar check`、`radar status` 或 `radar watch --once`；长期运行的 watch 不应该因为第一次告警就退出。
+
 ## 闭环如何工作
 
 1. 读取项目清单和实际安装的 npm 依赖图。
@@ -194,7 +209,7 @@ pnpm run try:dsh
 pnpm dlx --package=upstream-radar@latest upstream-radar radar watch ./upstream-radar.config.json --interval 1800
 ```
 
-CI 中使用 `--once --json`。它复用同一个状态文件，只输出新建、变化和恢复的事件。
+CI 中可以使用 `radar check --frozen --state :memory: --fail-on high --json`，直接检查提交到仓库的审查过的图；本地持续监控仍使用 `radar watch`，并让 DSH profile 自动刷新。
 
 投递消息保留明确的插件身份：
 
@@ -253,6 +268,8 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 `doctor` 只检查本地接线，不能证明 DSH 进程已经把任务交给模型，也不能证明漏洞源当前可用。
 
 候选依赖图默认只覆盖按版本排序的有限前缀，后续未查询版本会在事件中显示为未完整检查。遇到 registry 或 OSV 不可用时，Radar 保留不确定性并发出告警，不会生成“已安全”的结论。
+
+`radar check/watch --frozen` 会有意使用提交到仓库的配置图，适合 CI，但不能证明 DSH profile 的实际安装树没有变化；不加 `--frozen` 时，原生 DSH 和 CLI 轮询会先刷新选中的 profile。
 
 Upstream Radar 目前是面向 DSH developer preview 生态的 alpha 软件，事件结构和适配边界仍可能变化。
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -171,6 +171,18 @@ For a profile containing `dsh-cloudflare-browser-run@0.1.1`, initialization repo
 
 This is intentionally different from resolving the same package in a fresh npm project. A DSH profile may provide peer packages from its host, apply overrides, or leave a declaration unresolved; Radar keeps that difference visible instead of silently replacing it with a registry-generated graph.
 
+## Scene 13 — make the reviewed graph a CI gate
+
+For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
+
+```bash
+pnpm dlx --package=upstream-radar@0.20.0 upstream-radar radar check \
+  ./upstream-radar.config.json \
+  --frozen --state :memory: --fail-on high --json
+```
+
+`--frozen` prevents the command from looking for a local DSH profile. `--fail-on high` returns exit code `2` when the committed graph has an active high or critical vulnerability (malware is critical), while source or operational failures return `1`. This is a CI gate for deterministic evidence; it does not replace the native DSH Agent analysis or create an upgrade.
+
 ## Live sources
 
 The fixture isolates behavior from network timing. Production cycles use:

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -1,0 +1,30 @@
+name: Upstream Radar
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 6 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-radar:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Check the reviewed DSH graph
+        run: >-
+          pnpm dlx --package=upstream-radar@0.20.0 upstream-radar
+          radar check ./upstream-radar.config.json
+          --frozen
+          --state :memory:
+          --fail-on high
+          --json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.19.4",
+  "version": "0.20.0",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { NpmReleaseClient } from './npm-release.js'
 import { OsvClient } from './osv.js'
 import { verdictAtLeast } from './policy.js'
 import { emptyRadarState, pollRadar } from './radar.js'
+import { evaluateRadarPolicy, RADAR_FAIL_THRESHOLDS, renderRadarPolicy, type RadarFailThreshold } from './radar-policy.js'
 import { renderRadarEvents } from './radar-render.js'
 import { loadRadarState, saveRadarState } from './radar-state.js'
 import { createRadarStatus, renderRadarStatus } from './radar-status.js'
@@ -24,6 +25,7 @@ import type { Verdict } from './types.js'
 import { TOOL_VERSION } from './version.js'
 
 const VALID_THRESHOLDS = new Set<Verdict | 'never'>(['warn', 'review', 'block', 'never'])
+const VALID_RADAR_THRESHOLDS = new Set<RadarFailThreshold>(RADAR_FAIL_THRESHOLDS)
 
 function safeErrorMessage(value: string): string {
   return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, character => (
@@ -43,9 +45,9 @@ Usage:
   upstream-radar doctor [config.json] [options]
   upstream-radar scan <directory> [--json] [--fail-on <warn|review|block|never>]
   upstream-radar inspect npm:<package>@<exact-version> [--deep] [--json] [--fail-on <warn|review|block|never>]
-  upstream-radar radar check <config.json> [--state <state.json>] [--json]
-  upstream-radar radar watch <config.json> [--state <state.json>] [--interval <seconds>] [--once] [--json]
-  upstream-radar radar status <config.json> [--state <state.json>] [--json]
+  upstream-radar radar check <config.json> [--state <state.json>] [--frozen] [--fail-on <severity>] [--json]
+  upstream-radar radar watch <config.json> [--state <state.json>] [--interval <seconds>] [--once] [--frozen] [--fail-on <severity>] [--json]
+  upstream-radar radar status <config.json> [--state <state.json>] [--fail-on <severity>] [--json]
   upstream-radar radar compare <config.json> <before.json> <candidate.json> [--notes <release-notes.txt>] [--json]
   upstream-radar task list <state.json> [--json]
   upstream-radar task show <state.json> [task-id] [--json]
@@ -68,6 +70,8 @@ Options:
   --osv-base-url <url> alternate HTTPS OSV API base URL
   --interval <seconds> watch interval from 300 to 86400 seconds (default: 1800)
   --once               run one watch cycle and exit (useful for CI and demos)
+  --frozen             radar check/watch: use the reviewed graph in config without reading a local DSH profile
+  --fail-on <value>    scan/inspect verdict or radar severity: unknown|info|low|medium|high|critical|never
   --notes <path>       release notes used as untrusted compatibility evidence
   --profile <name>     DSH profile for init or doctor (init auto-selects the only candidate when omitted)
   --output <path>      init output path (default: ./upstream-radar.config.json)
@@ -75,11 +79,10 @@ Options:
   --patch <path>       DSH overlay to verify with doctor
   --force              allow init to replace an existing output file
   --json               emit the canonical JSON report
-  --fail-on <verdict>  CI threshold; default is review
 
 Exit codes:
-  0  scan completed and policy threshold was not reached
-  1  operational or input error
+  0  completed without an operational error or configured policy match
+  1  operational, source, or input error
   2  configured policy threshold was reached
 `
 }
@@ -185,6 +188,8 @@ async function runRadar(args: readonly string[]): Promise<number> {
   let intervalProvided = false
   let once = false
   let deepCandidates = true
+  let frozen = false
+  let failOn: RadarFailThreshold = 'never'
   for (let index = 2; index < args.length; index += 1) {
     const argument = args[index]
     if (argument === '--json') {
@@ -193,14 +198,22 @@ async function runRadar(args: readonly string[]): Promise<number> {
       once = true
     } else if (argument === '--no-deep-candidates') {
       deepCandidates = false
+    } else if (argument === '--frozen') {
+      frozen = true
     } else if (argument === '--state' || argument === '--osv-base-url' || argument === '--registry'
-      || argument === '--notes' || argument === '--interval') {
+      || argument === '--notes' || argument === '--interval' || argument === '--fail-on') {
       const value = args[index + 1]
       if (value === undefined || value.startsWith('-')) throw new Error(`${argument} requires a value`)
       if (argument === '--state') statePath = value
       else if (argument === '--osv-base-url') osvBaseUrl = value
       else if (argument === '--registry') registry = value
       else if (argument === '--notes') notesPath = value
+      else if (argument === '--fail-on') {
+        if (!VALID_RADAR_THRESHOLDS.has(value as RadarFailThreshold)) {
+          throw new Error(`invalid radar --fail-on value: ${value}`)
+        }
+        failOn = value as RadarFailThreshold
+      }
       else {
         intervalProvided = true
         const parsed = Number(value)
@@ -218,11 +231,13 @@ async function runRadar(args: readonly string[]): Promise<number> {
   }
 
   const readConfig = async () => parseRadarConfig(await readJson(configPath))
-  const readConfigForPoll = async () => refreshRadarConfigFromConfiguredProfile(await readConfig())
+  const readConfigForPoll = async () => frozen
+    ? readConfig()
+    : refreshRadarConfigFromConfiguredProfile(await readConfig())
   if (subcommand === 'status') {
     if (positional.length > 0 || notesPath !== undefined || once || intervalProvided
-      || osvBaseUrl !== undefined || registry !== undefined || !deepCandidates || statePath === ':memory:') {
-      throw new Error('radar status only accepts --state and --json options')
+      || osvBaseUrl !== undefined || registry !== undefined || !deepCandidates || frozen || statePath === ':memory:') {
+      throw new Error('radar status only accepts --state, --fail-on and --json options')
     }
     const config = await readConfig()
     const stateFile = statePath ?? `${resolve(configPath)}.state.json`
@@ -233,8 +248,16 @@ async function runRadar(args: readonly string[]): Promise<number> {
       stateFile: resolve(stateFile),
       stateExists,
     })
-    process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderRadarStatus(report))
-    return report.monitoring === 'degraded' || report.coverage === 'incomplete' ? 1 : 0
+    const policy = evaluateRadarPolicy(state, failOn)
+    if (json) {
+      process.stdout.write(failOn === 'never'
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : `${JSON.stringify({ ...report, policy }, null, 2)}\n`)
+    } else {
+      process.stdout.write(`${renderRadarStatus(report)}${failOn === 'never' ? '' : renderRadarPolicy(policy)}`)
+    }
+    if (report.monitoring === 'degraded' || report.coverage === 'incomplete') return 1
+    return policy.status === 'fail' ? 2 : 0
   }
   const osv = new OsvClient({
     ...(osvBaseUrl === undefined ? {} : { baseUrl: osvBaseUrl }),
@@ -254,10 +277,16 @@ async function runRadar(args: readonly string[]): Promise<number> {
     if (statePath !== ':memory:') await saveRadarState(stateFile, result.state)
     return result
   }
-  const writeCheckResult = (result: Awaited<ReturnType<typeof pollRadar>>, compactJson = false): void => {
-    process.stdout.write(json
-      ? `${JSON.stringify(result, null, compactJson ? 0 : 2)}\n`
-      : `${renderRadarEvents(result.events)}${result.sourceErrors.map(error => `Source warning (${error.source}): ${safeErrorMessage(error.message)}\n`).join('')}Prepared ${result.analysisTasks.length} DSH analysis task(s); queried ${result.packagesQueried} exact package versions and ${result.releasePackagesQueried} release streams.\n`)
+  const writeCheckResult = (result: Awaited<ReturnType<typeof pollRadar>>, compactJson = false) => {
+    const policy = evaluateRadarPolicy(result.state, failOn)
+    if (json) {
+      process.stdout.write(failOn === 'never'
+        ? `${JSON.stringify(result, null, compactJson ? 0 : 2)}\n`
+        : `${JSON.stringify({ ...result, policy }, null, compactJson ? 0 : 2)}\n`)
+    } else {
+      process.stdout.write(`${renderRadarEvents(result.events)}${result.sourceErrors.map(error => `Source warning (${error.source}): ${safeErrorMessage(error.message)}\n`).join('')}Prepared ${result.analysisTasks.length} DSH analysis task(s); queried ${result.packagesQueried} exact package versions and ${result.releasePackagesQueried} release streams.\n${failOn === 'never' ? '' : renderRadarPolicy(policy)}`)
+    }
+    return policy
   }
 
   if (subcommand === 'check') {
@@ -265,12 +294,14 @@ async function runRadar(args: readonly string[]): Promise<number> {
       throw new Error('radar check received an option meant for watch or compare')
     }
     const result = await runCheck()
-    writeCheckResult(result)
-    return result.sourceErrors.length === 0 ? 0 : 1
+    const policy = writeCheckResult(result)
+    if (result.sourceErrors.length > 0) return 1
+    return policy.status === 'fail' ? 2 : 0
   }
 
   if (subcommand === 'watch') {
     if (positional.length > 0 || notesPath !== undefined) throw new Error('radar watch received unexpected arguments')
+    if (failOn !== 'never' && !once) throw new Error('radar watch requires --once when --fail-on is used')
     let stopped = false
     let timer: NodeJS.Timeout | undefined
     let wake: (() => void) | undefined
@@ -285,8 +316,9 @@ async function runRadar(args: readonly string[]): Promise<number> {
       do {
         try {
           const result = await runCheck()
-          writeCheckResult(result, true)
+          const policy = writeCheckResult(result, true)
           if (once && result.sourceErrors.length > 0) return 1
+          if (once && policy.status === 'fail') return 2
         } catch (error: unknown) {
           const message = error instanceof Error ? error.message : String(error)
           process.stderr.write(`upstream-radar: watch cycle failed: ${safeErrorMessage(message)}\n`)
@@ -308,7 +340,7 @@ async function runRadar(args: readonly string[]): Promise<number> {
     return 0
   }
 
-  if (statePath !== undefined || osvBaseUrl !== undefined || registry !== undefined || once || intervalProvided || !deepCandidates) {
+  if (statePath !== undefined || osvBaseUrl !== undefined || registry !== undefined || once || intervalProvided || !deepCandidates || frozen || failOn !== 'never') {
     throw new Error('radar compare does not accept check or watch options')
   }
   const config = await readConfig()

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,14 @@ export {
 } from './init.js'
 export { loadRadarState, parseRadarState, saveRadarState } from './radar-state.js'
 export {
+  evaluateRadarPolicy,
+  renderRadarPolicy,
+  RADAR_FAIL_THRESHOLDS,
+  type RadarFailThreshold,
+  type RadarPolicyMatch,
+  type RadarPolicyResult,
+} from './radar-policy.js'
+export {
   createRadarStatus,
   renderRadarStatus,
   RADAR_STATUS_SCHEMA,

--- a/src/radar-policy.ts
+++ b/src/radar-policy.ts
@@ -1,0 +1,89 @@
+import type { RadarSeverity, RadarState, VulnerabilityEvent } from './radar-types.js'
+
+export type RadarFailThreshold = RadarSeverity | 'never'
+
+export interface RadarPolicyMatch {
+  incidentId: string
+  kind: VulnerabilityEvent['kind']
+  project: string
+  severity: RadarSeverity
+  package: string
+  advisory: string
+}
+
+export interface RadarPolicyResult {
+  threshold: RadarFailThreshold
+  status: 'pass' | 'fail'
+  matches: RadarPolicyMatch[]
+}
+
+const SEVERITY_RANK: Record<RadarSeverity, number> = {
+  unknown: 0,
+  info: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  critical: 5,
+}
+
+export const RADAR_FAIL_THRESHOLDS: readonly RadarFailThreshold[] = [
+  'unknown',
+  'info',
+  'low',
+  'medium',
+  'high',
+  'critical',
+  'never',
+]
+
+function display(value: string, maxLength = 512): string {
+  const escaped = value.replace(/[\u0000-\u001f\u007f-\u009f]/g, character => (
+    `\\u${character.codePointAt(0)?.toString(16).padStart(4, '0') ?? '0000'}`
+  ))
+  return escaped.length <= maxLength ? escaped : `${escaped.slice(0, maxLength)}…`
+}
+
+function effectiveSeverity(event: VulnerabilityEvent): RadarSeverity {
+  return event.kind === 'malware' ? 'critical' : event.advisory.severity
+}
+
+function policyMatch(event: VulnerabilityEvent): RadarPolicyMatch {
+  return {
+    incidentId: display(event.incidentId),
+    kind: event.kind,
+    project: display(event.project.name),
+    severity: effectiveSeverity(event),
+    package: display(`${event.affected.name}@${event.affected.version}`),
+    advisory: display(event.advisory.id),
+  }
+}
+
+export function evaluateRadarPolicy(state: RadarState, threshold: RadarFailThreshold): RadarPolicyResult {
+  if (threshold === 'never') return { threshold, status: 'pass', matches: [] }
+  const minimum = SEVERITY_RANK[threshold]
+  const matches = Object.values(state.activeVulnerabilities)
+    .map(item => policyMatch(item.event))
+    .filter(item => SEVERITY_RANK[item.severity] >= minimum)
+    .sort((left, right) => (
+      SEVERITY_RANK[right.severity] - SEVERITY_RANK[left.severity]
+        || left.project.localeCompare(right.project)
+        || left.incidentId.localeCompare(right.incidentId)
+    ))
+  return {
+    threshold,
+    status: matches.length === 0 ? 'pass' : 'fail',
+    matches,
+  }
+}
+
+export function renderRadarPolicy(policy: RadarPolicyResult): string {
+  if (policy.threshold === 'never') return 'Policy: not enforced\n'
+  if (policy.status === 'pass') {
+    return `Policy: PASS (no active vulnerability at or above ${policy.threshold})\n`
+  }
+  const lines = [`Policy: FAIL (active vulnerability at or above ${policy.threshold})`]
+  for (const match of policy.matches) {
+    lines.push(`  [${match.severity.toUpperCase()}] ${match.project}: ${match.package} (${match.advisory})`)
+  }
+  return `${lines.join('\n')}\n`
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.19.4'
+export const TOOL_VERSION = '0.20.0'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -22,6 +22,8 @@ describe('CLI option parsing', () => {
     assert.match(help.stdout, /radar watch <config\.json>/)
     assert.match(help.stdout, /radar status <config\.json>/)
     assert.match(help.stdout, /--once\s+run one watch cycle and exit/)
+    assert.match(help.stdout, /--frozen\s+radar check\/watch: use the reviewed graph/)
+    assert.match(help.stdout, /--fail-on <value>\s+scan\/inspect verdict or radar severity/)
     assert.match(help.stdout, /--dsh-patch <path>\s+write a self-contained DSH --patch overlay/)
 
     const blockedDoctor = spawnSync(process.execPath, [cli, 'doctor', resolve(tmpdir(), `upstream-radar-missing-${process.pid}.json`)], { encoding: 'utf8' })
@@ -52,6 +54,19 @@ describe('CLI option parsing', () => {
     assert.equal(report.schema, 'upstream-radar.radar-status/v1alpha1')
     assert.equal(report.stateExists, false)
     assert.equal(report.monitoring, 'not-started')
+
+    const gated = spawnSync(process.execPath, [cli, 'radar', 'status', config, '--state', missingState, '--fail-on', 'high', '--json'], { encoding: 'utf8' })
+    assert.equal(gated.status, 0)
+    const gatedReport = JSON.parse(gated.stdout) as { policy: { threshold: string; status: string } }
+    assert.deepEqual(gatedReport.policy, { threshold: 'high', status: 'pass', matches: [] })
+
+    const invalidThreshold = spawnSync(process.execPath, [cli, 'radar', 'status', config, '--fail-on', 'severe'], { encoding: 'utf8' })
+    assert.equal(invalidThreshold.status, 1)
+    assert.match(invalidThreshold.stderr, /invalid radar --fail-on value: severe/)
+
+    const longRunningGate = spawnSync(process.execPath, [cli, 'radar', 'watch', config, '--fail-on', 'high'], { encoding: 'utf8' })
+    assert.equal(longRunningGate.status, 1)
+    assert.match(longRunningGate.stderr, /requires --once when --fail-on is used/)
   })
 
   it('prints the local doctor command before the long-running DSH start command', async () => {

--- a/test/radar-policy.test.ts
+++ b/test/radar-policy.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { emptyRadarState } from '../src/radar.js'
+import { evaluateRadarPolicy, renderRadarPolicy } from '../src/radar-policy.js'
+import type { VulnerabilityEvent } from '../src/radar-types.js'
+
+function event(
+  incidentId: string,
+  kind: VulnerabilityEvent['kind'],
+  severity: VulnerabilityEvent['advisory']['severity'],
+): VulnerabilityEvent {
+  return {
+    schema: 'upstream-radar.event/v1alpha1',
+    id: `event-${incidentId}`,
+    incidentId,
+    kind,
+    change: 'new',
+    detectedAt: '2026-08-16T01:00:00.000Z',
+    project: { id: incidentId, name: `Project ${incidentId}` },
+    route: { channels: ['stdout'] },
+    plugin: { ecosystem: 'npm', name: 'demo-plugin', version: '1.0.0' },
+    affected: { ecosystem: 'npm', name: 'parser', version: '2.9.0' },
+    paths: [],
+    advisory: {
+      id: `GHSA-${incidentId}`,
+      aliases: [],
+      summary: 'Demo advisory',
+      details: 'Demo details',
+      severity,
+      modified: '2026-08-16T01:00:00.000Z',
+      fixedVersions: [],
+      references: [],
+    },
+  }
+}
+
+describe('radar policy', () => {
+  it('fails on active vulnerabilities at or above the selected severity', () => {
+    const state = emptyRadarState()
+    const high = event('high', 'vulnerability', 'high')
+    const medium = event('medium', 'vulnerability', 'medium')
+    const malware = event('malware', 'malware', 'unknown')
+    state.activeVulnerabilities = {
+      high: { key: 'high', event: high },
+      medium: { key: 'medium', event: medium },
+      malware: { key: 'malware', event: malware },
+    }
+
+    const result = evaluateRadarPolicy(state, 'high')
+    assert.equal(result.status, 'fail')
+    assert.deepEqual(result.matches.map(match => match.incidentId), ['malware', 'high'])
+    assert.equal(result.matches[0]?.severity, 'critical')
+    assert.match(renderRadarPolicy(result), /Policy: FAIL/)
+    assert.match(renderRadarPolicy(result), /Project malware: parser@2\.9\.0/)
+    assert.doesNotMatch(renderRadarPolicy(result), /Project medium/)
+  })
+
+  it('does not enforce a threshold when explicitly disabled', () => {
+    const state = emptyRadarState()
+    state.activeVulnerabilities = {
+      high: { key: 'high', event: event('high', 'vulnerability', 'high') },
+    }
+
+    const result = evaluateRadarPolicy(state, 'never')
+    assert.deepEqual(result, { threshold: 'never', status: 'pass', matches: [] })
+    assert.equal(renderRadarPolicy(result), 'Policy: not enforced\n')
+  })
+})


### PR DESCRIPTION
## What changed
- Add `radar check/status/watch --fail-on <severity>` for active vulnerability gates; malware is treated as critical.
- Add `--frozen` to `radar check` and `radar watch` so CI uses the reviewed config graph without a local DSH profile.
- Keep source/operational failures distinct from policy failures: exit 1 vs exit 2.
- Add a copyable GitHub Actions workflow using `--state :memory:`.
- Update English/Chinese docs, showcase, roadmap, changelog, and tests.

## DSH boundary
The native DSH bundle remains the always-on path and still refreshes the installed profile by default. The CI path checks deterministic evidence; it does not wake an Agent, execute plugin code, upgrade packages, or create a branch.

## Validation
- `pnpm run check`
- `pnpm test` (106 passing)
- `pnpm run scan:self`
- `pnpm run showcase:radar`
- `pnpm run try:dsh`
- `pnpm pack --dry-run` includes `dist/src/radar-policy.js`
- `git diff --check`