### PR TITLE
feat: add DSH compatibility matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,6 @@ jobs:
       - if: matrix.node == 22
         run: pnpm run try:dsh
       - if: matrix.node == 22
+        run: pnpm run showcase:dsh-probe
+      - if: matrix.node == 22
         run: pnpm pack --pack-destination /tmp

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,7 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm test
       - run: pnpm run try:dsh
+      - run: pnpm run showcase:dsh-probe
       - run: pnpm pack --pack-destination /tmp
       - name: Install OIDC-capable npm CLI
         run: npm install --global --ignore-scripts npm@11.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.26.0] - 2026-08-16
+
+### Added
+
+- Add `probe dsh-matrix` for testing one exact plugin tarball against two to eight exact DSH versions in isolated profiles.
+- Aggregate per-version load results conservatively: any `incompatible` blocks the matrix, and any `unknown` prevents a green result.
+- Add a real `0.1.0-rc.3` plus `0.1.0-rc.6` matrix showcase and run it in CI and the publish workflow.
+
+### Safety
+
+- Matrix runs are sequential and bounded; every version gets its own temporary `DSH_HOME` and the same artifact digest.
+- The matrix remains load-only evidence. It does not execute plugin business actions, benchmark capabilities, or prove package/dependency safety.
+
 ## [0.25.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This proof runs in CI on Node.js 22. See the executable [showcase contract](exam
 Before wiring a project into a compatibility gate, run the offline rule benchmark:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar benchmark compatibility
 ```
 
 It covers six contracts: a safe patch, a change that only needs project analysis, an incompatible DSH peer, a publisher-declared breaking release, a vulnerable candidate dependency, and an incomplete candidate graph. The command does not access the network, install a package, load a plugin, or start DSH. It checks the behavior of Radar's deterministic rules and the `breaking`/`any` gates; it is not a runtime compatibility proof.
@@ -206,7 +206,7 @@ When you have an exact plugin artifact and want to know whether one exact DSH re
 # Pack an exact npm release without running its lifecycle scripts.
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -229,6 +229,18 @@ pnpm run showcase:dsh-probe
 
 It exercises a loadable bundle, a bundle patch DSH rejects, and a package that remains `unknown` because it declares `postinstall`.
 
+To compare a plugin against more than one DSH release, use the matrix form:
+
+```bash
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar probe dsh-matrix \
+  ./dsh-plugin-1.2.3.tgz \
+  --dsh-version 0.1.0-rc.3 \
+  --dsh-version 0.1.0-rc.6 \
+  --json
+```
+
+The matrix runs versions one at a time in separate temporary profiles and evaluates the same artifact each time. It needs at least two distinct exact versions and accepts at most eight. The aggregate is `incompatible` if any version is incompatible, `unknown` if none is incompatible but at least one result is unknown, and `compatible` only when every tested version loads successfully. The JSON shape is documented in the [matrix result schema](schemas/dsh-load-matrix.schema.json).
+
 ## Run it in GitHub Actions
 
 If your team wants a scheduled CI gate before wiring a machine to a live DSH profile, commit the reviewed `upstream-radar.config.json` and copy [the example workflow](examples/github-actions/upstream-radar.yml). The reusable Action keeps the workflow to two meaningful steps:
@@ -236,7 +248,7 @@ If your team wants a scheduled CI gate before wiring a machine to a live DSH pro
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.25.0
+  - uses: MicroMilo/upstream-radar@v0.26.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -244,12 +256,12 @@ steps:
       fail-on-compatibility: breaking
 ```
 
-The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`; when the optional compatibility input is enabled, it also passes `--fail-on-compatibility breaking` or `any`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability or opted-in compatibility change meets its threshold, and exits `1` for an operational or source error. `breaking` catches confirmed or strong incompatibility signals; `any` catches every active compatibility event. The default is `never`, so vulnerability-only behavior stays unchanged. The Action does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.25.0`, and pin the checkout Action in your workflow according to your repository's policy.
+The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`; when the optional compatibility input is enabled, it also passes `--fail-on-compatibility breaking` or `any`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability or opted-in compatibility change meets its threshold, and exits `1` for an operational or source error. `breaking` catches confirmed or strong incompatibility signals; `any` catches every active compatibility event. The default is `never`, so vulnerability-only behavior stays unchanged. The Action does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.26.0`, and pin the checkout Action in your workflow according to your repository's policy.
 
 The Action requires the caller to check out the repository first. It does not install the project's dependencies or run their lifecycle scripts; it only reads the committed graph and queries the configured upstream sources. For a fully explicit, lower-level invocation, the equivalent command is:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -365,7 +377,7 @@ Advisories, release notes, links, package names, and repository strings remain u
 - compatibility signals for Node.js, peers, exports, entrypoints, bundle paths, dependencies, and version boundaries;
 - an opt-in CI gate for confirmed/strong (`breaking`) or all (`any`) active compatibility changes;
 - an offline `benchmark compatibility` command that locks the deterministic rule and gate behavior into six reviewable contracts;
-- a disposable `probe dsh-load` command that checks one exact DSH version against one exact bundle and returns `compatible`, `incompatible`, or `unknown`;
+- disposable `probe dsh-load` and `probe dsh-matrix` commands that check one exact DSH version or a bounded exact-version matrix against one bundle and return `compatible`, `incompatible`, or `unknown`;
 - network-free Radar and real DSH runtime showcases.
 
 The bounded pre-install scanner remains available as a supporting collector:
@@ -382,6 +394,7 @@ pnpm dlx --package=upstream-radar@latest upstream-radar inspect npm:dsh-cloudfla
 - Candidate upgrade graphs are resolved only for a bounded earliest prefix. A candidate with an incomplete or unavailable graph is not recommended; later unqueried candidates remain visibly unchecked. Pass `--no-deep-candidates` to opt out of this extra registry work.
 - Compatibility CI gating is opt-in: `--fail-on-compatibility breaking` fails on confirmed or strong incompatibility signals, while `any` fails on every active compatibility event; neither setting claims that a candidate is safe.
 - `probe dsh-load` is intentionally narrower than a security scan: a successful load proves only that the selected DSH profile accepted the bundle configuration. It does not execute plugin actions, compare capabilities, or grant admission to an unreviewed package.
+- `probe dsh-matrix` is intentionally sequential and bounded to eight versions. An incomplete matrix is not green: `unknown` propagates to the aggregate result until every selected DSH version has a reliable load result.
 - `radar check/watch --frozen` intentionally uses the graph committed in the config for CI; it does not prove that the installed DSH profile has not changed. Without `--frozen`, native DSH and CLI polling refresh the selected profile first.
 - `radar status` is a local snapshot only: it does not refresh OSV/npm/GitHub data, and it cannot prove that a source is current until a check has completed. Its next steps are guidance, not an automatic upgrade or safety decision.
 - `doctor` checks local wiring only; it cannot prove that a running DSH process has delivered a task to a model or that upstream feeds are current.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@
 - [x] Keep CLI `radar check/watch` aligned with the refreshed native DSH profile path.
 - [ ] Parse the native pnpm lockfile for pre-install and CI inspection.
 - [x] Run a plugin bundle-load probe in a disposable DSH profile for one explicit DSH version.
-- [ ] Record `compatible`, `incompatible`, and `unknown` against an explicit DSH version matrix.
+- [x] Record `compatible`, `incompatible`, and `unknown` against an explicit DSH version matrix.
 
 ## Milestone 2 — reliable project routing
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.25.0
+    default: 0.26.0
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -181,7 +181,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -194,7 +194,7 @@ pnpm dlx --package=upstream-radar@0.25.0 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -217,6 +217,20 @@ pnpm run showcase:dsh-probe
 
 它会展示一个能加载的 bundle、一个被 DSH 拒绝的 bundle，以及一个因为声明了 `postinstall` 而只能得到 `unknown` 的包。
 
+如果要比较多个 DSH 版本，可以使用矩阵入口：
+
+```bash
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar probe dsh-matrix \
+  ./dsh-plugin-1.2.3.tgz \
+  --dsh-version 0.1.0-rc.3 \
+  --dsh-version 0.1.0-rc.6 \
+  --json
+```
+
+它会把同一个发布物依次放进不同的临时 profile 中测试。矩阵至少需要两个不同的精确版本，最多八个。只要有一个版本不兼容，汇总就是 `incompatible`；没有不兼容但有 `unknown`，汇总就是 `unknown`；只有全部通过才是 `compatible`。
+
+JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json)。
+
 ## 在 GitHub Actions 中运行
 
 如果团队想先用定时 CI 检查，而不是马上在 runner 里安装 DSH，可以把审查过的 `upstream-radar.config.json` 提交到仓库，然后复制[示例 workflow](../examples/github-actions/upstream-radar.yml)。现在可以直接使用可复用的 GitHub Action，workflow 只需要两个关键步骤：
@@ -224,7 +238,7 @@ pnpm run showcase:dsh-probe
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.25.0
+  - uses: MicroMilo/upstream-radar@v0.26.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -232,12 +246,12 @@ steps:
       fail-on-compatibility: breaking
 ```
 
-这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.25.0` 的发布标签，并根据团队策略固定 checkout Action。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.26.0` 的发布标签，并根据团队策略固定 checkout Action。
 
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -320,7 +334,7 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查、默认可提交的相对 workspace、把审查过的图接入 CI 的可复用 GitHub Action、可选的 breaking/any 兼容性门禁、离线的 `benchmark compatibility` 规则契约检查，以及基于真实 DSH 插件的 consumer smoke。
 
-此外支持一次性的 `probe dsh-load`：在临时 DSH profile 中针对一个精确 DSH 版本加载一个精确 tarball，并返回 `compatible`、`incompatible` 或 `unknown`。它是加载兼容性证据，不是安全准入，也不是插件能力 benchmark。
+此外支持一次性的 `probe dsh-load` 和有界的 `probe dsh-matrix`：在临时 DSH profile 中针对一个或多个精确 DSH 版本加载一个精确 tarball，并返回 `compatible`、`incompatible` 或 `unknown`。它是加载兼容性证据，不是安全准入，也不是插件能力 benchmark。
 
 `init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查、活动事件摘要和下一步提示，但不会替你刷新漏洞源，也不会自动升级插件。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
 
@@ -329,6 +343,8 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 `doctor` 只检查本地接线，不能证明 DSH 进程已经把任务交给模型，也不能证明漏洞源当前可用。
 
 `probe dsh-load` 只证明选定 DSH 版本是否登记并加载了 bundle 配置；即使结果是 `compatible`，也不代表插件安全、业务动作可用或模型效果合格。要评估依赖漏洞，仍然使用 Radar 的依赖图和 OSV 监控。
+
+`probe dsh-matrix` 最多检查八个版本，并且逐个运行；只要还有一个版本是 `unknown`，汇总结果就不会变成 `compatible`。
 
 候选依赖图默认只覆盖按版本排序的有限前缀，后续未查询版本会在事件中显示为未完整检查。遇到 registry 或 OSV 不可用时，Radar 保留不确定性并发出告警，不会生成“已安全”的结论。
 

--- a/docs/checks.zh-CN.md
+++ b/docs/checks.zh-CN.md
@@ -19,7 +19,7 @@
 | 去重与恢复 | 重启、重复轮询是否丢失、刷屏或投递过期任务 | 保存活跃漏洞、活跃兼容性问题和待分析任务；同一 incident 的新任务替换旧任务，resolved 会撤销旧任务 | 至少一次投递，不变不重复，不过期投递 |
 | 源失败与健康 | OSV、npm release 或候选依赖图暂时查不到时，是否会被误判成“没有漏洞”，以及负责人能否知道源长期不可用 | 保留上一次确认的漏洞状态，不生成假的 `resolved`，仍继续投递已有 DSH 任务；连续 3 次失败生成持久 `source-health` DSH notice，恢复后 `resolved`；CLI/JSON 返回源警告 | `sourceErrors: osv/npm-releases/npm-candidate-graphs`、源健康状态、source-health 生命周期 |
 | 本地接线 | DSH profile 是否登记 Radar、overlay 是否指向同一份配置和状态、状态是否可读、必需依赖是否完整 | `doctor` 只读本地 manifest、配置、overlay 和状态，不访问 OSV/npm/GitHub，也不执行插件代码 | `READY`、`READY WITH WARNINGS` 或 `BLOCKED` |
-| DSH 加载兼容性 | 一个精确 DSH 版本能否加载一个精确插件 tarball 的 bundle 配置 | 先检查包内 `dsh.bundle.patch` 和 lifecycle scripts；再在临时 `headless` profile 中安装、登记并运行 `--dump-config` | `compatible`、`incompatible` 或 `unknown`；只代表加载结果，不代表安全或能力 |
+| DSH 加载兼容性 | 一个或多个精确 DSH 版本能否加载一个精确插件 tarball 的 bundle 配置 | 先检查包内 `dsh.bundle.patch` 和 lifecycle scripts；再把同一发布物依次放进临时 `headless` profile，安装、登记并运行 `--dump-config` | `compatible`、`incompatible` 或 `unknown`；只代表加载结果，不代表安全或能力 |
 
 ## 支持性的安装前检查
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -176,7 +176,7 @@ This is intentionally different from resolving the same package in a fresh npm p
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -190,7 +190,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.25.0
+  - uses: MicroMilo/upstream-radar@v0.26.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -213,7 +213,7 @@ with:
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -227,7 +227,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```
@@ -241,6 +241,8 @@ pnpm run showcase:dsh-probe
 ```
 
 This is a runtime compatibility proof for one DSH version, not a package-security admission, a plugin capability benchmark, or a test of business actions.
+
+The same showcase also runs the loadable fixture against DSH `0.1.0-rc.3` and `0.1.0-rc.6`. The matrix is green only because both exact versions complete all five stages; if one version timed out or could not be loaded, the aggregate would remain `unknown` rather than silently passing.
 
 ## Live sources
 

--- a/examples/dsh/README.md
+++ b/examples/dsh/README.md
@@ -35,3 +35,5 @@ pnpm run showcase:dsh-probe
 ```
 
 That showcase reports `compatible`, `incompatible`, and `unknown` independently. A successful result means only that DSH loaded the bundle configuration; it does not execute plugin business actions or replace the dependency and OSV checks.
+
+The showcase also exercises the matrix form against DSH `0.1.0-rc.3` and `0.1.0-rc.6`. The aggregate result is compatible only when both independent profiles load the same artifact.

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -22,7 +22,7 @@ fail-on-compatibility: breaking
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.25.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.26.0 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.25.0
+      - uses: MicroMilo/upstream-radar@v0.26.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.25.0
+      - uses: MicroMilo/upstream-radar@v0.26.0
         with:
           config: upstream-radar.config.json
           fail-on: high

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/schemas/dsh-load-matrix.schema.json
+++ b/schemas/dsh-load-matrix.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MicroMilo/upstream-radar/blob/main/schemas/dsh-load-matrix.schema.json",
+  "title": "Upstream Radar DSH load matrix report",
+  "description": "Load-only evidence for one exact DSH bundle tested against a bounded set of exact DSH versions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "probe",
+    "scope",
+    "artifact",
+    "dshVersions",
+    "reports",
+    "summary",
+    "result",
+    "reason",
+    "boundary"
+  ],
+  "properties": {
+    "schema": { "const": "upstream-radar.dsh-load-matrix/v1alpha1" },
+    "probe": { "const": "dsh-matrix" },
+    "scope": { "const": "bundle-load-only" },
+    "artifact": { "$ref": "#/$defs/artifact" },
+    "dshVersions": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 8,
+      "items": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$" },
+      "uniqueItems": true
+    },
+    "reports": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 8,
+      "items": { "$ref": "#/$defs/probeReport" }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "compatible", "incompatible", "unknown"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 2, "maximum": 8 },
+        "compatible": { "type": "integer", "minimum": 0 },
+        "incompatible": { "type": "integer", "minimum": 0 },
+        "unknown": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "result": { "enum": ["compatible", "incompatible", "unknown"] },
+    "reason": { "type": "string", "maxLength": 2048 },
+    "boundary": { "type": "string", "maxLength": 2048 }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1, "maxLength": 4096 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "name": { "type": "string", "minLength": 1, "maxLength": 214 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "bundlePatch": { "type": "string", "minLength": 1, "maxLength": 4096 },
+        "findings": { "type": "array", "maxItems": 32, "items": { "type": "string", "maxLength": 256 } }
+      }
+    },
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["passed", "failed", "skipped"] },
+        "code": { "type": ["integer", "null"] },
+        "detail": { "type": "string", "maxLength": 2048 },
+        "output": { "type": "string", "maxLength": 2048 }
+      }
+    },
+    "probeReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "probe", "scope", "dshVersion", "artifact", "stages", "result", "reason", "boundary"],
+      "properties": {
+        "schema": { "const": "upstream-radar.dsh-load-probe/v1alpha1" },
+        "probe": { "const": "dsh-load" },
+        "scope": { "const": "bundle-load-only" },
+        "dshVersion": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$" },
+        "artifact": { "$ref": "#/$defs/artifact" },
+        "stages": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["artifact", "profile", "install", "registration", "load"],
+          "properties": {
+            "artifact": { "$ref": "#/$defs/stage" },
+            "profile": { "$ref": "#/$defs/stage" },
+            "install": { "$ref": "#/$defs/stage" },
+            "registration": { "$ref": "#/$defs/stage" },
+            "load": { "$ref": "#/$defs/stage" }
+          }
+        },
+        "result": { "enum": ["compatible", "incompatible", "unknown"] },
+        "reason": { "type": "string", "maxLength": 2048 },
+        "profileDirectory": { "type": "string", "maxLength": 4096 },
+        "boundary": { "type": "string", "maxLength": 2048 }
+      }
+    }
+  }
+}

--- a/scripts/dsh-load-probe-showcase.mjs
+++ b/scripts/dsh-load-probe-showcase.mjs
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path'
 
 const ROOT = resolve(import.meta.dirname, '..')
 const DSH_VERSION = '0.1.0-rc.6'
+const MATRIX_VERSIONS = ['0.1.0-rc.3', '0.1.0-rc.6']
 const PNPM = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 
 function run(command, args, options = {}) {
@@ -55,6 +56,23 @@ async function probe(tarball) {
   }
 }
 
+async function probeMatrix(tarball) {
+  const result = await run(process.execPath, [
+    join(ROOT, 'dist/src/cli.js'),
+    'probe',
+    'dsh-matrix',
+    tarball,
+    '--dsh-version',
+    MATRIX_VERSIONS.join(','),
+    '--json',
+  ])
+  if (result.stdout.trim() === '') throw new Error(`matrix probe returned no JSON:\n${result.stderr}`)
+  return {
+    exitCode: result.code,
+    report: JSON.parse(result.stdout),
+  }
+}
+
 const scratch = await mkdtemp(join(tmpdir(), 'upstream-radar-dsh-probe-showcase-'))
 try {
   const cases = [
@@ -63,12 +81,14 @@ try {
     ['probe-unknown-dsh-plugin', 'unknown'],
   ]
   const results = []
+  let compatibleTarball
   for (const [fixture, expected] of cases) {
     const tarball = await packFixture(fixture, join(scratch, 'tarballs', fixture))
     const result = await probe(tarball)
     if (result.report.result !== expected) {
       throw new Error(`${fixture} expected ${expected}, got ${result.report.result}`)
     }
+    if (fixture === 'probe-compatible-dsh-plugin') compatibleTarball = tarball
     results.push({
       fixture,
       result: result.report.result,
@@ -77,10 +97,20 @@ try {
       stages: Object.fromEntries(Object.entries(result.report.stages).map(([stage, value]) => [stage, value.status])),
     })
   }
+  if (compatibleTarball === undefined) throw new Error('compatible showcase fixture was not packed')
+  const matrix = await probeMatrix(compatibleTarball)
+  if (matrix.report.result !== 'compatible') throw new Error(`matrix expected compatible, got ${matrix.report.result}`)
   console.log(JSON.stringify({
     dshVersion: DSH_VERSION,
+    matrixVersions: MATRIX_VERSIONS,
     scope: 'bundle-load-only',
     results,
+    matrix: {
+      result: matrix.report.result,
+      exitCode: matrix.exitCode,
+      summary: matrix.report.summary,
+      reason: matrix.report.reason,
+    },
   }, null, 2))
 } finally {
   await rm(scratch, { recursive: true, force: true })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { access, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { renderCompatibilityBenchmark, runCompatibilityBenchmark } from './compatibility-benchmark.js'
 import { assessCompatibilityChange } from './compatibility.js'
-import { probeDshLoad, renderDshLoadProbe } from './dsh-probe.js'
+import { probeDshLoad, probeDshLoadMatrix, renderDshLoadMatrix, renderDshLoadProbe } from './dsh-probe.js'
 import { createAnalysisTask, renderAgentAnalysisPrompt } from './dsh-analysis.js'
 import { createDoctorReport, renderDoctorReport } from './doctor.js'
 import { GitHubReleaseClient } from './github-release.js'
@@ -56,6 +56,7 @@ Usage:
   upstream-radar scan <directory> [--json] [--fail-on <warn|review|block|never>]
   upstream-radar inspect npm:<package>@<exact-version> [--deep] [--json] [--fail-on <warn|review|block|never>]
   upstream-radar probe dsh-load <package.tgz> [--dsh-version <exact-version>] [--timeout <seconds>] [--keep-profile] [--json]
+  upstream-radar probe dsh-matrix <package.tgz> --dsh-version <v1>[,<v2>,...] [--timeout <seconds>] [--keep-profile] [--json]
   upstream-radar benchmark compatibility [--json]
   upstream-radar radar check <config.json> [--state <state.json>] [--frozen] [--fail-on <severity>] [--fail-on-compatibility <never|breaking|any>] [--json]
   upstream-radar radar watch <config.json> [--state <state.json>] [--interval <seconds>] [--once] [--frozen] [--fail-on <severity>] [--fail-on-compatibility <never|breaking|any>] [--json]
@@ -71,7 +72,7 @@ Commands:
   doctor   check local Radar/DSH wiring without polling upstream sources
   scan     bounded, read-only inspection of a local package directory
   inspect  fetch and verify the exact npm artifact before inspecting its contents
-  probe    run a bounded DSH bundle-load check in a disposable profile
+  probe    run a bounded DSH bundle-load check or version matrix in disposable profiles
   benchmark run offline compatibility-rule contracts without network or plugin execution
   radar    monitor vulnerability changes, watch continuously, inspect status, or assess a candidate compatibility change
   task     inspect or acknowledge the durable DSH analysis outbox
@@ -189,10 +190,11 @@ async function runBenchmark(args: readonly string[]): Promise<number> {
 }
 
 async function runProbe(args: readonly string[]): Promise<number> {
-  if (args[0] !== 'dsh-load') throw new Error('probe requires dsh-load')
+  const mode = args[0]
+  if (mode !== 'dsh-load' && mode !== 'dsh-matrix') throw new Error('probe requires dsh-load or dsh-matrix')
   const packagePath = args[1]
-  if (packagePath === undefined || packagePath.startsWith('-')) throw new Error('probe dsh-load requires a package.tgz file')
-  let dshVersion: string | undefined
+  if (packagePath === undefined || packagePath.startsWith('-')) throw new Error(`probe ${mode} requires a package.tgz file`)
+  const dshVersions: string[] = []
   let timeoutSeconds = 120
   let keepProfile = false
   let json = false
@@ -206,7 +208,11 @@ async function runProbe(args: readonly string[]): Promise<number> {
       const value = args[index + 1]
       if (value === undefined || value.startsWith('-')) throw new Error(`${argument} requires a value`)
       if (argument === '--dsh-version') {
-        dshVersion = value
+        const values = value.split(',').map(item => item.trim()).filter(item => item !== '')
+        if (values.length === 0) throw new Error('--dsh-version requires at least one exact version')
+        if (mode === 'dsh-load' && values.length !== 1) throw new Error('probe dsh-load accepts only one DSH version')
+        if (mode === 'dsh-load' && dshVersions.length > 0) throw new Error('probe dsh-load accepts only one DSH version')
+        dshVersions.push(...values)
       } else {
         const parsed = Number(value)
         if (!Number.isSafeInteger(parsed) || parsed < 30 || parsed > 600) {
@@ -216,16 +222,27 @@ async function runProbe(args: readonly string[]): Promise<number> {
       }
       index += 1
     } else {
-      throw new Error(`unknown option for probe dsh-load: ${argument}`)
+      throw new Error(`unknown option for probe ${mode}: ${argument}`)
     }
   }
-  const report = await probeDshLoad({
+  const timeoutMs = timeoutSeconds * 1_000
+  if (mode === 'dsh-load') {
+    const report = await probeDshLoad({
+      packagePath,
+      ...(dshVersions[0] === undefined ? {} : { dshVersion: dshVersions[0] }),
+      timeoutMs,
+      keepProfile,
+    })
+    process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderDshLoadProbe(report))
+    return report.result === 'compatible' ? 0 : report.result === 'incompatible' ? 2 : 1
+  }
+  const report = await probeDshLoadMatrix({
     packagePath,
-    ...(dshVersion === undefined ? {} : { dshVersion }),
-    timeoutMs: timeoutSeconds * 1_000,
-    keepProfile,
+    dshVersions,
+    timeoutMs,
+    keepProfiles: keepProfile,
   })
-  process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderDshLoadProbe(report))
+  process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderDshLoadMatrix(report))
   return report.result === 'compatible' ? 0 : report.result === 'incompatible' ? 2 : 1
 }
 

--- a/src/dsh-probe.ts
+++ b/src/dsh-probe.ts
@@ -7,11 +7,14 @@ import { parsePackageManifestSnapshot } from './inventory.js'
 import { parseNpmTarball } from './tar.js'
 
 export const DSH_LOAD_PROBE_SCHEMA = 'upstream-radar.dsh-load-probe/v1alpha1' as const
+export const DSH_LOAD_MATRIX_SCHEMA = 'upstream-radar.dsh-load-matrix/v1alpha1' as const
 
 const DEFAULT_DSH_VERSION = '0.1.0-rc.6'
 const DEFAULT_TIMEOUT_MS = 120_000
 const MAX_ARTIFACT_BYTES = 64 * 1024 * 1024
 const MAX_OUTPUT_BYTES = 2 * 1024
+const MAX_MATRIX_VERSIONS = 8
+const PNPM_COMMAND = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 const LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepare'] as const
 
@@ -56,6 +59,33 @@ export interface DshLoadProbeOptions {
   dshVersion?: string
   timeoutMs?: number
   keepProfile?: boolean
+}
+
+export interface DshLoadMatrixOptions {
+  packagePath: string
+  dshVersions: readonly string[]
+  timeoutMs?: number
+  keepProfiles?: boolean
+}
+
+export interface DshLoadMatrixSummary {
+  total: number
+  compatible: number
+  incompatible: number
+  unknown: number
+}
+
+export interface DshLoadMatrixReport {
+  schema: typeof DSH_LOAD_MATRIX_SCHEMA
+  probe: 'dsh-matrix'
+  scope: 'bundle-load-only'
+  artifact: DshLoadProbeReport['artifact']
+  dshVersions: string[]
+  reports: DshLoadProbeReport[]
+  summary: DshLoadMatrixSummary
+  result: DshLoadProbeResult
+  reason: string
+  boundary: DshLoadProbeReport['boundary']
 }
 
 interface CommandResult {
@@ -196,13 +226,48 @@ function baseStageDetail(error: unknown): string {
   return bounded(error instanceof Error ? error.message : String(error))
 }
 
-export async function probeDshLoad(options: DshLoadProbeOptions): Promise<DshLoadProbeReport> {
-  const dshVersion = options.dshVersion ?? DEFAULT_DSH_VERSION
+function validateDshVersion(dshVersion: string): void {
   if (!EXACT_VERSION.test(dshVersion)) throw new Error('DSH version must be an exact semantic version')
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+}
+
+function validateTimeout(timeoutMs: number): void {
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 30_000 || timeoutMs > 600_000) {
     throw new Error('DSH probe timeout must be between 30000 and 600000 milliseconds')
   }
+}
+
+function validateMatrixVersions(dshVersions: readonly string[]): string[] {
+  const versions = [...dshVersions]
+  if (versions.length < 2) throw new Error('DSH matrix requires at least two exact DSH versions')
+  if (versions.length > MAX_MATRIX_VERSIONS) throw new Error(`DSH matrix supports at most ${MAX_MATRIX_VERSIONS} versions`)
+  const unique = new Set<string>()
+  for (const version of versions) {
+    validateDshVersion(version)
+    if (unique.has(version)) throw new Error(`DSH matrix contains duplicate version: ${version}`)
+    unique.add(version)
+  }
+  return versions
+}
+
+export function summarizeDshLoadResults(results: readonly DshLoadProbeResult[]): DshLoadMatrixSummary & { result: DshLoadProbeResult } {
+  if (results.length === 0) throw new Error('DSH matrix requires at least one result')
+  const summary: DshLoadMatrixSummary = {
+    total: results.length,
+    compatible: results.filter(result => result === 'compatible').length,
+    incompatible: results.filter(result => result === 'incompatible').length,
+    unknown: results.filter(result => result === 'unknown').length,
+  }
+  return {
+    ...summary,
+    result: summary.incompatible > 0 ? 'incompatible' : summary.unknown > 0 ? 'unknown' : 'compatible',
+  }
+}
+
+export async function probeDshLoad(options: DshLoadProbeOptions): Promise<DshLoadProbeReport> {
+  const dshVersion = options.dshVersion ?? DEFAULT_DSH_VERSION
+  validateDshVersion(dshVersion)
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  validateTimeout(timeoutMs)
   const artifactPath = resolve(options.packagePath)
   const baseReport = {
     schema: DSH_LOAD_PROBE_SCHEMA,
@@ -250,7 +315,7 @@ export async function probeDshLoad(options: DshLoadProbeOptions): Promise<DshLoa
     npm_config_ignore_scripts: 'true',
     PNPM_CONFIG_IGNORE_SCRIPTS: 'true',
   }
-  const run = (args: readonly string[]): Promise<CommandResult> => runCommand('pnpm', dshArgs(dshVersion, args), {
+  const run = (args: readonly string[]): Promise<CommandResult> => runCommand(PNPM_COMMAND, dshArgs(dshVersion, args), {
     cwd: process.cwd(),
     env,
     timeoutMs,
@@ -328,6 +393,45 @@ export async function probeDshLoad(options: DshLoadProbeOptions): Promise<DshLoa
   return report
 }
 
+export async function probeDshLoadMatrix(options: DshLoadMatrixOptions): Promise<DshLoadMatrixReport> {
+  const dshVersions = validateMatrixVersions(options.dshVersions)
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  validateTimeout(timeoutMs)
+  const reports: DshLoadProbeReport[] = []
+  for (const dshVersion of dshVersions) {
+    reports.push(await probeDshLoad({
+      packagePath: options.packagePath,
+      dshVersion,
+      timeoutMs,
+      ...(options.keepProfiles === undefined ? {} : { keepProfile: options.keepProfiles }),
+    }))
+  }
+  const summary = summarizeDshLoadResults(reports.map(report => report.result))
+  const firstReport = reports[0]
+  if (firstReport === undefined) throw new Error('DSH matrix produced no reports')
+  return {
+    schema: DSH_LOAD_MATRIX_SCHEMA,
+    probe: 'dsh-matrix',
+    scope: 'bundle-load-only',
+    artifact: firstReport.artifact,
+    dshVersions,
+    reports,
+    summary: {
+      total: summary.total,
+      compatible: summary.compatible,
+      incompatible: summary.incompatible,
+      unknown: summary.unknown,
+    },
+    result: summary.result,
+    reason: summary.incompatible > 0
+      ? 'at least one DSH version rejected the bundle'
+      : summary.unknown > 0
+        ? 'at least one DSH version could not establish a reliable load result'
+        : 'all tested DSH versions registered and loaded the bundle',
+    boundary: firstReport.boundary,
+  }
+}
+
 export function renderDshLoadProbe(report: DshLoadProbeReport): string {
   const lines = [
     'DSH load probe (disposable profile; load-only)',
@@ -340,6 +444,23 @@ export function renderDshLoadProbe(report: DshLoadProbeReport): string {
     lines.push(`  ${name}: ${stage.status}${stage.detail === undefined ? '' : ` (${stage.detail})`}`)
   }
   if (report.profileDirectory !== undefined) lines.push(`Profile: ${report.profileDirectory}`)
+  lines.push('', report.boundary)
+  return `${lines.join('\n')}\n`
+}
+
+export function renderDshLoadMatrix(report: DshLoadMatrixReport): string {
+  const lines = [
+    'DSH compatibility matrix (disposable profiles; load-only)',
+    `Artifact: ${report.artifact.name ?? 'unknown'}@${report.artifact.version ?? 'unknown'}`,
+    `Versions: ${report.dshVersions.join(', ')}`,
+    '',
+    `Result: ${report.result.toUpperCase()} — ${report.reason}`,
+    `Summary: ${report.summary.compatible} compatible, ${report.summary.incompatible} incompatible, ${report.summary.unknown} unknown`,
+  ]
+  for (const item of report.reports) {
+    lines.push(`  ${item.dshVersion}: ${item.result}${item.reason === '' ? '' : ` — ${item.reason}`}`)
+    if (item.profileDirectory !== undefined) lines.push(`    Profile: ${item.profileDirectory}`)
+  }
   lines.push('', report.boundary)
   return `${lines.join('\n')}\n`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,11 +27,18 @@ export {
 } from './radar.js'
 export { assessCompatibilityChange, assessCompatibilityChanges, type CompatibilityChangeInput } from './compatibility.js'
 export {
+  DSH_LOAD_MATRIX_SCHEMA,
   DSH_LOAD_PROBE_SCHEMA,
   inspectDshLoadArtifact,
   probeDshLoad,
+  probeDshLoadMatrix,
   renderDshLoadProbe,
+  renderDshLoadMatrix,
+  summarizeDshLoadResults,
   type DshLoadProbeArtifact,
+  type DshLoadMatrixOptions,
+  type DshLoadMatrixReport,
+  type DshLoadMatrixSummary,
   type DshLoadProbeOptions,
   type DshLoadProbeReport,
   type DshLoadProbeResult,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.25.0'
+export const TOOL_VERSION = '0.26.0'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -27,6 +27,7 @@ describe('CLI option parsing', () => {
     assert.match(help.stdout, /--fail-on-compatibility <value>\s+CI gate: never\|breaking\|any/)
     assert.match(help.stdout, /--dsh-patch <path>\s+write a self-contained DSH --patch overlay/)
     assert.match(help.stdout, /probe dsh-load <package\.tgz>/)
+    assert.match(help.stdout, /probe dsh-matrix <package\.tgz>/)
 
     const benchmark = spawnSync(process.execPath, [cli, 'benchmark', 'compatibility', '--json'], { encoding: 'utf8' })
     assert.equal(benchmark.status, 0)
@@ -37,6 +38,10 @@ describe('CLI option parsing', () => {
     const invalidProbeVersion = spawnSync(process.execPath, [cli, 'probe', 'dsh-load', 'missing.tgz', '--dsh-version', 'latest'], { encoding: 'utf8' })
     assert.equal(invalidProbeVersion.status, 1)
     assert.match(invalidProbeVersion.stderr, /DSH version must be an exact semantic version/)
+
+    const incompleteProbeMatrix = spawnSync(process.execPath, [cli, 'probe', 'dsh-matrix', 'missing.tgz', '--dsh-version', '0.1.0-rc.6'], { encoding: 'utf8' })
+    assert.equal(incompleteProbeMatrix.status, 1)
+    assert.match(incompleteProbeMatrix.stderr, /at least two exact DSH versions/)
 
     const blockedDoctor = spawnSync(process.execPath, [cli, 'doctor', resolve(tmpdir(), `upstream-radar-missing-${process.pid}.json`)], { encoding: 'utf8' })
     assert.equal(blockedDoctor.status, 1)

--- a/test/dsh-probe.test.ts
+++ b/test/dsh-probe.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, it } from 'node:test'
-import { inspectDshLoadArtifact, probeDshLoad } from '../src/dsh-probe.js'
+import { inspectDshLoadArtifact, probeDshLoad, probeDshLoadMatrix, summarizeDshLoadResults } from '../src/dsh-probe.js'
 import { makeTarball } from './helpers/tar.js'
 
 describe('DSH load probe', () => {
@@ -57,6 +57,34 @@ describe('DSH load probe', () => {
     await assert.rejects(
       probeDshLoad({ packagePath: '/tmp/not-used.tgz', dshVersion: 'latest' }),
       /DSH version must be an exact semantic version/,
+    )
+  })
+
+  it('summarizes a matrix without treating unknown as compatible', () => {
+    assert.deepEqual(summarizeDshLoadResults(['compatible', 'unknown']), {
+      total: 2,
+      compatible: 1,
+      incompatible: 0,
+      unknown: 1,
+      result: 'unknown',
+    })
+    assert.deepEqual(summarizeDshLoadResults(['unknown', 'incompatible', 'compatible']), {
+      total: 3,
+      compatible: 1,
+      incompatible: 1,
+      unknown: 1,
+      result: 'incompatible',
+    })
+  })
+
+  it('requires at least two distinct exact versions for a matrix', async () => {
+    await assert.rejects(
+      probeDshLoadMatrix({ packagePath: '/tmp/not-used.tgz', dshVersions: ['0.1.0-rc.6'] }),
+      /at least two exact DSH versions/,
+    )
+    await assert.rejects(
+      probeDshLoadMatrix({ packagePath: '/tmp/not-used.tgz', dshVersions: ['0.1.0-rc.6', '0.1.0-rc.6'] }),
+      /duplicate version/,
     )
   })
 })


### PR DESCRIPTION
## What changed

- add `probe dsh-matrix <package.tgz>` for two to eight exact DSH versions
- run each version sequentially in its own temporary profile against the same artifact
- aggregate results conservatively: `incompatible` wins over `unknown`, and `unknown` wins over `compatible`
- add the machine-readable matrix JSON schema
- add a real DSH `0.1.0-rc.3` / `0.1.0-rc.6` showcase and run it in CI and the publish workflow
- bump package and Action examples to `0.26.0`

## Why

The first load probe answered one version at a time. A plugin update often has to remain usable across the DSH versions a team actually runs. The matrix makes that question one simple command while keeping uncertainty visible.

## Validation

- `pnpm test` — 115/115 passing
- `pnpm run check` — passing
- `pnpm run scan:self` — no implemented static findings; coverage remains incomplete by design
- `pnpm run try:dsh` — real DSH headless installation and Agent handoff passing
- `pnpm run showcase:dsh-probe` — three single-probe outcomes plus a real 2-version matrix passing
- `pnpm pack --dry-run` — matrix CLI and schema included

## Boundary

This remains load-only evidence. It does not execute plugin business actions, benchmark capability, or prove package/dependency safety. The matrix is bounded to eight versions and keeps `unknown` from becoming a green result.
