### PR TITLE
feat: route Radar notices to matching DSH projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.28.0] - 2026-08-16
+
+### Added
+
+- Route pending DSH analysis notices to the root Agent whose session workspace exactly matches the Radar project workspace.
+- Keep tasks queued when multiple DSH roots exist but no trustworthy workspace match is available.
+- Preserve single-root delivery for existing installations and continue delivery for unrelated projects when one route fails.
+- Add routing tests and document the multi-project behavior in the English and Chinese guides.
+
+### Safety
+
+- The adapter never guesses between multiple project sessions; an ambiguous route is visible as a durable pending task and a DSH warning.
+
 ## [0.27.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The generated graph is the actual installed profile graph. DSH also maintains a 
 
 For a hand-written or CI fixture, use [the example inventory](examples/radar/config.json). If neither a generated `--patch` overlay nor `UPSTREAM_RADAR_CONFIG` is provided, the bundle stays dormant and performs no polling.
 
-Once running, Radar polls OSV, npm, and public GitHub Releases, persists incident state before delivery, and submits only changed incidents to the first live root DSH Agent. If a source is temporarily unavailable, Radar keeps the last confirmed state instead of claiming that the project is clean, continues delivering already queued tasks, and creates one source-health notice after three consecutive failures.
+Once running, Radar polls OSV, npm, and public GitHub Releases, persists incident state before delivery, and submits only changed incidents to the matching DSH project session. With one root Agent, delivery remains automatic; with multiple roots, Radar requires an exact match between `project.workspace` and `Agent.session.header.cwd`, and keeps the task queued when it cannot prove the route. If a source is temporarily unavailable, Radar keeps the last confirmed state instead of claiming that the project is clean, continues delivering already queued tasks, and creates one source-health notice after three consecutive failures.
 
 Each release cycle also checks a bounded prefix of candidate dependency graphs. This is enabled by default in the DSH adapter and CLI; use `--no-deep-candidates` only when you deliberately want manifest-only compatibility checks. The graph resolver is isolated in a temporary directory and uses `package-lock-only` plus `ignore-scripts`, so candidate package code is not loaded or executed.
 
@@ -193,7 +193,7 @@ This proof runs in CI on Node.js 22. See the executable [showcase contract](exam
 Before wiring a project into a compatibility gate, run the offline rule benchmark:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar benchmark compatibility
 ```
 
 It covers six contracts: a safe patch, a change that only needs project analysis, an incompatible DSH peer, a publisher-declared breaking release, a vulnerable candidate dependency, and an incomplete candidate graph. The command does not access the network, install a package, load a plugin, or start DSH. It checks the behavior of Radar's deterministic rules and the `breaking`/`any` gates; it is not a runtime compatibility proof.
@@ -206,7 +206,7 @@ When you have an exact plugin artifact and want to know whether one exact DSH re
 # Pack an exact npm release without running its lifecycle scripts.
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -232,7 +232,7 @@ It exercises a loadable bundle, a bundle patch DSH rejects, and a package that r
 To compare a plugin against more than one DSH release, use the matrix form:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -248,7 +248,7 @@ If your team wants a scheduled CI gate before wiring a machine to a live DSH pro
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.27.0
+  - uses: MicroMilo/upstream-radar@v0.28.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -256,12 +256,12 @@ steps:
       fail-on-compatibility: breaking
 ```
 
-The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`; when the optional compatibility input is enabled, it also passes `--fail-on-compatibility breaking` or `any`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability or opted-in compatibility change meets its threshold, and exits `1` for an operational or source error. `breaking` catches confirmed or strong incompatibility signals; `any` catches every active compatibility event. The default is `never`, so vulnerability-only behavior stays unchanged. The Action does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.27.0`, and pin the checkout Action in your workflow according to your repository's policy.
+The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`; when the optional compatibility input is enabled, it also passes `--fail-on-compatibility breaking` or `any`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability or opted-in compatibility change meets its threshold, and exits `1` for an operational or source error. `breaking` catches confirmed or strong incompatibility signals; `any` catches every active compatibility event. The default is `never`, so vulnerability-only behavior stays unchanged. The Action does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.28.0`, and pin the checkout Action in your workflow according to your repository's policy.
 
 The Action requires the caller to check out the repository first. It does not install the project's dependencies or run their lifecycle scripts; it only reads the committed graph and queries the configured upstream sources. For a fully explicit, lower-level invocation, the equivalent command is:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -269,7 +269,7 @@ pnpm dlx --package=upstream-radar@0.27.0 upstream-radar radar check \
 To add the optional DSH load matrix for a published plugin, provide an exact npm package and at least two exact DSH versions:
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.27.0
+- uses: MicroMilo/upstream-radar@v0.28.0
   id: radar
   with:
     config: upstream-radar.config.json
@@ -297,7 +297,7 @@ For a local or self-hosted DSH machine, omit `--frozen` so Radar refreshes the s
 3. Watch npm releases for the installed plugin and DSH/Cordis packages.
 4. Create or update one durable incident with the exact dependency path.
 5. Persist a constrained analysis task before delivery.
-6. Send a plugin-originated follow-up to the first live root DSH Agent.
+6. Route a plugin-originated follow-up to the DSH root whose session workspace matches the project.
 7. Keep the task on disk when no Agent is available; cancel it when the incident resolves.
 
 For a local process or a scheduled runner, the same loop is available as:
@@ -417,7 +417,7 @@ pnpm dlx --package=upstream-radar@latest upstream-radar inspect npm:dsh-cloudfla
 - OSV, npm `latest`, and public GitHub Release notes are live sources; changelog, comparison-diff, and migration-guide ingestion are deferred.
 - A failed OSV check preserves confirmed matches and returns a visible source warning; source health is durable and routed through DSH after three consecutive failures, while source-claim conflict handling and external health destinations are not implemented yet.
 - `radar watch` is a CLI monitoring fallback; it does not deliver tasks into DSH by itself.
-- Delivery currently targets the first live root Agent rather than a project-specific session.
+- Delivery uses one root Agent as the simple default; when several roots exist, it requires an exact project-workspace match and leaves ambiguous tasks queued instead of guessing.
 - Agent conclusions stay in the DSH Session; Radar does not ingest them back into incident state yet.
 - No Issue, branch, Pull Request, dependency override, or merge is created automatically.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,7 +44,7 @@
 
 - [ ] Add pnpm and Yarn lock graph adapters.
 - [ ] Maintain one durable project registry across multiple machines.
-- [ ] Deliver to the correct DSH project session instead of one security-inbox Agent.
+- [x] Deliver to the correct DSH project session instead of one security-inbox Agent.
 - [ ] Add Feishu, Slack, email, and generic webhook delivery with acknowledgement state.
 - [ ] Add suppression, ownership, maintenance-window, and dev-only rules.
 - [ ] Keep event history for new, updated, acknowledged, fixed, withdrawn, and ignored states.

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.27.0
+    default: 0.28.0
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -147,7 +147,7 @@ pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.
 
 如果需要手写配置或制作 CI fixture，可以参考[示例清单](../examples/radar/config.json)。如果既没有 `--patch` overlay，也没有设置 `UPSTREAM_RADAR_CONFIG`，插件会保持休眠，不发起轮询。
 
-启动后，Radar 会轮询 OSV 与 npm，先把事件状态持久化，再把有变化的事件交给第一个在线的根 DSH Agent。
+启动后，Radar 会轮询 OSV 与 npm，先把事件状态持久化，再把有变化的事件交给项目 workspace 对应的根 DSH Agent。只有一个 root 时保持自动投递；有多个 root 且无法精确匹配 workspace 时，任务会留在队列中，不会误投给另一个项目。
 
 每轮发现新版本时，默认还会检查最早的一小段候选依赖图。CLI 可以用 `--no-deep-candidates` 显式关闭；原生 DSH 配置可以设置 `deepCandidates: false`。这项解析在临时目录中运行 `npm install --package-lock-only --ignore-scripts`，只解析 manifest 和 lockfile，不加载或执行候选代码。
 
@@ -181,7 +181,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -194,7 +194,7 @@ pnpm dlx --package=upstream-radar@0.27.0 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -220,7 +220,7 @@ pnpm run showcase:dsh-probe
 如果要比较多个 DSH 版本，可以使用矩阵入口：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -238,7 +238,7 @@ JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.27.0
+  - uses: MicroMilo/upstream-radar@v0.28.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -246,12 +246,12 @@ steps:
       fail-on-compatibility: breaking
 ```
 
-这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.27.0` 的发布标签，并根据团队策略固定 checkout Action。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.28.0` 的发布标签，并根据团队策略固定 checkout Action。
 
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -259,7 +259,7 @@ pnpm dlx --package=upstream-radar@0.27.0 upstream-radar radar check \
 如果还要检查一个已发布插件能否跨多个 DSH 版本加载，可以增加三个 input：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.27.0
+- uses: MicroMilo/upstream-radar@v0.28.0
   id: radar
   with:
     config: upstream-radar.config.json
@@ -346,11 +346,11 @@ DSH Agent 收到的任务要求：只读分析、引用项目证据、保留不�
 
 ## 当前能力与边界
 
-已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查、默认可提交的相对 workspace、把审查过的图接入 CI 的可复用 GitHub Action、可选的 breaking/any 兼容性门禁、可选的 DSH 版本加载矩阵、离线的 `benchmark compatibility` 规则契约检查，以及基于真实 DSH 插件的 consumer smoke。
+已经支持：DSH profile 实际安装树和 npm lock 依赖图、重复版本路径、未解析依赖的覆盖提示、OSV 精确版本匹配、恶意包记录、npm release 监听（只接受高于当前安装版本的候选；npm 的 `latest` 回退不会制造 breaking 告警；最新版本有确定性阻断时会检查历史候选的 OSV 状态和最早一小段传递依赖图，并筛出第一个没有确定性阻断且没有已知漏洞路径、值得交给 DSH 分析的候选；图不完整、图解析或 OSV 失败时不推荐候选）、公开 GitHub Release 说明、OSV 故障时保留已确认状态、连续失败后的 source-health DSH notice、持久事件、按项目 workspace 精确路由到 DSH Agent、DSH 原生投递，以及 Node/peer/exports/入口/bundle/版本边界检查；还包括不联网的 `doctor` 接线检查、默认可提交的相对 workspace、把审查过的图接入 CI 的可复用 GitHub Action、可选的 breaking/any 兼容性门禁、可选的 DSH 版本加载矩阵、离线的 `benchmark compatibility` 规则契约检查，以及基于真实 DSH 插件的 consumer smoke。
 
 此外支持一次性的 `probe dsh-load` 和有界的 `probe dsh-matrix`：在临时 DSH profile 中针对一个或多个精确 DSH 版本加载一个精确 tarball，并返回 `compatible`、`incompatible` 或 `unknown`。它是加载兼容性证据，不是安全准入，也不是插件能力 benchmark。
 
-`init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查、活动事件摘要和下一步提示，但不会替你刷新漏洞源，也不会自动升级插件。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、项目级 Session 精确路由、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。
+`init` 在省略 `--profile` 时可以自动选择唯一一个含第三方 bundle 的 DSH profile；多个候选仍要求显式指定。默认读取实际安装树，因此 pnpm override 和本地解析选择会被纳入；原生解析 pnpm lockfile 以支持安装前/CI 检查仍未实现。加上 `--dsh-patch <path>` 可以生成不依赖环境变量的 DSH overlay。`radar status` 提供离线的首次运行检查、活动事件摘要和下一步提示，但不会替你刷新漏洞源，也不会自动升级插件。暂未支持 Yarn 图适配、changelog/比较 diff/迁移文档源、把 Agent 结论写回事件，以及自动创建 Issue 或 PR。多 root Agent 场景下，只有 `project.workspace` 与 DSH 会话的 `cwd` 精确一致才会投递；无法确认时任务会留在队列中。
 
 `radar watch` 是 CLI 监控入口，本身不会把任务投递给 DSH；需要 Agent 分析时应使用原生 DSH bundle。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,7 @@ poll sources
   -> calculate state changes
   -> replace stale tasks and cancel resolved incidents
   -> atomically save active matches and pending tasks
-  -> select a live root Agent
+  -> select the root Agent whose session workspace matches the project
   -> submit plugin-originated follow-up
   -> atomically remove synchronously accepted tasks from the outbox
 ```
@@ -126,7 +126,7 @@ The same local plane renders a bounded action summary from durable state. It pre
 
 The adapter uses only the small Cordis surface needed for lifecycle cleanup, root-Agent discovery, and `followup`. It intentionally does not depend on the session-local Schedule plugin. A local timer performs fixed polling while the DSH process is alive; durable state provides restart recovery.
 
-Today, the first live root Agent acts as a security inbox. A later adapter will select or create the project-specific session named by each event.
+With one live root Agent, that Agent remains the simple security inbox. When several roots exist, the adapter compares the event's `project.workspace` with each root's `session.header.cwd`; only an exact match is accepted. An absent or ambiguous match leaves the task in the durable outbox, so a security notice cannot be silently delivered to another project.
 
 ## Supporting pre-install collector
 

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -176,7 +176,7 @@ This is intentionally different from resolving the same package in a fresh npm p
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -190,7 +190,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.27.0
+  - uses: MicroMilo/upstream-radar@v0.28.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -223,7 +223,7 @@ It packs without lifecycle scripts, runs one temporary DSH profile per version, 
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -237,7 +237,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -31,7 +31,7 @@ The optional probe is load-only. It packs with `--ignore-scripts`, uses a tempor
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.27.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.28.0 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.27.0
+      - uses: MicroMilo/upstream-radar@v0.28.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.27.0
+      - uses: MicroMilo/upstream-radar@v0.28.0
         with:
           config: upstream-radar.config.json
           fail-on: high

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/dsh-plugin.ts
+++ b/src/dsh-plugin.ts
@@ -10,7 +10,7 @@ import { NpmCandidateGraphClient } from './npm-candidate.js'
 import { NpmReleaseClient } from './npm-release.js'
 import { pollRadar } from './radar.js'
 import { loadRadarState, saveRadarState } from './radar-state.js'
-import type { AnalysisTask, RadarState } from './radar-types.js'
+import type { AnalysisTask, ProjectReference, RadarState } from './radar-types.js'
 
 export const name = 'upstream-radar'
 export const inject = ['agents']
@@ -44,6 +44,11 @@ export interface DshRadarMessage {
 
 interface DshAgentLike {
   followup(message: DshRadarMessage): void
+  session?: {
+    header?: {
+      cwd?: string | null
+    }
+  }
 }
 
 interface DshRadarContext {
@@ -133,15 +138,47 @@ export function createDshRadarFamilyMessage(tasks: readonly AnalysisTask[]): Dsh
   })
 }
 
-/** Synchronous follow-up admission is the acknowledgement boundary; failures stay queued. */
-export function deliverPendingAnalysisTasks(state: RadarState, agent: DshAgentLike): RadarState {
+function normalizedWorkspace(workspace: string | undefined): string | undefined {
+  if (workspace === undefined || workspace.trim() === '') return undefined
+  return resolve(workspace)
+}
+
+/**
+ * Match one project to a DSH root by the session's working directory.
+ *
+ * A single root remains the backwards-compatible default. With multiple roots,
+ * an exact workspace match is required; guessing would deliver a security
+ * notice to the wrong project session.
+ */
+export function selectDshAgentForProject(
+  project: ProjectReference,
+  agents: readonly DshAgentLike[],
+): DshAgentLike | undefined {
+  if (agents.length === 1) return agents[0]
+  const workspace = normalizedWorkspace(project.workspace)
+  if (workspace === undefined) return undefined
+  const matches = agents.filter((agent) => {
+    const cwd = agent.session?.header?.cwd
+    return typeof cwd === 'string' && normalizedWorkspace(cwd) === workspace
+  })
+  return matches.length === 1 ? matches[0] : undefined
+}
+
+/** Deliver grouped tasks to the matching DSH root; unroutable tasks stay queued. */
+export function deliverPendingAnalysisTasksToAgents(state: RadarState, agents: readonly DshAgentLike[]): RadarState {
   const deliveredIds = new Set<string>()
   for (const group of groupPendingAnalysisTasks(state.pendingAnalysisTasks)) {
+    const first = group[0]
+    if (first === undefined) continue
+    const agent = selectDshAgentForProject(first.event.project, agents)
+    if (agent === undefined) continue
     try {
       agent.followup(group.length === 1 ? createDshRadarMessage(group[0]!) : createDshRadarFamilyMessage(group))
       for (const task of group) deliveredIds.add(task.id)
     } catch {
-      break
+      // Admission failed for this project only; unrelated project tasks may
+      // still be delivered, while this group remains durable for retry.
+      continue
     }
   }
   if (deliveredIds.size === 0) return state
@@ -149,6 +186,11 @@ export function deliverPendingAnalysisTasks(state: RadarState, agent: DshAgentLi
     ...state,
     pendingAnalysisTasks: state.pendingAnalysisTasks.filter(task => !deliveredIds.has(task.id)),
   }
+}
+
+/** Synchronous follow-up admission is the acknowledgement boundary; failures stay queued. */
+export function deliverPendingAnalysisTasks(state: RadarState, agent: DshAgentLike): RadarState {
+  return deliverPendingAnalysisTasksToAgents(state, [agent])
 }
 
 async function readConfig(path: string): Promise<ReturnType<typeof parseRadarConfig>> {
@@ -207,10 +249,20 @@ export function apply(ctx: DshRadarContext, config: Config = {}): void {
             ctx.logger.warn(`upstream-radar: ${error.source}: ${safeMessage(error.message)}`)
           }
         }
-        const agent = ctx.agents.roots()[0]
-        if (agent === undefined || state.pendingAnalysisTasks.length === 0) return
-        const next = deliverPendingAnalysisTasks(state, agent)
+        const agents = ctx.agents.roots()
+        if (agents.length === 0 || state.pendingAnalysisTasks.length === 0) return
+        const next = deliverPendingAnalysisTasksToAgents(state, agents)
         if (next !== state) await saveRadarState(stateFile, next)
+        const unrouted = groupPendingAnalysisTasks(next.pendingAnalysisTasks).find((group) => {
+          const first = group[0]
+          return first !== undefined && selectDshAgentForProject(first.event.project, agents) === undefined
+        })
+        if (unrouted !== undefined) {
+          const first = unrouted[0]
+          if (first !== undefined) {
+            ctx.logger.warn(`upstream-radar: kept ${unrouted.length} analysis task(s) queued; no DSH root matches project ${first.event.project.name} workspace ${first.event.project.workspace ?? '(not configured)'}`)
+          }
+        }
       }).catch((error: unknown) => {
         ctx.logger.warn(`upstream-radar: cycle failed: ${safeMessage(error)}`)
       })

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.27.0'
+export const TOOL_VERSION = '0.28.0'

--- a/test/dsh-plugin.test.ts
+++ b/test/dsh-plugin.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { createAnalysisTask } from '../src/dsh-analysis.js'
-import { createDshRadarMessage, deliverPendingAnalysisTasks, groupPendingAnalysisTasks } from '../src/dsh-plugin.js'
+import {
+  createDshRadarMessage,
+  deliverPendingAnalysisTasks,
+  deliverPendingAnalysisTasksToAgents,
+  groupPendingAnalysisTasks,
+  selectDshAgentForProject,
+} from '../src/dsh-plugin.js'
 import { emptyRadarState } from '../src/radar.js'
 import type { CompatibilityEvent, SourceHealthEvent } from '../src/radar-types.js'
 
@@ -95,5 +101,74 @@ describe('DSH radar plugin adapter', () => {
     assert.match(messages[0]?.content[0]?.text ?? '', /@deepseek-ai\/dsh-agent/)
     assert.match(messages[0]?.content[0]?.text ?? '', /@deepseek-ai\/dsh-session/)
     assert.match(messages[0]?.source.summary ?? '', /DSH runtime compatibility changes \(2\)/)
+  })
+
+  it('routes multiple projects by exact DSH session workspace', () => {
+    const secondEvent: CompatibilityEvent = {
+      ...event,
+      id: 'event-compat-second',
+      incidentId: 'incident-compat-second',
+      project: { id: 'project-b', name: 'Project B', workspace: '/workspace/project-b' },
+    }
+    const firstTask = createAnalysisTask(event)
+    const secondTask = createAnalysisTask(secondEvent)
+    const firstMessages: unknown[] = []
+    const secondMessages: unknown[] = []
+    const firstAgent = {
+      session: { header: { cwd: '/workspace/project-a' } },
+      followup: (message: unknown) => firstMessages.push(message),
+    }
+    const secondAgent = {
+      session: { header: { cwd: '/workspace/project-b' } },
+      followup: (message: unknown) => secondMessages.push(message),
+    }
+
+    assert.equal(selectDshAgentForProject(event.project, [firstAgent, secondAgent]), firstAgent)
+    assert.equal(selectDshAgentForProject(secondEvent.project, [firstAgent, secondAgent]), secondAgent)
+    const state = emptyRadarState()
+    state.pendingAnalysisTasks.push(firstTask, secondTask)
+    const remaining = deliverPendingAnalysisTasksToAgents(state, [firstAgent, secondAgent])
+
+    assert.equal(remaining.pendingAnalysisTasks.length, 0)
+    assert.equal(firstMessages.length, 1)
+    assert.equal(secondMessages.length, 1)
+    assert.match(JSON.stringify(firstMessages[0]), /Project A/)
+    assert.match(JSON.stringify(secondMessages[0]), /Project B/)
+  })
+
+  it('keeps a multi-project task queued when no workspace match is trustworthy', () => {
+    const state = emptyRadarState()
+    state.pendingAnalysisTasks.push(createAnalysisTask(event))
+    const messages: unknown[] = []
+    const otherAgent = {
+      session: { header: { cwd: '/workspace/other' } },
+      followup: (message: unknown) => messages.push(message),
+    }
+
+    const remaining = deliverPendingAnalysisTasksToAgents(state, [otherAgent, {
+      session: { header: { cwd: '/workspace/another' } },
+      followup: (message: unknown) => messages.push(message),
+    }])
+
+    assert.equal(remaining.pendingAnalysisTasks.length, 1)
+    assert.equal(messages.length, 0)
+  })
+
+  it('does not guess when two roots advertise the same workspace', () => {
+    const matches = [
+      { session: { header: { cwd: '/workspace/project-a' } }, followup: () => undefined },
+      { session: { header: { cwd: '/workspace/project-a' } }, followup: () => undefined },
+    ]
+    assert.equal(selectDshAgentForProject(event.project, matches), undefined)
+  })
+
+  it('preserves single-root compatibility even without session metadata', () => {
+    const state = emptyRadarState()
+    state.pendingAnalysisTasks.push(createAnalysisTask(event))
+    const messages: unknown[] = []
+    const remaining = deliverPendingAnalysisTasksToAgents(state, [{ followup: message => messages.push(message) }])
+
+    assert.equal(remaining.pendingAnalysisTasks.length, 0)
+    assert.equal(messages.length, 1)
   })
 })


### PR DESCRIPTION
## What changed

- match each pending analysis task to the DSH root whose `session.header.cwd` exactly matches `project.workspace`
- preserve the existing single-root behavior
- keep tasks queued when multiple roots are ambiguous or have no trustworthy workspace match
- continue delivering unrelated project groups when one project admission fails
- add English/Chinese documentation, roadmap updates, and routing tests
- bump the next release metadata to `0.28.0`

## Evidence

- `pnpm test` — 118 passed
- `pnpm run check` — passed
- `pnpm run scan:self` — no implemented static findings
- `pnpm run try:dsh` — real DSH `0.1.0-rc.6` delivery smoke passed
- `pnpm run showcase:dsh-probe` — compatible/incompatible/unknown fixtures and 2-version matrix passed
- `git diff --check` — passed

## Safety boundary

The adapter never guesses between multiple DSH project sessions. An ambiguous route remains a durable pending task and emits a warning.