### PR TITLE
feat: add compatibility rule benchmark

### DIFF
--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.23.0
+      - uses: MicroMilo/upstream-radar@v0.24.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.24.0] - 2026-08-16
+
+### Added
+
+- Add `benchmark compatibility` for an offline, no-network regression check of deterministic compatibility signals and the `breaking`/`any` CI gates.
+- Cover safe patches, analysis-only changes, DSH peer incompatibility, publisher-declared breaking changes, candidate dependency vulnerabilities, and incomplete graphs.
+
+### Safety
+
+- The benchmark does not install packages, load plugins, start DSH, or claim runtime compatibility; it checks the rule contract only.
+
 ## [0.23.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ The command fails unless DSH proves all four facts:
 
 This proof runs in CI on Node.js 22. See the executable [showcase contract](examples/dsh/README.md) and its checked-in [result](examples/dsh/reports/headless-smoke.json). Run `pnpm run try:dsh:live` to include a current OSV and npm poll before the DSH handoff.
 
+## Validate the compatibility rules
+
+Before wiring a project into a compatibility gate, run the offline rule benchmark:
+
+```bash
+pnpm dlx --package=upstream-radar@0.24.0 upstream-radar benchmark compatibility
+```
+
+It covers six contracts: a safe patch, a change that only needs project analysis, an incompatible DSH peer, a publisher-declared breaking release, a vulnerable candidate dependency, and an incomplete candidate graph. The command does not access the network, install a package, load a plugin, or start DSH. It checks the behavior of Radar's deterministic rules and the `breaking`/`any` gates; it is not a runtime compatibility proof.
+
 ## Run it in GitHub Actions
 
 If your team wants a scheduled CI gate before wiring a machine to a live DSH profile, commit the reviewed `upstream-radar.config.json` and copy [the example workflow](examples/github-actions/upstream-radar.yml). The reusable Action keeps the workflow to two meaningful steps:
@@ -195,7 +205,7 @@ If your team wants a scheduled CI gate before wiring a machine to a live DSH pro
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.23.0
+  - uses: MicroMilo/upstream-radar@v0.24.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -203,12 +213,12 @@ steps:
       fail-on-compatibility: breaking
 ```
 
-The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`; when the optional compatibility input is enabled, it also passes `--fail-on-compatibility breaking` or `any`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability or opted-in compatibility change meets its threshold, and exits `1` for an operational or source error. `breaking` catches confirmed or strong incompatibility signals; `any` catches every active compatibility event. The default is `never`, so vulnerability-only behavior stays unchanged. The Action does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.23.0`, and pin the checkout Action in your workflow according to your repository's policy.
+The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`; when the optional compatibility input is enabled, it also passes `--fail-on-compatibility breaking` or `any`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability or opted-in compatibility change meets its threshold, and exits `1` for an operational or source error. `breaking` catches confirmed or strong incompatibility signals; `any` catches every active compatibility event. The default is `never`, so vulnerability-only behavior stays unchanged. The Action does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.24.0`, and pin the checkout Action in your workflow according to your repository's policy.
 
 The Action requires the caller to check out the repository first. It does not install the project's dependencies or run their lifecycle scripts; it only reads the committed graph and queries the configured upstream sources. For a fully explicit, lower-level invocation, the equivalent command is:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.23.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.24.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -323,6 +333,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 - a network-free `doctor` command that checks local DSH registration, overlay/config alignment, state readability, and dependency coverage;
 - compatibility signals for Node.js, peers, exports, entrypoints, bundle paths, dependencies, and version boundaries;
 - an opt-in CI gate for confirmed/strong (`breaking`) or all (`any`) active compatibility changes;
+- an offline `benchmark compatibility` command that locks the deterministic rule and gate behavior into six reviewable contracts;
 - network-free Radar and real DSH runtime showcases.
 
 The bounded pre-install scanner remains available as a supporting collector:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,7 @@
 - [x] Publish a reusable composite GitHub Action for the frozen deterministic CI gate.
 - [x] Verify the published Action with a real DSH plugin consumer snapshot and a dogfood workflow.
 - [x] Add an opt-in compatibility-change gate for breaking DSH/plugin updates.
+- [x] Provide an offline compatibility-rule benchmark covering deterministic and analysis-only outcomes.
 - [ ] Re-check the installed and proposed graph in GitHub Actions.
 - [ ] Attach project evidence to a GitHub Issue only after routing policy permits it.
 - [ ] Generate an upgrade branch or Pull Request behind explicit approval.
@@ -76,4 +77,4 @@
 
 The pre-install scanner remains useful for collecting manifests and exact graphs. Signature, provenance, artifact identity, isolated detonation, and admission receipts are secondary tracks; they must not delay continuous vulnerability and compatibility monitoring.
 
-Plugin usefulness benchmarks remain out of scope.
+Plugin runtime usefulness, task success, cost, and latency benchmarks remain out of scope. The repository does include an offline compatibility-rule contract benchmark; it is a regression surface for deterministic Radar behavior, not a plugin capability score.

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.23.0
+    default: 0.24.0
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -176,6 +176,16 @@ pnpm run try:dsh
 
 运行 `pnpm run try:dsh:live`，可以在 DSH 投递前加入一次当前 OSV 与 npm 数据轮询。
 
+## 验证兼容性规则
+
+在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
+
+```bash
+pnpm dlx --package=upstream-radar@0.24.0 upstream-radar benchmark compatibility
+```
+
+它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
+
 ## 在 GitHub Actions 中运行
 
 如果团队想先用定时 CI 检查，而不是马上在 runner 里安装 DSH，可以把审查过的 `upstream-radar.config.json` 提交到仓库，然后复制[示例 workflow](../examples/github-actions/upstream-radar.yml)。现在可以直接使用可复用的 GitHub Action，workflow 只需要两个关键步骤：
@@ -183,7 +193,7 @@ pnpm run try:dsh
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.23.0
+  - uses: MicroMilo/upstream-radar@v0.24.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -191,12 +201,12 @@ steps:
       fail-on-compatibility: breaking
 ```
 
-这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.23.0` 的发布标签，并根据团队策略固定 checkout Action。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.24.0` 的发布标签，并根据团队策略固定 checkout Action。
 
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.23.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.24.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -277,7 +287,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查、默认可提交的相对 workspace、把审查过的图接入 CI 的可复用 GitHub Action、可选的 breaking/any 兼容性门禁，以及基于真实 DSH 插件的 consumer smoke。
+已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查、默认可提交的相对 workspace、把审查过的图接入 CI 的可复用 GitHub Action、可选的 breaking/any 兼容性门禁、离线的 `benchmark compatibility` 规则契约检查，以及基于真实 DSH 插件的 consumer smoke。
 
 `init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查、活动事件摘要和下一步提示，但不会替你刷新漏洞源，也不会自动升级插件。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 

--- a/docs/checks.zh-CN.md
+++ b/docs/checks.zh-CN.md
@@ -45,7 +45,7 @@
 - 在 microVM/容器中执行安装和加载，观察文件、网络、进程和凭据探测；
 - 恶意包情报、多源漏洞情报和 maintainer 异常监测；
 - SBOM、签名 review receipt、撤销和 `dsh plugin add/load` 的强制准入；
-- 插件能力、任务成功率、成本和延迟 benchmark。
+- 插件运行时能力、任务成功率、成本和延迟 benchmark；当前提供的是离线兼容性规则契约 benchmark，不是插件能力 benchmark。
 
 因此，真实样例即使当前风险检查全部通过，也会得到 `riskVerdict=allow`、`coverageVerdict=incomplete`、`verdict=review`。这不是保守文案，而是产品最重要的安全语义。
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -176,7 +176,7 @@ This is intentionally different from resolving the same package in a fresh npm p
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.23.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.24.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -190,7 +190,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.23.0
+  - uses: MicroMilo/upstream-radar@v0.24.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -208,7 +208,17 @@ with:
 
 `breaking` fails only when the program has a confirmed or strong incompatibility signal. `any` fails on every active compatibility event; `never` is the default.
 
-## Scene 15 — verify the consumer path with a real DSH plugin
+## Scene 15 — validate the rule contract offline
+
+The package includes a no-network compatibility benchmark for the deterministic gate itself:
+
+```bash
+pnpm dlx --package=upstream-radar@0.24.0 upstream-radar benchmark compatibility
+```
+
+It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
+
+## Scene 16 — verify the consumer path with a real DSH plugin
 
 The repository also carries a copyable consumer smoke under [`examples/github-actions/consumer`](../examples/github-actions/consumer/README.md). Its snapshot is built from the published `dsh-cloudflare-browser-run@0.1.1` package and its resolved graph, so the first-run path exercises real npm manifests and real DSH package names. A project should regenerate this snapshot with `radar init` after reviewing its own DSH profile.
 

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -22,7 +22,7 @@ fail-on-compatibility: breaking
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.23.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.24.0 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.23.0
+      - uses: MicroMilo/upstream-radar@v0.24.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.23.0
+      - uses: MicroMilo/upstream-radar@v0.24.0
         with:
           config: upstream-radar.config.json
           fail-on: high

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",
@@ -77,6 +77,7 @@
     "showcase:admission:reports": "pnpm run build && node scripts/showcase.mjs --write-reports",
     "showcase:radar": "pnpm run build && node scripts/radar-showcase.mjs",
     "showcase:radar:reports": "pnpm run build && node scripts/radar-showcase.mjs --write-reports",
+    "benchmark:compatibility": "pnpm run build && node dist/src/cli.js benchmark compatibility",
     "try:consumer": "node scripts/consumer-smoke.mjs",
     "try:dsh": "pnpm run build && node scripts/dsh-headless-showcase.mjs",
     "try:dsh:live": "pnpm run build && node scripts/dsh-headless-showcase.mjs --live-feeds",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import process from 'node:process'
 import { access, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { renderCompatibilityBenchmark, runCompatibilityBenchmark } from './compatibility-benchmark.js'
 import { assessCompatibilityChange } from './compatibility.js'
 import { createAnalysisTask, renderAgentAnalysisPrompt } from './dsh-analysis.js'
 import { createDoctorReport, renderDoctorReport } from './doctor.js'
@@ -53,6 +54,7 @@ Usage:
   upstream-radar doctor [config.json] [options]
   upstream-radar scan <directory> [--json] [--fail-on <warn|review|block|never>]
   upstream-radar inspect npm:<package>@<exact-version> [--deep] [--json] [--fail-on <warn|review|block|never>]
+  upstream-radar benchmark compatibility [--json]
   upstream-radar radar check <config.json> [--state <state.json>] [--frozen] [--fail-on <severity>] [--fail-on-compatibility <never|breaking|any>] [--json]
   upstream-radar radar watch <config.json> [--state <state.json>] [--interval <seconds>] [--once] [--frozen] [--fail-on <severity>] [--fail-on-compatibility <never|breaking|any>] [--json]
   upstream-radar radar status <config.json> [--state <state.json>] [--fail-on <severity>] [--fail-on-compatibility <never|breaking|any>] [--json]
@@ -67,6 +69,7 @@ Commands:
   doctor   check local Radar/DSH wiring without polling upstream sources
   scan     bounded, read-only inspection of a local package directory
   inspect  fetch and verify the exact npm artifact before inspecting its contents
+  benchmark run offline compatibility-rule contracts without network or plugin execution
   radar    monitor vulnerability changes, watch continuously, inspect status, or assess a candidate compatibility change
   task     inspect or acknowledge the durable DSH analysis outbox
 
@@ -168,6 +171,18 @@ async function readJson(path: string): Promise<unknown> {
   } catch {
     throw new Error(`${path} is not valid JSON`)
   }
+}
+
+async function runBenchmark(args: readonly string[]): Promise<number> {
+  if (args[0] !== 'compatibility') throw new Error('benchmark requires compatibility')
+  let json = false
+  for (const argument of args.slice(1)) {
+    if (argument === '--json') json = true
+    else throw new Error(`unknown option for benchmark: ${argument}`)
+  }
+  const report = runCompatibilityBenchmark()
+  process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderCompatibilityBenchmark(report))
+  return report.summary.failed === 0 ? 0 : 1
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -557,6 +572,7 @@ async function main(args: readonly string[]): Promise<number> {
   }
   if (command === 'init') return runInit(args.slice(1))
   if (command === 'doctor') return runDoctor(args.slice(1))
+  if (command === 'benchmark') return runBenchmark(args.slice(1))
   if (command === 'radar') return runRadar(args.slice(1))
   if (command === 'task') return runTask(args.slice(1))
   if (command !== 'scan' && command !== 'inspect') throw new Error(`unknown command: ${command}`)

--- a/src/compatibility-benchmark.ts
+++ b/src/compatibility-benchmark.ts
@@ -1,0 +1,222 @@
+import { assessCompatibilityChange } from './compatibility.js'
+import { emptyRadarState } from './radar.js'
+import { evaluateRadarPolicy, type RadarCompatibilityFailThreshold } from './radar-policy.js'
+import type {
+  CompatibilityDependencyCheck,
+  CompatibilityEvent,
+  PackageManifestSnapshot,
+  ProjectInventory,
+} from './radar-types.js'
+
+export const COMPATIBILITY_BENCHMARK_SCHEMA = 'upstream-radar.compatibility-benchmark/v1alpha1' as const
+
+type BenchmarkOutcome = 'pass' | 'fail'
+
+interface BenchmarkExpected {
+  breaking: BenchmarkOutcome
+  any: BenchmarkOutcome
+}
+
+interface BenchmarkCase {
+  id: string
+  title: string
+  previous: PackageManifestSnapshot
+  candidate: PackageManifestSnapshot
+  releaseNotes?: string
+  candidateDependencyCheck?: CompatibilityDependencyCheck
+  expected: BenchmarkExpected
+}
+
+export interface CompatibilityBenchmarkCaseResult {
+  id: string
+  title: string
+  event: boolean
+  signals: Array<{ code: string; confidence: string }>
+  actual: BenchmarkExpected
+  expected: BenchmarkExpected
+  passed: boolean
+}
+
+export interface CompatibilityBenchmarkReport {
+  schema: typeof COMPATIBILITY_BENCHMARK_SCHEMA
+  mode: 'offline-rules'
+  cases: CompatibilityBenchmarkCaseResult[]
+  summary: {
+    total: number
+    passed: number
+    failed: number
+  }
+  boundary: string
+}
+
+const benchmarkInventory: ProjectInventory = {
+  schema: 'upstream-radar.inventory/v1alpha1',
+  project: {
+    id: 'compatibility-benchmark',
+    name: 'Compatibility benchmark',
+    channels: ['stdout'],
+  },
+  environment: { nodeVersion: '22.18.0' },
+  plugins: [{
+    package: { ecosystem: 'npm', name: 'demo-dsh-plugin', version: '1.0.0' },
+    graph: {
+      schema: 'upstream-radar.dependency-graph/v1alpha1',
+      rootNodeId: 'demo-dsh-plugin',
+      nodes: [
+        { id: 'demo-dsh-plugin', name: 'demo-dsh-plugin', version: '1.0.0' },
+        { id: 'dsh-agent', name: '@deepseek-ai/dsh-agent', version: '0.0.1-rc.5' },
+        { id: 'dsh-invariants', name: '@deepseek-ai/dsh-invariants', version: '0.0.1-rc.5' },
+      ],
+      edges: [
+        { from: 'demo-dsh-plugin', to: 'dsh-agent', kind: 'peer' },
+        { from: 'demo-dsh-plugin', to: 'dsh-invariants', kind: 'peer' },
+      ],
+    },
+  }],
+}
+
+const dependencyAdvisory = {
+  id: 'GHSA-benchmark-transitive',
+  aliases: [],
+  summary: 'A transitive candidate dependency is vulnerable.',
+  details: 'Synthetic benchmark evidence only.',
+  severity: 'high' as const,
+  modified: '2026-08-16T00:00:00.000Z',
+  fixedVersions: ['3.0.0'],
+  references: [],
+}
+
+const cases: readonly BenchmarkCase[] = [
+  {
+    id: 'safe-patch',
+    title: 'patch with no structural change',
+    previous: { name: 'demo-dsh-plugin', version: '1.0.0', main: './dist/index.js' },
+    candidate: { name: 'demo-dsh-plugin', version: '1.0.1', main: './dist/index.js' },
+    expected: { breaking: 'pass', any: 'pass' },
+  },
+  {
+    id: 'analysis-only-entrypoint-change',
+    title: 'entrypoint change needs project analysis',
+    previous: { name: 'demo-dsh-plugin', version: '1.0.0', main: './dist/index.js' },
+    candidate: { name: 'demo-dsh-plugin', version: '1.1.0', main: './dist/next.js' },
+    expected: { breaking: 'pass', any: 'fail' },
+  },
+  {
+    id: 'dsh-peer-incompatible',
+    title: 'candidate excludes the installed DSH peer',
+    previous: { name: '@deepseek-ai/dsh-agent', version: '0.0.1-rc.5' },
+    candidate: {
+      name: '@deepseek-ai/dsh-agent',
+      version: '0.1.0-rc.6',
+      peerDependencies: { '@deepseek-ai/dsh-invariants': '^0.1.0-rc.6' },
+    },
+    expected: { breaking: 'fail', any: 'fail' },
+  },
+  {
+    id: 'publisher-breaking',
+    title: 'publisher explicitly declares a breaking release',
+    previous: { name: 'demo-dsh-plugin', version: '1.0.0', main: './dist/index.js' },
+    candidate: { name: 'demo-dsh-plugin', version: '1.0.1', main: './dist/index.js' },
+    releaseNotes: 'BREAKING CHANGE: the plugin now requires a new project session.',
+    expected: { breaking: 'fail', any: 'fail' },
+  },
+  {
+    id: 'candidate-transitive-vulnerability',
+    title: 'candidate graph contains a confirmed vulnerability',
+    previous: { name: 'demo-dsh-plugin', version: '1.0.0', main: './dist/index.js' },
+    candidate: { name: 'demo-dsh-plugin', version: '1.0.1', main: './dist/index.js' },
+    candidateDependencyCheck: {
+      status: 'checked',
+      nodeCount: 3,
+      unresolvedCount: 0,
+      findings: [{
+        package: { ecosystem: 'npm', name: 'parser', version: '2.9.0' },
+        advisory: dependencyAdvisory,
+        paths: [[
+          { ecosystem: 'npm', name: 'demo-dsh-plugin', version: '1.0.1' },
+          { ecosystem: 'npm', name: 'parser', version: '2.9.0' },
+        ]],
+      }],
+    },
+    expected: { breaking: 'fail', any: 'fail' },
+  },
+  {
+    id: 'incomplete-candidate-graph',
+    title: 'incomplete graph stays analysis-only under breaking gate',
+    previous: { name: 'demo-dsh-plugin', version: '1.0.0', main: './dist/index.js' },
+    candidate: { name: 'demo-dsh-plugin', version: '1.0.1', main: './dist/index.js' },
+    candidateDependencyCheck: {
+      status: 'incomplete',
+      nodeCount: 3,
+      unresolvedCount: 1,
+      findings: [],
+    },
+    expected: { breaking: 'pass', any: 'fail' },
+  },
+]
+
+function policyOutcome(event: CompatibilityEvent | undefined, threshold: RadarCompatibilityFailThreshold): BenchmarkOutcome {
+  const state = emptyRadarState()
+  if (event !== undefined) {
+    state.activeCompatibility[event.incidentId] = { key: event.incidentId, event }
+  }
+  return evaluateRadarPolicy(state, 'never', threshold).status === 'fail' ? 'fail' : 'pass'
+}
+
+export function runCompatibilityBenchmark(): CompatibilityBenchmarkReport {
+  const results = cases.map((item): CompatibilityBenchmarkCaseResult => {
+    const event = assessCompatibilityChange(benchmarkInventory, {
+      previous: item.previous,
+      candidate: item.candidate,
+      detectedAt: '2026-08-16T00:00:00.000Z',
+      ...(item.releaseNotes === undefined ? {} : { releaseNotes: item.releaseNotes }),
+      ...(item.candidateDependencyCheck === undefined ? {} : {
+        candidateDependencyChecks: new Map([['npm:demo-dsh-plugin@1.0.1', item.candidateDependencyCheck]]),
+        candidateDependencyStatus: 'checked' as const,
+      }),
+    })
+    const actual = {
+      breaking: policyOutcome(event, 'breaking'),
+      any: policyOutcome(event, 'any'),
+    }
+    const passed = actual.breaking === item.expected.breaking && actual.any === item.expected.any
+    return {
+      id: item.id,
+      title: item.title,
+      event: event !== undefined,
+      signals: event?.signals.map(signal => ({ code: signal.code, confidence: signal.confidence })) ?? [],
+      actual,
+      expected: item.expected,
+      passed,
+    }
+  })
+  const passed = results.filter(item => item.passed).length
+  return {
+    schema: COMPATIBILITY_BENCHMARK_SCHEMA,
+    mode: 'offline-rules',
+    cases: results,
+    summary: {
+      total: results.length,
+      passed,
+      failed: results.length - passed,
+    },
+    boundary: 'This checks deterministic rule and gate behavior only. It does not load a plugin, run DSH, or prove runtime compatibility.',
+  }
+}
+
+export function renderCompatibilityBenchmark(report: CompatibilityBenchmarkReport): string {
+  const lines = [
+    'Compatibility benchmark (offline rules; no network or plugin execution)',
+    '',
+  ]
+  for (const item of report.cases) {
+    const mark = item.passed ? 'PASS' : 'FAIL'
+    lines.push(`${mark} ${item.id}: ${item.title} — breaking=${item.actual.breaking}, any=${item.actual.any}`)
+    if (!item.passed) {
+      lines.push(`  expected: breaking=${item.expected.breaking}, any=${item.expected.any}`)
+    }
+  }
+  lines.push('', `Result: ${report.summary.passed}/${report.summary.total} benchmark contracts passed.`)
+  lines.push(report.boundary)
+  return `${lines.join('\n')}\n`
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,13 @@ export {
   type ReleaseSource,
 } from './radar.js'
 export { assessCompatibilityChange, assessCompatibilityChanges, type CompatibilityChangeInput } from './compatibility.js'
+export {
+  COMPATIBILITY_BENCHMARK_SCHEMA,
+  renderCompatibilityBenchmark,
+  runCompatibilityBenchmark,
+  type CompatibilityBenchmarkCaseResult,
+  type CompatibilityBenchmarkReport,
+} from './compatibility-benchmark.js'
 export { createAnalysisTask, renderAgentAnalysisGroupPrompt, renderAgentAnalysisPrompt, renderDshAnalysisPrompt } from './dsh-analysis.js'
 export { parsePackageManifestSnapshot, parseRadarConfig } from './inventory.js'
 export {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.23.0'
+export const TOOL_VERSION = '0.24.0'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -27,6 +27,12 @@ describe('CLI option parsing', () => {
     assert.match(help.stdout, /--fail-on-compatibility <value>\s+CI gate: never\|breaking\|any/)
     assert.match(help.stdout, /--dsh-patch <path>\s+write a self-contained DSH --patch overlay/)
 
+    const benchmark = spawnSync(process.execPath, [cli, 'benchmark', 'compatibility', '--json'], { encoding: 'utf8' })
+    assert.equal(benchmark.status, 0)
+    const benchmarkReport = JSON.parse(benchmark.stdout) as { mode: string; summary: { total: number; failed: number } }
+    assert.equal(benchmarkReport.mode, 'offline-rules')
+    assert.deepEqual(benchmarkReport.summary, { total: 6, passed: 6, failed: 0 })
+
     const blockedDoctor = spawnSync(process.execPath, [cli, 'doctor', resolve(tmpdir(), `upstream-radar-missing-${process.pid}.json`)], { encoding: 'utf8' })
     assert.equal(blockedDoctor.status, 1)
     assert.match(blockedDoctor.stdout, /Status: BLOCKED/)

--- a/test/compatibility-benchmark.test.ts
+++ b/test/compatibility-benchmark.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { renderCompatibilityBenchmark, runCompatibilityBenchmark } from '../src/compatibility-benchmark.js'
+
+describe('compatibility benchmark', () => {
+  it('keeps the rule and CI-gate contracts explicit and passing', () => {
+    const report = runCompatibilityBenchmark()
+    assert.equal(report.mode, 'offline-rules')
+    assert.deepEqual(report.summary, { total: 6, passed: 6, failed: 0 })
+    assert.deepEqual(report.cases.map(item => item.id), [
+      'safe-patch',
+      'analysis-only-entrypoint-change',
+      'dsh-peer-incompatible',
+      'publisher-breaking',
+      'candidate-transitive-vulnerability',
+      'incomplete-candidate-graph',
+    ])
+    assert.equal(report.cases.every(item => item.passed), true)
+    assert.equal(report.cases.find(item => item.id === 'analysis-only-entrypoint-change')?.actual.breaking, 'pass')
+    assert.equal(report.cases.find(item => item.id === 'analysis-only-entrypoint-change')?.actual.any, 'fail')
+    assert.equal(report.cases.find(item => item.id === 'dsh-peer-incompatible')?.actual.breaking, 'fail')
+    assert.match(renderCompatibilityBenchmark(report), /6\/6 benchmark contracts passed/)
+  })
+})

--- a/test/consumer.test.ts
+++ b/test/consumer.test.ts
@@ -27,7 +27,7 @@ describe('consumer smoke example', () => {
     assert.equal(plugin?.graph?.rootNodeId, 'node_modules/dsh-cloudflare-browser-run')
     assert.ok((plugin?.graph?.nodes?.length ?? 0) >= 18)
     assert.equal(plugin?.graph?.edges?.length, 65)
-    assert.match(workflow, /uses: MicroMilo\/upstream-radar@v0\.23\.0/)
+    assert.match(workflow, /uses: MicroMilo\/upstream-radar@v0\.24\.0/)
     assert.match(workflow, /config: examples\/github-actions\/consumer\/upstream-radar\.config\.json/)
     assert.match(workflow, /fail-on: high/)
     assert.match(workflow, /contents: read/)


### PR DESCRIPTION
## What changed

- add `upstream-radar benchmark compatibility [--json]`;
- cover six offline contracts: safe patch, analysis-only entrypoint change, incompatible DSH peer, publisher-declared breaking release, candidate transitive vulnerability, and incomplete candidate graph;
- expose the benchmark in the npm package, README/showcase, and roadmap;
- bump the package and reusable Action to `v0.24.0`.

## Why

The compatibility gate is now a real CI decision, so its behavior needs a small, repeatable contract surface. The benchmark proves that `breaking` catches confirmed/strong signals while leaving `needs-analysis` events for DSH analysis, and that `any` intentionally catches every active compatibility event.

This is deliberately not a runtime plugin benchmark: it does not use the network, install packages, load plugin code, or start DSH. The real `dsh-cloudflare-browser-run@0.1.1` consumer workflow remains the integration proof.

## Verification

- `pnpm test` — 110 tests passed;
- `pnpm run benchmark:compatibility` — 6/6 contracts passed;
- `pnpm run scan:self` — no findings in implemented static checks;
- `pnpm run check` and `git diff --check` — passed;
- `npm pack --dry-run` — includes the compiled benchmark and updated CLI.
