### PR TITLE
fix: publish valid GitHub Action manifest

### DIFF
--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.22.0
+      - uses: MicroMilo/upstream-radar@v0.22.1
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to Upstream Radar are documented here.
 
-## Unreleased
+## [0.22.1] - 2026-08-16
+
+### Fixed
+
+- Quote the Action's `:memory:` input description so GitHub's workflow runner accepts the manifest as valid YAML.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -195,18 +195,18 @@ If your team wants a scheduled CI gate before wiring a machine to a live DSH pro
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.22.0
+  - uses: MicroMilo/upstream-radar@v0.22.1
     with:
       config: upstream-radar.config.json
       fail-on: high
 ```
 
-The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability meets the threshold, and exits `1` for an operational or source error. It does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.22.0`, and pin the checkout Action in your workflow according to your repository's policy.
+The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability meets the threshold, and exits `1` for an operational or source error. It does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.22.1`, and pin the checkout Action in your workflow according to your repository's policy.
 
 The Action requires the caller to check out the repository first. It does not install the project's dependencies or run their lifecycle scripts; it only reads the committed graph and queries the configured upstream sources. For a fully explicit, lower-level invocation, the equivalent command is:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.22.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.22.1 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high --json
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -15,13 +15,13 @@ inputs:
     required: false
     default: high
   state:
-    description: Radar state path; use :memory: for an independent CI check.
+    description: 'Radar state path; use :memory: for an independent CI check.'
     required: false
     default: ':memory:'
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.22.0
+    default: 0.22.1
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -183,18 +183,18 @@ pnpm run try:dsh
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.22.0
+  - uses: MicroMilo/upstream-radar@v0.22.1
     with:
       config: upstream-radar.config.json
       fail-on: high
 ```
 
-这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；达到阈值时返回 `2`，运行或漏洞源出错时返回 `1`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.22.0` 的发布标签，并根据团队策略固定 checkout Action。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；达到阈值时返回 `2`，运行或漏洞源出错时返回 `1`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.22.1` 的发布标签，并根据团队策略固定 checkout Action。
 
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.22.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.22.1 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high --json
 ```
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -176,7 +176,7 @@ This is intentionally different from resolving the same package in a fresh npm p
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.22.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.22.1 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -190,7 +190,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.22.0
+  - uses: MicroMilo/upstream-radar@v0.22.1
     with:
       config: upstream-radar.config.json
       fail-on: high

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -16,7 +16,7 @@ The workflow runs on demand or weekly. It checks the committed graph against OSV
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.22.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.22.1 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.22.0
+      - uses: MicroMilo/upstream-radar@v0.22.1
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.22.0
+      - uses: MicroMilo/upstream-radar@v0.22.1
         with:
           config: upstream-radar.config.json
           fail-on: high

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/scripts/consumer-smoke.mjs
+++ b/scripts/consumer-smoke.mjs
@@ -5,10 +5,11 @@ import { dirname, resolve } from 'node:path'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const packageJson = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'))
+const radarVersion = process.env.UPSTREAM_RADAR_CONSUMER_VERSION ?? packageJson.version
 const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const args = [
   'dlx',
-  `--package=upstream-radar@${packageJson.version}`,
+  `--package=upstream-radar@${radarVersion}`,
   'upstream-radar',
   'radar',
   'check',
@@ -45,7 +46,7 @@ if (result.sourceErrors.length > 0) {
 }
 
 console.log(JSON.stringify({
-  radarVersion: packageJson.version,
+  radarVersion,
   plugin: 'dsh-cloudflare-browser-run@0.1.1',
   packagesQueried: result.packagesQueried,
   releasePackagesQueried: result.releasePackagesQueried,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.22.0'
+export const TOOL_VERSION = '0.22.1'

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -13,6 +13,7 @@ describe('reusable GitHub Action', () => {
     assert.equal(typeof packageJson.version, 'string')
     assert.match(action, /runs:\n\s+using: composite/)
     assert.match(action, new RegExp(`default: ${String(packageJson.version).replaceAll('.', '\\.')}`))
+    assert.match(action, /description: ['"]Radar state path; use :memory: for an independent CI check\.['"]/)
     assert.match(action, /uses: pnpm\/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6\.0\.10/)
     assert.match(action, /uses: actions\/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7\.0\.0/)
     assert.match(action, /RADAR_CONFIG: \$\{\{ inputs\.config \}\}/)

--- a/test/consumer.test.ts
+++ b/test/consumer.test.ts
@@ -27,7 +27,7 @@ describe('consumer smoke example', () => {
     assert.equal(plugin?.graph?.rootNodeId, 'node_modules/dsh-cloudflare-browser-run')
     assert.ok((plugin?.graph?.nodes?.length ?? 0) >= 18)
     assert.equal(plugin?.graph?.edges?.length, 65)
-    assert.match(workflow, /uses: MicroMilo\/upstream-radar@v0\.22\.0/)
+    assert.match(workflow, /uses: MicroMilo\/upstream-radar@v0\.22\.1/)
     assert.match(workflow, /config: examples\/github-actions\/consumer\/upstream-radar\.config\.json/)
     assert.match(workflow, /fail-on: high/)
     assert.match(workflow, /contents: read/)


### PR DESCRIPTION
## What changed

- quote the `:memory:` input description in `action.yml` so GitHub's runner accepts the manifest
- bump the package and Action references to patch release `0.22.1`
- keep the real DSH consumer smoke, docs, and dogfood workflow on the fixed tag
- add a regression assertion for the quoted metadata

## Why

The first real GitHub runner execution of `MicroMilo/upstream-radar@v0.22.0` failed before the composite Action started. YAML interpreted the unquoted `:memory:` text in the input description as invalid mapping syntax. Local TypeScript tests could not catch this because they inspected the file as text rather than loading it through the Actions runner.

This patch release is necessary because `v0.22.0` is already published and its tag cannot be safely rewritten.

## Validation

- `pnpm run check`
- `pnpm test` — 108 passing
- `UPSTREAM_RADAR_CONSUMER_VERSION=0.22.0 pnpm run try:consumer`
- `pnpm run scan:self`
- `git diff --check`
