### PR TITLE
test: dogfood the published consumer action

### DIFF
--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -1,0 +1,20 @@
+name: Consumer Action smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  real-dsh-plugin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: MicroMilo/upstream-radar@v0.22.0
+        with:
+          config: examples/github-actions/consumer/upstream-radar.config.json
+          fail-on: high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## Unreleased
+
+### Added
+
+- Add a real DSH plugin consumer smoke with a copyable config, workflow, local command, and scheduled dogfood workflow for the published GitHub Action.
+
 ## [0.22.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ pnpm dlx --package=upstream-radar@0.22.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high --json
 ```
 
+For a runnable consumer example using the real [`dsh-cloudflare-browser-run@0.1.1`](examples/github-actions/consumer/upstream-radar.config.json) graph, see the [consumer smoke README](examples/github-actions/consumer/README.md) and its [copyable workflow](examples/github-actions/consumer/upstream-radar.yml).
+
+Run the same released Action locally from this repository with:
+
+```bash
+pnpm run try:consumer
+```
+
 For a local or self-hosted DSH machine, omit `--frozen` so Radar refreshes the selected profile before each cycle. Use `--fail-on` only with `radar check`, `radar status`, or `radar watch --once`; a long-running watch should continue routing incidents instead of terminating on the first one.
 
 ## How the loop works
@@ -307,6 +315,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 - automatic selection of the only DSH profile with third-party bundles, plus a network-free `radar status` snapshot;
 - commit-friendly `init` output that records the project workspace as `.` by default;
 - a reusable GitHub Action that turns the reviewed graph into a two-step, frozen CI gate;
+- a real DSH plugin consumer smoke that runs the published Action against 18 exact package versions;
 - an actionable, network-free `radar status` summary with exact active paths, candidate signals, and next steps;
 - a network-free `doctor` command that checks local DSH registration, overlay/config alignment, state readability, and dependency coverage;
 - compatibility signals for Node.js, peers, exports, entrypoints, bundle paths, dependencies, and version boundaries;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,7 @@
 
 - [x] Provide a frozen one-shot CI check with severity exit codes and a copyable GitHub Actions workflow.
 - [x] Publish a reusable composite GitHub Action for the frozen deterministic CI gate.
+- [x] Verify the published Action with a real DSH plugin consumer snapshot and a dogfood workflow.
 - [ ] Re-check the installed and proposed graph in GitHub Actions.
 - [ ] Attach project evidence to a GitHub Issue only after routing policy permits it.
 - [ ] Generate an upgrade branch or Pull Request behind explicit approval.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -198,6 +198,14 @@ pnpm dlx --package=upstream-radar@0.22.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high --json
 ```
 
+如果想先跑一个真实消费者样例，可以参考使用真实 [`dsh-cloudflare-browser-run@0.1.1`](../examples/github-actions/consumer/upstream-radar.config.json) 依赖图的[consumer smoke 说明](../examples/github-actions/consumer/README.md)和[可复制 workflow](../examples/github-actions/consumer/upstream-radar.yml)。
+
+在本仓库中也可以直接运行同一个已发布 Action：
+
+```bash
+pnpm run try:consumer
+```
+
 在本地或自托管 DSH 机器上不要加 `--frozen`，这样 Radar 会在每轮检查前刷新选中的 profile。`--fail-on` 适用于一次性 `radar check`、`radar status` 或 `radar watch --once`；长期运行的 watch 不应该因为第一次告警就退出。
 
 ## 闭环如何工作
@@ -266,7 +274,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查、默认可提交的相对 workspace，以及把审查过的图接入 CI 的可复用 GitHub Action。
+已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查、默认可提交的相对 workspace、把审查过的图接入 CI 的可复用 GitHub Action，以及基于真实 DSH 插件的 consumer smoke。
 
 `init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查、活动事件摘要和下一步提示，但不会替你刷新漏洞源，也不会自动升级插件。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -198,6 +198,10 @@ steps:
 
 The Action checks out no code by itself and does not run DSH or plugin lifecycle scripts. It reads the reviewed graph from the caller's workspace, queries the configured sources, and fails only according to the explicit threshold. The native DSH bundle remains the path for always-on monitoring and model analysis.
 
+## Scene 15 — verify the consumer path with a real DSH plugin
+
+The repository also carries a copyable consumer smoke under [`examples/github-actions/consumer`](../examples/github-actions/consumer/README.md). Its snapshot is built from the published `dsh-cloudflare-browser-run@0.1.1` package and its resolved graph, so the first-run path exercises real npm manifests and real DSH package names. A project should regenerate this snapshot with `radar init` after reviewing its own DSH profile.
+
 ## Live sources
 
 The fixture isolates behavior from network timing. Production cycles use:

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -1,0 +1,31 @@
+# Consumer smoke: a real DSH plugin in GitHub Actions
+
+This directory is a copyable consumer example for a DSH plugin project. It uses the real published `dsh-cloudflare-browser-run@0.1.1` package and its resolved dependency graph, rather than a fictional package name.
+
+## Run the example
+
+Copy these two files into a repository that has reviewed the corresponding DSH plugin graph:
+
+- [`upstream-radar.config.json`](upstream-radar.config.json)
+- [`upstream-radar.yml`](upstream-radar.yml) into `.github/workflows/`
+
+The workflow runs on demand or weekly. It checks the committed graph against OSV and npm, and fails when an active high-or-higher vulnerability is present. It does not install the plugin, run lifecycle scripts, start DSH, or modify the repository.
+
+## Generate your own graph
+
+For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
+
+```bash
+pnpm dlx --package=upstream-radar@0.22.0 upstream-radar init \
+  --profile <dsh-profile> \
+  --project-id <project-id> \
+  --project-name "Your project" \
+  --output ./upstream-radar.config.json \
+  --dsh-patch ./upstream-radar.dsh.yml
+```
+
+Review the generated graph, commit the config, and then use the Action. The config is an evidence snapshot, not a safety certificate; the native DSH bundle remains the always-on path that refreshes the installed profile and routes model analysis.
+
+## What success means
+
+The first run should show an independent frozen check with no DSH profile required on the runner. A source outage is a failed check, not a clean result. If the plugin or a transitive dependency becomes vulnerable, the workflow exits non-zero and preserves the exact package path in the JSON report.

--- a/examples/github-actions/consumer/upstream-radar.config.json
+++ b/examples/github-actions/consumer/upstream-radar.config.json
@@ -1,0 +1,490 @@
+{
+  "schema": "upstream-radar.radar-config/v1alpha1",
+  "projects": [
+    {
+      "schema": "upstream-radar.inventory/v1alpha1",
+      "project": {
+        "id": "dsh-cloudflare-browser-run-consumer",
+        "name": "DSH Cloudflare Browser Run (consumer smoke)",
+        "repository": "https://github.com/MicroMilo/upstream-radar",
+        "workspace": "examples/github-actions/consumer",
+        "owner": "upstream-radar-maintainers",
+        "channels": [
+          "github-actions"
+        ]
+      },
+      "environment": {
+        "nodeVersion": "22.18.0"
+      },
+      "plugins": [
+        {
+          "package": {
+            "ecosystem": "npm",
+            "name": "dsh-cloudflare-browser-run",
+            "version": "0.1.1"
+          },
+          "manifest": {
+            "name": "dsh-cloudflare-browser-run",
+            "version": "0.1.1",
+            "main": "dist/index.js",
+            "type": "module",
+            "exports": {
+              ".": "./dist/index.js"
+            },
+            "dependencies": {
+              "@deepseek-ai/cordis": "^4.0.1",
+              "@deepseek-ai/dsh-tools": "^0.0.1-rc.1",
+              "@deepseek-ai/schemastery": "^3.18.0"
+            },
+            "engines": {
+              "node": ">=20.0.0"
+            },
+            "dsh": {
+              "bundle": {
+                "patch": "./cordis.patch.yml"
+              }
+            }
+          },
+          "graph": {
+            "schema": "upstream-radar.dependency-graph/v1alpha1",
+            "rootNodeId": "node_modules/dsh-cloudflare-browser-run",
+            "nodes": [
+              {
+                "id": "node_modules/dsh-cloudflare-browser-run",
+                "name": "dsh-cloudflare-browser-run",
+                "version": "0.1.1"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/cordis",
+                "name": "@deepseek-ai/cordis",
+                "version": "4.0.1"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/cosmokit",
+                "name": "@deepseek-ai/cosmokit",
+                "version": "1.8.2"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-agent",
+                "name": "@deepseek-ai/dsh-agent",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-attachment",
+                "name": "@deepseek-ai/dsh-attachment",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-brand",
+                "name": "@deepseek-ai/dsh-brand",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-code-runtime",
+                "name": "@deepseek-ai/dsh-code-runtime",
+                "version": "0.0.1-rc.1"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-invariants",
+                "name": "@deepseek-ai/dsh-invariants",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-llm",
+                "name": "@deepseek-ai/dsh-llm",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-scope",
+                "name": "@deepseek-ai/dsh-scope",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-session",
+                "name": "@deepseek-ai/dsh-session",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "name": "@deepseek-ai/dsh-system-prompt",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-timeout",
+                "name": "@deepseek-ai/dsh-timeout",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-tools",
+                "name": "@deepseek-ai/dsh-tools",
+                "version": "0.0.1-rc.1"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-typert-protocol",
+                "name": "@deepseek-ai/dsh-typert-protocol",
+                "version": "0.0.1-rc.5"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/dsh-user-approval",
+                "name": "@deepseek-ai/dsh-user-approval",
+                "version": "0.0.1-rc.1"
+              },
+              {
+                "id": "node_modules/@deepseek-ai/schemastery",
+                "name": "@deepseek-ai/schemastery",
+                "version": "3.18.1"
+              },
+              {
+                "id": "node_modules/@standard-schema/spec",
+                "name": "@standard-schema/spec",
+                "version": "1.1.0"
+              }
+            ],
+            "edges": [
+              {
+                "from": "node_modules/@deepseek-ai/cordis",
+                "to": "node_modules/@deepseek-ai/cosmokit",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/cordis",
+                "to": "node_modules/@standard-schema/spec",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-agent",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-agent",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-agent",
+                "to": "node_modules/@deepseek-ai/dsh-llm",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-agent",
+                "to": "node_modules/@deepseek-ai/dsh-scope",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-agent",
+                "to": "node_modules/@deepseek-ai/dsh-session",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-agent",
+                "to": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-agent",
+                "to": "node_modules/@deepseek-ai/dsh-typert-protocol",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-attachment",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-attachment",
+                "to": "node_modules/@deepseek-ai/dsh-brand",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-attachment",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-brand",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-brand",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-code-runtime",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-code-runtime",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-invariants",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-invariants",
+                "to": "node_modules/@deepseek-ai/schemastery",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-llm",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-llm",
+                "to": "node_modules/@deepseek-ai/dsh-attachment",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-llm",
+                "to": "node_modules/@deepseek-ai/dsh-brand",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-llm",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-llm",
+                "to": "node_modules/@deepseek-ai/dsh-timeout",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-llm",
+                "to": "node_modules/@deepseek-ai/schemastery",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-scope",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-scope",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-session",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-session",
+                "to": "node_modules/@deepseek-ai/dsh-brand",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-session",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-session",
+                "to": "node_modules/@deepseek-ai/dsh-llm",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-session",
+                "to": "node_modules/@deepseek-ai/dsh-scope",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-session",
+                "to": "node_modules/@deepseek-ai/dsh-typert-protocol",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "to": "node_modules/@deepseek-ai/dsh-llm",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "to": "node_modules/@deepseek-ai/dsh-scope",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "to": "node_modules/@deepseek-ai/schemastery",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-timeout",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-timeout",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/dsh-agent",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/dsh-code-runtime",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/dsh-llm",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/dsh-scope",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/dsh-session",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/dsh-user-approval",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-tools",
+                "to": "node_modules/@deepseek-ai/schemastery",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-typert-protocol",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-typert-protocol",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/dsh-agent",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/dsh-brand",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/dsh-invariants",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/dsh-llm",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/dsh-scope",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/dsh-session",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/dsh-system-prompt",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/dsh-user-approval",
+                "to": "node_modules/@deepseek-ai/schemastery",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/schemastery",
+                "to": "node_modules/@deepseek-ai/cosmokit",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/schemastery",
+                "to": "node_modules/@standard-schema/spec",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/dsh-cloudflare-browser-run",
+                "to": "node_modules/@deepseek-ai/cordis",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/dsh-cloudflare-browser-run",
+                "to": "node_modules/@deepseek-ai/dsh-tools",
+                "kind": "runtime"
+              },
+              {
+                "from": "node_modules/dsh-cloudflare-browser-run",
+                "to": "node_modules/@deepseek-ai/schemastery",
+                "kind": "runtime"
+              }
+            ],
+            "digest": "sha256:420420ef4411ce7be791126c356b3d4923a5e96739e4e65e443a3c9f26b2f678",
+            "unresolved": [
+              {
+                "from": "node_modules/@deepseek-ai/cordis",
+                "name": "@deepseek-ai/cordis-plugin-include",
+                "spec": "^1.0.6",
+                "kind": "peer"
+              },
+              {
+                "from": "node_modules/@deepseek-ai/cordis",
+                "name": "@deepseek-ai/cordis-plugin-loader",
+                "spec": "^1.0.2",
+                "kind": "peer"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -1,0 +1,20 @@
+name: DSH plugin upstream radar
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-radar:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: MicroMilo/upstream-radar@v0.22.0
+        with:
+          config: examples/github-actions/consumer/upstream-radar.config.json
+          fail-on: high

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "showcase:admission:reports": "pnpm run build && node scripts/showcase.mjs --write-reports",
     "showcase:radar": "pnpm run build && node scripts/radar-showcase.mjs",
     "showcase:radar:reports": "pnpm run build && node scripts/radar-showcase.mjs --write-reports",
+    "try:consumer": "node scripts/consumer-smoke.mjs",
     "try:dsh": "pnpm run build && node scripts/dsh-headless-showcase.mjs",
     "try:dsh:live": "pnpm run build && node scripts/dsh-headless-showcase.mjs --live-feeds",
     "try:dsh:report": "pnpm run build && node scripts/dsh-headless-showcase.mjs --write-report",

--- a/scripts/consumer-smoke.mjs
+++ b/scripts/consumer-smoke.mjs
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const packageJson = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'))
+const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const args = [
+  'dlx',
+  `--package=upstream-radar@${packageJson.version}`,
+  'upstream-radar',
+  'radar',
+  'check',
+  'examples/github-actions/consumer/upstream-radar.config.json',
+  '--frozen',
+  '--state',
+  ':memory:',
+  '--fail-on',
+  'high',
+  '--json',
+]
+
+const result = await new Promise((resolveResult, reject) => {
+  const child = spawn(command, args, { cwd: root, stdio: ['ignore', 'pipe', 'inherit'] })
+  const chunks = []
+  child.stdout.on('data', chunk => chunks.push(Buffer.from(chunk)))
+  child.on('error', reject)
+  child.on('close', code => {
+    const output = Buffer.concat(chunks).toString('utf8')
+    if (code !== 0) {
+      reject(new Error(`consumer check exited with code ${code}\n${output}`))
+      return
+    }
+    try {
+      resolveResult(JSON.parse(output))
+    } catch (error) {
+      reject(new Error(`consumer check did not return JSON: ${error instanceof Error ? error.message : String(error)}`))
+    }
+  })
+})
+
+if (result.sourceErrors.length > 0) {
+  throw new Error(`consumer check reported source errors: ${JSON.stringify(result.sourceErrors)}`)
+}
+
+console.log(JSON.stringify({
+  radarVersion: packageJson.version,
+  plugin: 'dsh-cloudflare-browser-run@0.1.1',
+  packagesQueried: result.packagesQueried,
+  releasePackagesQueried: result.releasePackagesQueried,
+  events: result.events.length,
+  activeVulnerabilities: Object.keys(result.state.activeVulnerabilities).length,
+  policy: result.policy,
+}, null, 2))

--- a/test/consumer.test.ts
+++ b/test/consumer.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'node:test'
+
+const root = fileURLToPath(new URL('../../', import.meta.url))
+
+describe('consumer smoke example', () => {
+  it('uses a real DSH plugin graph and the published Action contract', async () => {
+    const config = JSON.parse(await readFile(`${root}/examples/github-actions/consumer/upstream-radar.config.json`, 'utf8')) as {
+      schema?: unknown
+      projects?: Array<{
+        plugins?: Array<{
+          package?: { name?: unknown; version?: unknown }
+          manifest?: { dsh?: unknown }
+          graph?: { rootNodeId?: unknown; nodes?: unknown[]; edges?: unknown[] }
+        }>
+      }>
+    }
+    const workflow = await readFile(`${root}/.github/workflows/action-consumer-smoke.yml`, 'utf8')
+    const plugin = config.projects?.[0]?.plugins?.[0]
+
+    assert.equal(config.schema, 'upstream-radar.radar-config/v1alpha1')
+    assert.equal(plugin?.package?.name, 'dsh-cloudflare-browser-run')
+    assert.equal(plugin?.package?.version, '0.1.1')
+    assert.deepEqual(plugin?.manifest?.dsh, { bundle: { patch: './cordis.patch.yml' } })
+    assert.equal(plugin?.graph?.rootNodeId, 'node_modules/dsh-cloudflare-browser-run')
+    assert.ok((plugin?.graph?.nodes?.length ?? 0) >= 18)
+    assert.equal(plugin?.graph?.edges?.length, 65)
+    assert.match(workflow, /uses: MicroMilo\/upstream-radar@v0\.22\.0/)
+    assert.match(workflow, /config: examples\/github-actions\/consumer\/upstream-radar\.config\.json/)
+    assert.match(workflow, /fail-on: high/)
+    assert.match(workflow, /contents: read/)
+  })
+})


### PR DESCRIPTION
## What changed

- add a real consumer snapshot for `dsh-cloudflare-browser-run@0.1.1` with its resolved 18-package graph
- add a copyable workflow and README for DSH plugin projects
- add `pnpm run try:consumer`, which invokes the released `upstream-radar@0.22.0` package
- add a scheduled/manual dogfood workflow that uses `MicroMilo/upstream-radar@v0.22.0` from a GitHub runner
- add tests for the consumer config and Action contract

## Why

The generic Action example assumed that a consumer already had `upstream-radar.config.json`, but the repository did not provide a real configuration that could be run immediately. The old showcase config intentionally uses fictional package names and is not suitable for an external npm check.

This closes the first-use loop with a real DSH bundle. The local and GitHub-runner checks query 18 exact package versions and expose current DSH preview compatibility changes while keeping vulnerability policy independent.

## Safety

- the snapshot is reviewed evidence, not a safety certificate
- the Action remains frozen and does not install or execute plugin code
- source failures remain failures; the smoke does not convert an unavailable feed into a clean result

## Validation

- `pnpm run check`
- `pnpm test` — 108 passing
- `pnpm run try:consumer` — published 0.22.0, 18 packages, 15 release streams, 0 active vulnerabilities
- `pnpm run scan:self`
- `git diff --check`
