### PR TITLE
feat: publish reusable GitHub Action for DSH graph checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.22.0] - 2026-08-16
+
+### Added
+
+- Publish a reusable GitHub composite Action for the reviewed, frozen Radar CI gate.
+- Allow repositories to configure the graph path, failure threshold, state path, exact Radar version, Node.js version, and working directory without copying the runner setup.
+
+### Safety
+
+- The Action pins its setup dependencies to exact commit SHAs and passes user inputs through environment variables before invoking the CLI.
+- The Action requires the caller to check out the repository and only runs `radar check --frozen`; it does not start DSH, execute plugin code, modify dependencies, or create a branch.
+
 ## [0.21.0] - 2026-08-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -190,16 +190,25 @@ This proof runs in CI on Node.js 22. See the executable [showcase contract](exam
 
 ## Run it in GitHub Actions
 
-If your team wants a scheduled CI gate before wiring a machine to a live DSH profile, commit the reviewed `upstream-radar.config.json` and copy [the example workflow](examples/github-actions/upstream-radar.yml). It runs the same exact dependency and OSV checks without needing DSH installed in the runner:
+If your team wants a scheduled CI gate before wiring a machine to a live DSH profile, commit the reviewed `upstream-radar.config.json` and copy [the example workflow](examples/github-actions/upstream-radar.yml). The reusable Action keeps the workflow to two meaningful steps:
 
 ```yaml
-run: >-
-  pnpm dlx --package=upstream-radar@0.21.0 upstream-radar
-  radar check ./upstream-radar.config.json
-  --frozen --state :memory: --fail-on high --json
+steps:
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  - uses: MicroMilo/upstream-radar@v0.22.0
+    with:
+      config: upstream-radar.config.json
+      fail-on: high
 ```
 
-`--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. `--state :memory:` makes each run independent. The command exits `2` when an active vulnerability meets the threshold, and exits `1` for an operational or source error. It does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path.
+The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability meets the threshold, and exits `1` for an operational or source error. It does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.22.0`, and pin the checkout Action in your workflow according to your repository's policy.
+
+The Action requires the caller to check out the repository first. It does not install the project's dependencies or run their lifecycle scripts; it only reads the committed graph and queries the configured upstream sources. For a fully explicit, lower-level invocation, the equivalent command is:
+
+```bash
+pnpm dlx --package=upstream-radar@0.22.0 upstream-radar radar check \
+  ./upstream-radar.config.json --frozen --state :memory: --fail-on high --json
+```
 
 For a local or self-hosted DSH machine, omit `--frozen` so Radar refreshes the selected profile before each cycle. Use `--fail-on` only with `radar check`, `radar status`, or `radar watch --once`; a long-running watch should continue routing incidents instead of terminating on the first one.
 
@@ -297,6 +306,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 - native DSH bundle installation, startup polling, `agent/created` retry, and plugin-source attribution;
 - automatic selection of the only DSH profile with third-party bundles, plus a network-free `radar status` snapshot;
 - commit-friendly `init` output that records the project workspace as `.` by default;
+- a reusable GitHub Action that turns the reviewed graph into a two-step, frozen CI gate;
 - an actionable, network-free `radar status` summary with exact active paths, candidate signals, and next steps;
 - a network-free `doctor` command that checks local DSH registration, overlay/config alignment, state readability, and dependency coverage;
 - compatibility signals for Node.js, peers, exports, entrypoints, bundle paths, dependencies, and version boundaries;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,6 +63,7 @@
 ## Milestone 4 — GitHub execution arm
 
 - [x] Provide a frozen one-shot CI check with severity exit codes and a copyable GitHub Actions workflow.
+- [x] Publish a reusable composite GitHub Action for the frozen deterministic CI gate.
 - [ ] Re-check the installed and proposed graph in GitHub Actions.
 - [ ] Attach project evidence to a GitHub Issue only after routing policy permits it.
 - [ ] Generate an upgrade branch or Pull Request behind explicit approval.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,60 @@
+name: Upstream Radar
+description: Check a reviewed DSH dependency graph for active upstream vulnerabilities.
+author: MicroMilo
+branding:
+  icon: shield
+  color: blue
+
+inputs:
+  config:
+    description: Reviewed Upstream Radar config path, relative to the working directory.
+    required: false
+    default: upstream-radar.config.json
+  fail-on:
+    description: Minimum active vulnerability severity that fails the job.
+    required: false
+    default: high
+  state:
+    description: Radar state path; use :memory: for an independent CI check.
+    required: false
+    default: ':memory:'
+  version:
+    description: Exact upstream-radar npm version to execute.
+    required: false
+    default: 0.22.0
+  node-version:
+    description: Node.js version used to run the CLI.
+    required: false
+    default: '22'
+  working-directory:
+    description: Directory containing the reviewed config and project checkout.
+    required: false
+    default: .
+
+runs:
+  using: composite
+  steps:
+    - name: Set up pnpm
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      with:
+        version: 11.3.0
+        run_install: false
+    - name: Set up Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Check reviewed DSH graph
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        RADAR_CONFIG: ${{ inputs.config }}
+        RADAR_FAIL_ON: ${{ inputs.fail-on }}
+        RADAR_STATE: ${{ inputs.state }}
+        RADAR_VERSION: ${{ inputs.version }}
+      run: >-
+        pnpm dlx --package="upstream-radar@$RADAR_VERSION" upstream-radar
+        radar check "$RADAR_CONFIG"
+        --frozen
+        --state "$RADAR_STATE"
+        --fail-on "$RADAR_FAIL_ON"
+        --json

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -178,16 +178,25 @@ pnpm run try:dsh
 
 ## 在 GitHub Actions 中运行
 
-如果团队想先用定时 CI 检查，而不是马上在 runner 里安装 DSH，可以把审查过的 `upstream-radar.config.json` 提交到仓库，然后复制[示例 workflow](../examples/github-actions/upstream-radar.yml)：
+如果团队想先用定时 CI 检查，而不是马上在 runner 里安装 DSH，可以把审查过的 `upstream-radar.config.json` 提交到仓库，然后复制[示例 workflow](../examples/github-actions/upstream-radar.yml)。现在可以直接使用可复用的 GitHub Action，workflow 只需要两个关键步骤：
 
 ```yaml
-run: >-
-  pnpm dlx --package=upstream-radar@0.21.0 upstream-radar
-  radar check ./upstream-radar.config.json
-  --frozen --state :memory: --fail-on high --json
+steps:
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  - uses: MicroMilo/upstream-radar@v0.22.0
+    with:
+      config: upstream-radar.config.json
+      fail-on: high
 ```
 
-`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。`--state :memory:` 让每次运行彼此独立。达到阈值时返回 `2`；运行或漏洞源出错时返回 `1`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；达到阈值时返回 `2`，运行或漏洞源出错时返回 `1`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.22.0` 的发布标签，并根据团队策略固定 checkout Action。
+
+调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
+
+```bash
+pnpm dlx --package=upstream-radar@0.22.0 upstream-radar radar check \
+  ./upstream-radar.config.json --frozen --state :memory: --fail-on high --json
+```
 
 在本地或自托管 DSH 机器上不要加 `--frozen`，这样 Radar 会在每轮检查前刷新选中的 profile。`--fail-on` 适用于一次性 `radar check`、`radar status` 或 `radar watch --once`；长期运行的 watch 不应该因为第一次告警就退出。
 
@@ -257,7 +266,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查和默认可提交的相对 workspace。
+已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查、默认可提交的相对 workspace，以及把审查过的图接入 CI 的可复用 GitHub Action。
 
 `init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查、活动事件摘要和下一步提示，但不会替你刷新漏洞源，也不会自动升级插件。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -176,12 +176,27 @@ This is intentionally different from resolving the same package in a fresh npm p
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.21.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.22.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
 
 `--frozen` prevents the command from looking for a local DSH profile. `--fail-on high` returns exit code `2` when the committed graph has an active high or critical vulnerability (malware is critical), while source or operational failures return `1`. This is a CI gate for deterministic evidence; it does not replace the native DSH Agent analysis or create an upgrade.
+
+## Scene 14 — make the gate two workflow steps
+
+The published Action packages the same frozen check so a DSH plugin project does not need to copy the runner setup or remember the safety flags:
+
+```yaml
+steps:
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  - uses: MicroMilo/upstream-radar@v0.22.0
+    with:
+      config: upstream-radar.config.json
+      fail-on: high
+```
+
+The Action checks out no code by itself and does not run DSH or plugin lifecycle scripts. It reads the reviewed graph from the caller's workspace, queries the configured sources, and fails only according to the explicit threshold. The native DSH bundle remains the path for always-on monitoring and model analysis.
 
 ## Live sources
 

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -13,18 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: MicroMilo/upstream-radar@v0.22.0
         with:
-          version: 10
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - name: Check the reviewed DSH graph
-        run: >-
-          pnpm dlx --package=upstream-radar@0.21.0 upstream-radar
-          radar check ./upstream-radar.config.json
-          --frozen
-          --state :memory:
-          --fail-on high
-          --json
+          config: upstream-radar.config.json
+          fail-on: high

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.21.0'
+export const TOOL_VERSION = '0.22.0'

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'node:test'
+
+describe('reusable GitHub Action', () => {
+  it('keeps the published Action thin, pinned, and frozen', async () => {
+    const actionPath = fileURLToPath(new URL('../../action.yml', import.meta.url))
+    const packagePath = fileURLToPath(new URL('../../package.json', import.meta.url))
+    const action = await readFile(actionPath, 'utf8')
+    const packageJson = JSON.parse(await readFile(packagePath, 'utf8')) as { version?: unknown }
+
+    assert.equal(typeof packageJson.version, 'string')
+    assert.match(action, /runs:\n\s+using: composite/)
+    assert.match(action, new RegExp(`default: ${String(packageJson.version).replaceAll('.', '\\.')}`))
+    assert.match(action, /uses: pnpm\/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6\.0\.10/)
+    assert.match(action, /uses: actions\/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7\.0\.0/)
+    assert.match(action, /RADAR_CONFIG: \$\{\{ inputs\.config \}\}/)
+    assert.match(action, /RADAR_FAIL_ON: \$\{\{ inputs\.fail-on \}\}/)
+    assert.match(action, /RADAR_STATE: \$\{\{ inputs\.state \}\}/)
+    assert.match(action, /RADAR_VERSION: \$\{\{ inputs\.version \}\}/)
+    assert.match(action, /pnpm dlx --package="upstream-radar@\$RADAR_VERSION" upstream-radar/)
+    assert.match(action, /--frozen/)
+    assert.match(action, /--state "\$RADAR_STATE"/)
+    assert.match(action, /--fail-on "\$RADAR_FAIL_ON"/)
+    assert.match(action, /--json/)
+    assert.doesNotMatch(action, /pnpm install|npm install/)
+  })
+})


### PR DESCRIPTION
## What changed

- add a reusable root `action.yml` for the reviewed, frozen Radar CI gate
- pin the Action's setup dependencies to exact commit SHAs
- pass Action inputs through environment variables and invoke only `radar check --frozen`
- update the copyable workflow, README pages, showcase, roadmap, changelog, and v0.22.0 metadata
- add metadata tests that protect the pinned and frozen execution contract

## Why

The DSH-native bundle remains the always-on path for monitoring and model analysis. This PR adds the simplest adoption path for projects that want a deterministic CI alarm without installing DSH or copying a 30-line runner setup.

The Action does not execute plugin code, install the caller's dependencies, deliver a DSH task, modify a branch, or create an upgrade. The caller checks out the repository; the Action reads the reviewed graph, queries configured upstream sources, and applies the explicit severity threshold.

## Validation

- `pnpm run check`
- `pnpm test` — 107 passing
- `pnpm run scan:self`
- `pnpm run showcase:radar`
- `pnpm run try:dsh`
- `pnpm pack --dry-run`
- `git diff --check`
