### PR TITLE
Make init output portable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.21.0] - 2026-08-16
+
+### Changed
+
+- Make `init` record `project.workspace` as `.` by default, so the generated dependency inventory can be reviewed and committed without embedding the creator's absolute home path.
+- Remove the unnecessary `$PWD` argument from the first-use commands; pass `--workspace <absolute-path>` only when DSH is launched outside the project root.
+
+### Safety
+
+- The portable default changes only the project path presented to the DSH Agent; it does not change the exact installed dependency graph or its source evidence.
+
 ## [0.20.0] - 2026-08-16
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,6 @@ dsh plugin --profile contributor-qa add dsh-cloudflare-browser-run@0.1.1
 pnpm dlx upstream-radar@latest init \
   --profile contributor-qa \
   --project-name "Contributor QA" \
-  --workspace "$PWD" \
   --output ./upstream-radar.config.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ dsh plugin --profile web add upstream-radar@latest
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
   --profile web \
   --project-name "My DSH project" \
-  --workspace "$PWD" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
 pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
@@ -130,12 +129,11 @@ Generate the inventory from the DSH profile instead of writing the dependency gr
 ```bash
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
   --project-name "My DSH project" \
-  --workspace "$PWD" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
 ```
 
-The initializer reads the profile's actual third-party bundles and follows the installed `node_modules` tree exposed by that profile, including duplicate versions, overrides, and local package-manager choices. It reads manifests only: it does not import plugin code, run lifecycle scripts, start DSH, or enable polling. Review both generated files, then run:
+The initializer reads the profile's actual third-party bundles and follows the installed `node_modules` tree exposed by that profile, including duplicate versions, overrides, and local package-manager choices. By default it records the workspace as `.` so the config can be committed and reused on another machine; start DSH from the project root. Pass `--workspace <absolute-path>` only when DSH is launched elsewhere. It reads manifests only: it does not import plugin code, run lifecycle scripts, start DSH, or enable polling. Review both generated files, then run:
 
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml --dump-config
@@ -196,7 +194,7 @@ If your team wants a scheduled CI gate before wiring a machine to a live DSH pro
 
 ```yaml
 run: >-
-  pnpm dlx --package=upstream-radar@0.20.0 upstream-radar
+  pnpm dlx --package=upstream-radar@0.21.0 upstream-radar
   radar check ./upstream-radar.config.json
   --frozen --state :memory: --fail-on high --json
 ```
@@ -298,6 +296,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 - durable incident state with current-task replacement and resolution;
 - native DSH bundle installation, startup polling, `agent/created` retry, and plugin-source attribution;
 - automatic selection of the only DSH profile with third-party bundles, plus a network-free `radar status` snapshot;
+- commit-friendly `init` output that records the project workspace as `.` by default;
 - an actionable, network-free `radar status` summary with exact active paths, candidate signals, and next steps;
 - a network-free `doctor` command that checks local DSH registration, overlay/config alignment, state readability, and dependency coverage;
 - compatibility signals for Node.js, peers, exports, entrypoints, bundle paths, dependencies, and version boundaries;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,7 @@
 - [x] Auto-select the only DSH profile with third-party bundles and provide a network-free first-run status snapshot.
 - [x] Provide a network-free doctor command for DSH bundle registration, overlay/config alignment, state readability, and dependency coverage.
 - [x] Show bounded active-incident paths, candidate signals, and next-step guidance in the network-free status command.
+- [x] Make the generated project workspace portable by default so the reviewed inventory can be committed and reused.
 
 ## Milestone 1 — compatibility radar
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -25,7 +25,6 @@ dsh plugin --profile web add upstream-radar@latest
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
   --profile web \
   --project-name "我的 DSH 项目" \
-  --workspace "$PWD" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
 pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
@@ -120,12 +119,11 @@ dsh plugin --profile web add upstream-radar@latest
 ```bash
 pnpm dlx --package=upstream-radar@latest upstream-radar init \
   --project-name "我的 DSH 项目" \
-  --workspace "$PWD" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
 ```
 
-初始化命令会读取 profile 中实际安装的第三方 bundle，并沿着该 profile 暴露的 `node_modules` 目录构建依赖图，包括重复版本、override 和本地 package-manager 选择。它只读取 manifest，不会导入插件代码、运行 lifecycle scripts、启动 DSH 或开启轮询。检查生成文件后，直接运行：
+初始化命令会读取 profile 中实际安装的第三方 bundle，并沿着该 profile 暴露的 `node_modules` 目录构建依赖图，包括重复版本、override 和本地 package-manager 选择。默认把 workspace 写成 `.`，因此配置可以提交并在另一台机器复用；请从项目根目录启动 DSH。如果 DSH 从其他目录启动，再传入 `--workspace <绝对路径>`。它只读取 manifest，不会导入插件代码、运行 lifecycle scripts、启动 DSH 或开启轮询。检查生成文件后，直接运行：
 
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml --dump-config
@@ -184,7 +182,7 @@ pnpm run try:dsh
 
 ```yaml
 run: >-
-  pnpm dlx --package=upstream-radar@0.20.0 upstream-radar
+  pnpm dlx --package=upstream-radar@0.21.0 upstream-radar
   radar check ./upstream-radar.config.json
   --frozen --state :memory: --fail-on high --json
 ```
@@ -259,7 +257,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查。
+已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查和默认可提交的相对 workspace。
 
 `init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查、活动事件摘要和下一步提示，但不会替你刷新漏洞源，也不会自动升级插件。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,8 @@ poll sources
 
 When a generated inventory is used, the native DSH adapter and CLI `radar check/watch` first rebuild the installed graph from the selected DSH profile. This refresh is manifest-only and never executes plugin code. A failed refresh aborts that cycle before state replacement, so an unreadable or half-updated profile cannot be reported as clean. Read-only `status` and explicit-file `compare` do not refresh.
 
+CLI-generated inventories record the project workspace as `.` by default. This keeps the graph and Agent context reviewable in version control without embedding the creator's absolute home path; the DSH process is expected to start from the project root. `--workspace <absolute-path>` remains available when that launch arrangement is not possible.
+
 The delivery boundary is intentionally at-least-once. A crash after follow-up admission but before the second state write can repeat a task; it cannot silently erase it. Event and task ids allow later delivery adapters to deduplicate.
 
 The `doctor` command is a separate local diagnosis plane. It parses the config and state, reads the selected DSH profile manifest, checks the generated overlay's paths, and reuses the network-free status snapshot. It never polls an upstream source and never loads a plugin, so a `READY` result means “the wiring is locally coherent,” not “the feeds are current” or “the model has completed an analysis.”

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -115,7 +115,7 @@ After three consecutive failed OSV checks, Radar creates one project-routed `sou
 
 ## Scene 9 — onboarding without shell state
 
-`init --dsh-patch ./upstream-radar.dsh.yml` writes the exact inventory and a reviewable DSH overlay. The overlay replaces the bundle's environment-derived paths with explicit config and state files, so the profile can start with one visible command:
+`init --dsh-patch ./upstream-radar.dsh.yml` writes the exact inventory and a reviewable DSH overlay. The inventory records `project.workspace` as `.` by default, so it can be committed without embedding a creator's home directory; run DSH from the project root. The overlay replaces the bundle's environment-derived paths with explicit config and state files, so the profile can start with one visible command:
 
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml
@@ -176,7 +176,7 @@ This is intentionally different from resolving the same package in a fresh npm p
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.20.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.21.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 22
       - name: Check the reviewed DSH graph
         run: >-
-          pnpm dlx --package=upstream-radar@0.20.0 upstream-radar
+          pnpm dlx --package=upstream-radar@0.21.0 upstream-radar
           radar check ./upstream-radar.config.json
           --frozen
           --state :memory:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/init.ts
+++ b/src/init.ts
@@ -170,7 +170,10 @@ export async function createRadarConfigFromDshProfile(options: DshInitOptions): 
   const profileDirectory = resolve(options.profileDirectory)
   const bundles = await readDshProfileBundles(profileDirectory)
 
-  const workspace = options.workspace ?? process.cwd()
+  // Keep the generated inventory portable by default. DSH is expected to be
+  // started from the project root; callers that launch it elsewhere can pass
+  // an explicit absolute workspace path.
+  const workspace = options.workspace ?? '.'
   const projectId = options.projectId ?? defaultProjectId(workspace)
   const projectName = options.projectName ?? defaultProjectName(workspace)
   const inspect = options.inspect ?? inspectNpmPackage

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.20.0'
+export const TOOL_VERSION = '0.21.0'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -106,6 +106,8 @@ describe('CLI option parsing', () => {
       assert.ok(doctorAt >= 0)
       assert.ok(dshAt > doctorAt)
       assert.match(result.stdout, /--patch .*upstream-radar\.dsh\.yml/)
+      const savedConfig = JSON.parse(await readFile(config, 'utf8')) as { projects: Array<{ project: { workspace?: string } }> }
+      assert.equal(savedConfig.projects[0]?.project.workspace, '.')
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -178,6 +178,7 @@ describe('DSH profile initialization', () => {
       }))
 
       const config = await createRadarConfigFromDshProfile({ profileDirectory: profile })
+      assert.equal(config.projects[0]?.project.workspace, '.')
       assert.equal(config.projects[0]?.plugins[0]?.graph.source, 'installed-node-modules')
       assert.equal(config.projects[0]?.plugins[0]?.graph.nodes.length, 2)
     } finally {


### PR DESCRIPTION
## What changed
- Make generated `project.workspace` default to `.` instead of embedding the creator's absolute home path.
- Keep `--workspace <absolute-path>` as an explicit escape hatch for DSH launched elsewhere.
- Remove unnecessary `$PWD` from first-use and contributor commands.
- Document that DSH should start from the project root and that the reviewed config can be committed/reused.
- Add CLI/init assertions for the actual saved JSON.
- Bump release metadata to v0.21.0.

## Why
This shortens first use and makes the same reviewed dependency graph usable in GitHub Actions and on another machine without leaking a local filesystem path into the project inventory.

## Safety boundary
The exact installed graph, package versions, paths, and coverage evidence are unchanged. Only the project workspace reference defaults to a portable relative value.

## Validation
- `pnpm run check`
- `pnpm test` (106 passing)
- `pnpm run scan:self`
- `pnpm run showcase:radar`
- `pnpm run try:dsh`
- `pnpm pack --dry-run`
- `git diff --check`