### PR TITLE
feat: add one-command DSH setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.30.0] - 2026-08-16
+
+### Added
+
+- Add an explicit `upstream-radar setup` command that installs the exact running Radar version through DSH, generates the reviewable inventory and overlay, and runs the network-free wiring check.
+- Add `--no-install` for profiles that already contain the Radar bundle.
+- Shorten the DSH quickstart and document the safe boundary: setup does not start DSH or execute plugin business actions.
+
+### Validation
+
+- Add a CLI integration test covering exact DSH installation arguments, generated files, and the doctor result.
+
 ## [0.29.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,17 +31,15 @@ Use a DSH profile that already contains at least one third-party bundle. Replace
 
 ```bash
 # Terminal 1
-dsh plugin --profile web add upstream-radar@latest
-pnpm dlx --package=upstream-radar@latest upstream-radar init \
+pnpm dlx --package=upstream-radar@latest upstream-radar setup \
   --profile web \
   --project-name "My DSH project" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
-pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
-  --profile web \
-  --patch ./upstream-radar.dsh.yml
 dsh --profile web --patch ./upstream-radar.dsh.yml
 ```
+
+`setup` explicitly installs the exact Radar version used by the command into the selected DSH profile, discovers the installed graph, writes the reviewable config and overlay, and runs the network-free wiring check. It does not start DSH or execute plugin business actions; review the generated files before starting the process. If Radar is already installed, add `--no-install`.
 
 After DSH is running, use a second terminal for the read-only status check:
 
@@ -50,7 +48,7 @@ After DSH is running, use a second terminal for the read-only status check:
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-The initializer writes a reviewable inventory and an explicit DSH overlay. `doctor` verifies the local wiring before DSH starts; `radar status` confirms the first completed check without another network request. Read the [full DSH setup](#install-in-dsh) for the legacy environment-variable path, profile boundaries, and the real runtime proof.
+The setup command writes a reviewable inventory and an explicit DSH overlay. Its local doctor check verifies the wiring before DSH starts; `radar status` confirms the first completed check without another network request. Read the [full DSH setup](#install-in-dsh) for the legacy environment-variable path, profile boundaries, and the real runtime proof.
 
 If you want to try the monitoring loop without booting a DSH profile, run one cycle from a reviewed inventory:
 
@@ -121,25 +119,24 @@ That incident becomes a plugin-originated DSH notice. It is not copied into a ge
 Upstream Radar is an npm-published DSH bundle, so no install-time build permission is required:
 
 ```bash
-dsh plugin --profile web add upstream-radar@latest
-```
-
-Generate the inventory from the DSH profile instead of writing the dependency graph by hand:
-
-```bash
-pnpm dlx --package=upstream-radar@latest upstream-radar init \
+pnpm dlx --package=upstream-radar@latest upstream-radar setup \
+  --profile web \
   --project-name "My DSH project" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
 ```
 
-The initializer reads the profile's actual third-party bundles and follows the installed `node_modules` tree exposed by that profile, including duplicate versions, overrides, and local package-manager choices. By default it records the workspace as `.` so the config can be committed and reused on another machine; start DSH from the project root. Pass `--workspace <absolute-path>` only when DSH is launched elsewhere. It reads manifests only: it does not import plugin code, run lifecycle scripts, start DSH, or enable polling. Review both generated files, then run:
+`setup` delegates the package installation to DSH using the exact Radar version currently being run. It then generates the inventory and overlay and runs `doctor` locally without contacting OSV, npm, or GitHub. It does not start DSH. Review the two generated files, then start the profile:
 
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml --dump-config
 dsh --profile web --patch ./upstream-radar.dsh.yml
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
+
+For an already installed bundle, add `--no-install`. The lower-level manual path remains available when you want to review the DSH installation separately: run `dsh plugin --profile web add upstream-radar@<exact-version>`, then use `init --profile web --dsh-patch ...` and `doctor`.
+
+The initializer reads the profile's actual third-party bundles and follows the installed `node_modules` tree exposed by that profile, including duplicate versions, overrides, and local package-manager choices. By default it records the workspace as `.` so the config can be committed and reused on another machine; start DSH from the project root. Pass `--workspace <absolute-path>` only when DSH is launched elsewhere. It reads manifests only: it does not import plugin code, run lifecycle scripts, start DSH, or enable polling.
 
 If startup does not behave as expected, run the local wiring check before looking at upstream feeds:
 
@@ -194,7 +191,7 @@ This proof runs in CI on Node.js 22. See the executable [showcase contract](exam
 Before wiring a project into a compatibility gate, run the offline rule benchmark:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar benchmark compatibility
 ```
 
 It covers six contracts: a safe patch, a change that only needs project analysis, an incompatible DSH peer, a publisher-declared breaking release, a vulnerable candidate dependency, and an incomplete candidate graph. The command does not access the network, install a package, load a plugin, or start DSH. It checks the behavior of Radar's deterministic rules and the `breaking`/`any` gates; it is not a runtime compatibility proof.
@@ -207,7 +204,7 @@ When you have an exact plugin artifact and want to know whether one exact DSH re
 # Pack an exact npm release without running its lifecycle scripts.
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -233,7 +230,7 @@ It exercises a loadable bundle, a bundle patch DSH rejects, and a package that r
 To compare a plugin against more than one DSH release, use the matrix form:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -249,7 +246,7 @@ If your team wants a scheduled CI gate before wiring a machine to a live DSH pro
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.29.0
+  - uses: MicroMilo/upstream-radar@v0.30.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -257,12 +254,12 @@ steps:
       fail-on-compatibility: breaking
 ```
 
-The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`; when the optional compatibility input is enabled, it also passes `--fail-on-compatibility breaking` or `any`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability or opted-in compatibility change meets its threshold, and exits `1` for an operational or source error. `breaking` catches confirmed or strong incompatibility signals; `any` catches every active compatibility event. The default is `never`, so vulnerability-only behavior stays unchanged. The Action does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.29.0`, and pin the checkout Action in your workflow according to your repository's policy.
+The Action is a thin wrapper around `radar check --frozen --state :memory: --fail-on high --json`; when the optional compatibility input is enabled, it also passes `--fail-on-compatibility breaking` or `any`. `--frozen` is deliberate: it uses the graph in the reviewed config and does not try to read a developer's local DSH profile. Each run is independent, exits `2` when an active vulnerability or opted-in compatibility change meets its threshold, and exits `1` for an operational or source error. `breaking` catches confirmed or strong incompatibility signals; `any` catches every active compatibility event. The default is `never`, so vulnerability-only behavior stays unchanged. The Action does not deliver a DSH Agent task or modify a branch; the native DSH bundle remains the always-on analysis path. Pin the Action to a release tag such as `v0.30.0`, and pin the checkout Action in your workflow according to your repository's policy.
 
 The Action requires the caller to check out the repository first. It does not install the project's dependencies or run their lifecycle scripts; it only reads the committed graph and queries the configured upstream sources. For a fully explicit, lower-level invocation, the equivalent command is:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -270,7 +267,7 @@ pnpm dlx --package=upstream-radar@0.29.0 upstream-radar radar check \
 To add the optional DSH load matrix for a published plugin, provide an exact npm package and at least two exact DSH versions:
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.29.0
+- uses: MicroMilo/upstream-radar@v0.30.0
   id: radar
   with:
     config: upstream-radar.config.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@
 - [x] Provide a network-free doctor command for DSH bundle registration, overlay/config alignment, state readability, and dependency coverage.
 - [x] Show bounded active-incident paths, candidate signals, and next-step guidance in the network-free status command.
 - [x] Make the generated project workspace portable by default so the reviewed inventory can be committed and reused.
+- [x] Provide one explicit DSH setup command that installs the exact Radar version, generates wiring, and runs the network-free doctor check.
 
 ## Milestone 1 — compatibility radar
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.29.0
+    default: 0.30.0
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -21,15 +21,11 @@
 
 ```bash
 # 终端 1
-dsh plugin --profile web add upstream-radar@latest
-pnpm dlx --package=upstream-radar@latest upstream-radar init \
+pnpm dlx --package=upstream-radar@latest upstream-radar setup \
   --profile web \
   --project-name "我的 DSH 项目" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
-pnpm dlx --package=upstream-radar@latest upstream-radar doctor ./upstream-radar.config.json \
-  --profile web \
-  --patch ./upstream-radar.dsh.yml
 dsh --profile web --patch ./upstream-radar.dsh.yml
 ```
 
@@ -40,7 +36,7 @@ DSH 启动后，在第二个终端执行只读状态检查：
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
 
-初始化命令会写出可审查的清单和 DSH overlay。`doctor` 会在 DSH 启动前检查本地接线；`radar status` 会在不重新请求网络的情况下确认第一次完整检查。完整的状态文件、兼容的旧环境变量方式、profile 边界和真实运行证明见[完整 DSH 配置](#安装到-dsh)。
+`setup` 会明确调用 DSH 的安装命令，把当前正在运行的精确 Radar 版本放进选中的 profile，然后写出可审查的清单和 DSH overlay，并运行不联网的本地接线检查。它不会启动 DSH，也不会执行插件业务动作；检查生成文件后再启动。已经安装过 bundle 时加 `--no-install`。`radar status` 会在不重新请求网络的情况下确认第一次完整检查。完整的状态文件、兼容的旧环境变量方式、profile 边界和真实运行证明见[完整 DSH 配置](#安装到-dsh)。
 
 如果只想先试跑一次监控，而不启动 DSH profile，可以使用同一份清单：
 
@@ -111,25 +107,24 @@ Route: payments-platform via feishu:payments-security
 Upstream Radar 发布的是已经构建好的 npm bundle，不需要开放安装期构建权限：
 
 ```bash
-dsh plugin --profile web add upstream-radar@latest
-```
-
-不用手写依赖图，可以直接从 DSH profile 生成项目清单：
-
-```bash
-pnpm dlx --package=upstream-radar@latest upstream-radar init \
+pnpm dlx --package=upstream-radar@latest upstream-radar setup \
+  --profile web \
   --project-name "我的 DSH 项目" \
   --output ./upstream-radar.config.json \
   --dsh-patch ./upstream-radar.dsh.yml
 ```
 
-初始化命令会读取 profile 中实际安装的第三方 bundle，并沿着该 profile 暴露的 `node_modules` 目录构建依赖图，包括重复版本、override 和本地 package-manager 选择。默认把 workspace 写成 `.`，因此配置可以提交并在另一台机器复用；请从项目根目录启动 DSH。如果 DSH 从其他目录启动，再传入 `--workspace <绝对路径>`。它只读取 manifest，不会导入插件代码、运行 lifecycle scripts、启动 DSH 或开启轮询。检查生成文件后，直接运行：
+`setup` 会使用当前命令对应的精确 Radar 版本调用 DSH 安装器，生成项目清单和 overlay，并运行不联网的 `doctor`。它不会启动 DSH。检查两个生成文件后启动 profile：
 
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml --dump-config
 dsh --profile web --patch ./upstream-radar.dsh.yml
 pnpm dlx --package=upstream-radar@latest upstream-radar radar status ./upstream-radar.config.json
 ```
+
+如果 bundle 已经在 profile 中，加入 `--no-install`。如果你想把安装单独拿出来审查，也可以使用底层路径：先运行 `dsh plugin --profile web add upstream-radar@<精确版本>`，再运行 `init --profile web --dsh-patch ...` 和 `doctor`。
+
+初始化命令会读取 profile 中实际安装的第三方 bundle，并沿着该 profile 暴露的 `node_modules` 目录构建依赖图，包括重复版本、override 和本地 package-manager 选择。默认把 workspace 写成 `.`，因此配置可以提交并在另一台机器复用；请从项目根目录启动 DSH。如果 DSH 从其他目录启动，再传入 `--workspace <绝对路径>`。它只读取 manifest，不会导入插件代码、运行 lifecycle scripts、启动 DSH 或开启轮询。
 
 如果启动结果不对，先运行本地接线检查，不需要访问漏洞源：
 
@@ -189,7 +184,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -202,7 +197,7 @@ pnpm dlx --package=upstream-radar@0.29.0 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -228,7 +223,7 @@ pnpm run showcase:dsh-probe
 如果要比较多个 DSH 版本，可以使用矩阵入口：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -246,7 +241,7 @@ JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.29.0
+  - uses: MicroMilo/upstream-radar@v0.30.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -254,12 +249,12 @@ steps:
       fail-on-compatibility: breaking
 ```
 
-这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.29.0` 的发布标签，并根据团队策略固定 checkout Action。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.30.0` 的发布标签，并根据团队策略固定 checkout Action。
 
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -267,7 +262,7 @@ pnpm dlx --package=upstream-radar@0.29.0 upstream-radar radar check \
 如果还要检查一个已发布插件能否跨多个 DSH 版本加载，可以增加三个 input：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.29.0
+- uses: MicroMilo/upstream-radar@v0.30.0
   id: radar
   with:
     config: upstream-radar.config.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,8 @@ CLI-generated inventories record the project workspace as `.` by default. This k
 
 The delivery boundary is intentionally at-least-once. A crash after follow-up admission but before the second state write can repeat a task; it cannot silently erase it. Event and task ids allow later delivery adapters to deduplicate. A result is never used to rewrite deterministic vulnerability or compatibility state; a new or updated event deletes the old conclusion, and a response for a stale event is discarded.
 
+The `setup` command is a thin, explicit onboarding wrapper around this path: it asks DSH to install the exact Radar version being run, then generates the inventory and overlay and runs the same local doctor checks. It does not start DSH or execute plugin business actions. `--no-install` keeps the generation/check path available for a profile that already contains the bundle.
+
 The `doctor` command is a separate local diagnosis plane. It parses the config and state, reads the selected DSH profile manifest, checks the generated overlay's paths, and reuses the network-free status snapshot. It never polls an upstream source and never loads a plugin, so a `READY` result means “the wiring is locally coherent,” not “the feeds are current” or “the model has completed an analysis.”
 
 The same local plane renders a bounded action summary from durable state. It preserves the exact first dependency path for a vulnerability, the first checked candidate and strongest compatibility signal for an upgrade, or the failing source for a health incident. Its suggested next step is explicitly guidance; it never upgrades a package or converts incomplete coverage into a safe result.

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -115,13 +115,13 @@ After three consecutive failed OSV checks, Radar creates one project-routed `sou
 
 ## Scene 9 — onboarding without shell state
 
-`init --dsh-patch ./upstream-radar.dsh.yml` writes the exact inventory and a reviewable DSH overlay. The inventory records `project.workspace` as `.` by default, so it can be committed without embedding a creator's home directory; run DSH from the project root. The overlay replaces the bundle's environment-derived paths with explicit config and state files, so the profile can start with one visible command:
+`setup --profile web --dsh-patch ./upstream-radar.dsh.yml` installs the exact running Radar version through DSH, writes the inventory and a reviewable DSH overlay, and runs the local doctor. The inventory records `project.workspace` as `.` by default, so it can be committed without embedding a creator's home directory; run DSH from the project root. The overlay replaces the bundle's environment-derived paths with explicit config and state files, so the profile can start with one visible command:
 
 ```bash
 dsh --profile web --patch ./upstream-radar.dsh.yml
 ```
 
-The generated overlay does not install packages or start DSH; the user still reviews both files and installs the Radar bundle explicitly.
+The setup command does not start DSH or execute plugin business actions; the user still reviews both generated files before launching the profile. Use `--no-install` when the bundle is already present.
 
 ## Scene 10 — confirm the first run without another network request
 
@@ -178,7 +178,7 @@ This is intentionally different from resolving the same package in a fresh npm p
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -192,7 +192,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.29.0
+  - uses: MicroMilo/upstream-radar@v0.30.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -225,7 +225,7 @@ It packs without lifecycle scripts, runs one temporary DSH profile per version, 
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -239,7 +239,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -31,7 +31,7 @@ The optional probe is load-only. It packs with `--ignore-scripts`, uses a tempor
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.29.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.30.0 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.29.0
+      - uses: MicroMilo/upstream-radar@v0.30.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.29.0
+      - uses: MicroMilo/upstream-radar@v0.30.0
         with:
           config: upstream-radar.config.json
           fail-on: high

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import process from 'node:process'
+import { spawnSync } from 'node:child_process'
 import { access, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { renderCompatibilityBenchmark, runCompatibilityBenchmark } from './compatibility-benchmark.js'
@@ -51,6 +52,7 @@ function usage(): string {
   return `Upstream Radar — always-on dependency and compatibility monitoring for DSH plugins
 
 Usage:
+  upstream-radar setup [--profile <name>] [options]
   upstream-radar init [--profile <name>] [options]
   upstream-radar doctor [config.json] [options]
   upstream-radar scan <directory> [--json] [--fail-on <warn|review|block|never>]
@@ -70,6 +72,7 @@ Usage:
   upstream-radar version
 
 Commands:
+  setup    install the exact Radar bundle, generate DSH wiring, and run doctor
   init     discover third-party bundles in a DSH profile and write a reviewable inventory
   doctor   check local Radar/DSH wiring without polling upstream sources
   scan     bounded, read-only inspection of a local package directory
@@ -93,6 +96,7 @@ Options:
   --fail-on-compatibility <value>  CI gate: never|breaking|any (default: never)
   --notes <path>       release notes used as untrusted compatibility evidence
   --profile <name>     DSH profile for init or doctor (init auto-selects the only candidate when omitted)
+  --no-install          setup: reuse an already installed upstream-radar bundle
   --output <path>      init output path (default: ./upstream-radar.config.json)
   --dsh-patch <path>   write a self-contained DSH --patch overlay (optional)
   --patch <path>       DSH overlay to verify with doctor
@@ -519,6 +523,92 @@ async function runRadar(args: readonly string[]): Promise<number> {
   return 0
 }
 
+async function runSetup(args: readonly string[]): Promise<number> {
+  let profile: string | undefined
+  let output = 'upstream-radar.config.json'
+  let patchFile: string | undefined
+  let noInstall = false
+  const initArgs: string[] = []
+  const valueOptions = new Set([
+    '--profile', '--output', '--dsh-patch', '--project-id', '--project-name',
+    '--repository', '--workspace', '--channel', '--registry',
+  ])
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--no-install') {
+      noInstall = true
+      continue
+    }
+    if (argument === '--json') throw new Error('setup does not accept --json; use init --json')
+    if (argument === '--force') {
+      initArgs.push(argument)
+      continue
+    }
+    if (valueOptions.has(argument ?? '')) {
+      const value = args[index + 1]
+      if (value === undefined || value.startsWith('-')) throw new Error(`${argument} requires a value`)
+      if (argument === '--profile') profile = value
+      else if (argument === '--output') output = value
+      else if (argument === '--dsh-patch') patchFile = value
+      initArgs.push(argument ?? '', value)
+      index += 1
+      continue
+    }
+    throw new Error(`unknown option for setup: ${argument}`)
+  }
+
+  let resolvedProfile = profile
+  if (!noInstall && resolvedProfile === undefined) {
+    const candidates = await discoverDshProfiles()
+    if (candidates.length === 0) {
+      throw new Error('setup could not find a DSH profile with third-party bundles; pass --profile <name>')
+    }
+    if (candidates.length > 1) {
+      throw new Error(`setup found multiple DSH profiles with third-party bundles (${candidates.join(', ')}); pass --profile <name>`)
+    }
+    resolvedProfile = candidates[0]
+  }
+  if (resolvedProfile !== undefined && profile === undefined) {
+    initArgs.unshift('--profile', resolvedProfile)
+  }
+
+  if (!noInstall) {
+    if (resolvedProfile === undefined) throw new Error('setup could not select a DSH profile')
+    resolveDshProfileDirectory(resolvedProfile)
+    const dshCommand = process.platform === 'win32' ? 'dsh.cmd' : 'dsh'
+    process.stdout.write(`Installing upstream-radar@${TOOL_VERSION} into DSH profile ${resolvedProfile}...\n`)
+    const result = spawnSync(dshCommand, [
+      'plugin', '--profile', resolvedProfile, 'add', `upstream-radar@${TOOL_VERSION}`,
+    ], {
+      env: process.env,
+      stdio: 'inherit',
+    })
+    if (result.error !== undefined) {
+      throw new Error(`setup could not run ${dshCommand}: ${safeErrorMessage(result.error.message)}`)
+    }
+    if (result.status !== 0) {
+      throw new Error(`DSH plugin installation failed with exit code ${result.status ?? 'unknown'}`)
+    }
+  }
+
+  const initStatus = await runInit(initArgs)
+  if (initStatus !== 0) return initStatus
+
+  const outputPath = resolve(output)
+  const config = parseRadarConfig(await readJson(outputPath))
+  const statePath = `${outputPath}.state.json`
+  const doctorOptions: Parameters<typeof createDoctorReport>[0] = {
+    configFile: outputPath,
+    stateFile: statePath,
+  }
+  const doctorProfile = config.dshProfile?.name ?? resolvedProfile
+  if (doctorProfile !== undefined) doctorOptions.profile = doctorProfile
+  if (patchFile !== undefined) doctorOptions.patchFile = patchFile
+  const doctor = await createDoctorReport(doctorOptions)
+  process.stdout.write(`\nLocal wiring check:\n${renderDoctorReport(doctor)}`)
+  return doctor.status === 'blocked' ? 1 : 0
+}
+
 async function runInit(args: readonly string[]): Promise<number> {
   let profile: string | undefined
   let output = 'upstream-radar.config.json'
@@ -691,6 +781,7 @@ async function main(args: readonly string[]): Promise<number> {
     process.stdout.write(`${TOOL_VERSION}\n`)
     return 0
   }
+  if (command === 'setup') return runSetup(args.slice(1))
   if (command === 'init') return runInit(args.slice(1))
   if (command === 'doctor') return runDoctor(args.slice(1))
   if (command === 'probe') return runProbe(args.slice(1))

--- a/src/dsh-plugin.ts
+++ b/src/dsh-plugin.ts
@@ -513,7 +513,6 @@ export function apply(ctx: DshRadarContext, config: Config = {}): void {
     const inFlightDeliveries = new Map<string, AnalysisDelivery>()
     const onSessionEvent = (session: DshSessionLike, event: DshSessionEventLike): void => {
       serial = serial.then(async () => {
-        if (stopped) return
         const state = await loadRadarState(stateFile)
         const outcome = applyDshAnalysisSessionEvent(state, session, event, inFlightDeliveries)
         if (outcome.state !== state) await saveRadarState(stateFile, outcome.state)

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.29.0'
+export const TOOL_VERSION = '0.30.0'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -18,6 +18,7 @@ describe('CLI option parsing', () => {
   it('advertises a one-command watch loop and validates its safety interval', () => {
     const help = spawnSync(process.execPath, [cli, '--help'], { encoding: 'utf8' })
     assert.equal(help.status, 0)
+    assert.match(help.stdout, /setup \[--profile <name>\]/)
     assert.match(help.stdout, /doctor \[config\.json\]/)
     assert.match(help.stdout, /radar watch <config\.json>/)
     assert.match(help.stdout, /radar status <config\.json>/)
@@ -133,6 +134,61 @@ describe('CLI option parsing', () => {
       assert.match(result.stdout, /--patch .*upstream-radar\.dsh\.yml/)
       const savedConfig = JSON.parse(await readFile(config, 'utf8')) as { projects: Array<{ project: { workspace?: string } }> }
       assert.equal(savedConfig.projects[0]?.project.workspace, '.')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('sets up an exact Radar bundle and verifies the generated DSH wiring', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'upstream-radar-setup-cli-'))
+    try {
+      const dshHome = join(root, 'dsh-home')
+      const profile = join(dshHome, 'profiles', 'web')
+      const bin = join(root, 'bin')
+      const dshLog = join(root, 'dsh-command.txt')
+      await mkdir(join(profile, 'node_modules', 'demo-plugin'), { recursive: true })
+      await mkdir(bin, { recursive: true })
+      await writeFile(join(profile, 'package.json'), JSON.stringify({
+        name: 'dsh-profile-web',
+        dsh: { profile: { bundles: ['upstream-radar', 'demo-plugin'] } },
+      }))
+      await writeFile(join(profile, 'node_modules', 'demo-plugin', 'package.json'), JSON.stringify({
+        name: 'demo-plugin',
+        version: '1.0.0',
+        main: './index.js',
+      }))
+      await writeFile(join(bin, process.platform === 'win32' ? 'dsh.cmd' : 'dsh'),
+        process.platform === 'win32'
+          ? '@echo %* > "%UPSTREAM_RADAR_TEST_LOG%"\r\n'
+          : '#!/bin/sh\nprintf "%s\\n" "$*" > "$UPSTREAM_RADAR_TEST_LOG"\n',
+        { mode: 0o755 })
+
+      const config = join(root, 'upstream-radar.config.json')
+      const patch = join(root, 'upstream-radar.dsh.yml')
+      const result = spawnSync(process.execPath, [
+        cli,
+        'setup',
+        '--profile',
+        'web',
+        '--output',
+        config,
+        '--dsh-patch',
+        patch,
+      ], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          DSH_HOME: dshHome,
+          PATH: `${bin}:${process.env.PATH ?? ''}`,
+          UPSTREAM_RADAR_TEST_LOG: dshLog,
+        },
+      })
+      assert.equal(result.status, 0)
+      assert.match(result.stdout, /Installing upstream-radar@0\.30\.0 into DSH profile web/)
+      assert.match(result.stdout, /Local wiring check:/)
+      assert.match(result.stdout, /Status: READY WITH WARNINGS/)
+      assert.match(await readFile(dshLog, 'utf8'), /plugin --profile web add upstream-radar@0\.30\.0/)
+      assert.equal(JSON.parse(await readFile(config, 'utf8')).dshProfile.name, 'web')
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## What changed

- Add `upstream-radar setup`, an explicit onboarding wrapper for DSH users.
- Install the exact Radar version currently running through `dsh plugin --profile <name> add upstream-radar@<exact-version>`.
- Generate the reviewable inventory and self-contained overlay, then run the network-free local doctor automatically.
- Add `--no-install` for profiles that already contain Radar.
- Shorten English and Chinese quickstarts and document the side-effect/safety boundary.
- Bump the package and Action examples to v0.30.0.

## Why

The previous first-use path required separate plugin installation, initialization, doctor, and startup commands. This keeps installation explicit but reduces onboarding to one setup command plus the final DSH start command. Setup never starts DSH or executes plugin business actions.

## Validation

- [x] `pnpm test` (124 tests)
- [x] `pnpm run try:dsh`
- [x] `pnpm run showcase:dsh-probe`
- [x] `pnpm run benchmark:compatibility`
- [x] `pnpm run scan:self`
- [x] `pnpm pack`
- [ ] GitHub CI matrix (Node 22/24)

The release will publish v0.30.0 only after the CI matrix passes.