### PR TITLE
Enable the always-on upstream observer

### DIFF
--- a/.github/workflows/upstream-observer.yml
+++ b/.github/workflows/upstream-observer.yml
@@ -1,0 +1,109 @@
+name: Upstream Radar observer
+
+on:
+  workflow_dispatch:
+  schedule:
+    # The observer is intentionally periodic: durable state makes the loop
+    # restartable, while the report stays quiet when nothing meaningful changed.
+    - cron: '23 6 * * *'
+
+permissions:
+  contents: write
+
+# Only one run may read/write observations.json at a time. A later run must
+# wait for the earlier run so an observation point is never lost.
+concurrency:
+  group: upstream-radar-observer
+  cancel-in-progress: false
+
+jobs:
+  observe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out the observer and its targets
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11.3.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Build the checked-out Radar
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Observe upstream changes
+        id: observe
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OBSERVER_REPORT: ${{ runner.temp }}/upstream-radar-observer.md
+          OBSERVER_JSON: ${{ runner.temp }}/upstream-radar-observer.json
+          ISSUE_LOCATOR_LLM_BASE_URL: ${{ secrets.ISSUE_LOCATOR_LLM_BASE_URL }}
+          ISSUE_LOCATOR_LLM_API_KEY: ${{ secrets.ISSUE_LOCATOR_LLM_API_KEY }}
+          ISSUE_LOCATOR_LLM_MODEL: ${{ secrets.ISSUE_LOCATOR_LLM_MODEL }}
+        shell: bash
+        run: |
+          set +e
+          llm_env_file="$RUNNER_TEMP/issue-locator.env"
+          trap 'rm -f "$llm_env_file"' EXIT
+          observe_args=(
+            node dist/src/cli.js observe
+            examples/upstream-observer/targets.yml
+            --state observations.json
+            --report "$OBSERVER_REPORT"
+            --retry-pending
+            --json
+          )
+          if [[ -n "${ISSUE_LOCATOR_LLM_BASE_URL:-}" && -n "${ISSUE_LOCATOR_LLM_API_KEY:-}" && -n "${ISSUE_LOCATOR_LLM_MODEL:-}" ]]; then
+            umask 077
+            {
+              printf 'ISSUE_LOCATOR_LLM_BASE_URL=%s\n' "$ISSUE_LOCATOR_LLM_BASE_URL"
+              printf 'ISSUE_LOCATOR_LLM_API_KEY=%s\n' "$ISSUE_LOCATOR_LLM_API_KEY"
+              printf 'ISSUE_LOCATOR_LLM_MODEL=%s\n' "$ISSUE_LOCATOR_LLM_MODEL"
+            } > "$llm_env_file"
+            observe_args+=(--llm-env-file "$llm_env_file")
+            echo 'Optional DSH Agent analysis: configured'
+          else
+            echo 'Optional DSH Agent analysis: not configured; static observation remains active'
+          fi
+          "${observe_args[@]}" | tee "$OBSERVER_JSON"
+          observer_exit=${PIPESTATUS[0]}
+          set -e
+          if [[ -n "${GITHUB_STEP_SUMMARY:-}" && -s "$OBSERVER_REPORT" ]]; then
+            cat "$OBSERVER_REPORT" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "exit=$observer_exit" >> "$GITHUB_OUTPUT"
+          exit "$observer_exit"
+
+      # The state is written even when an upstream source or the optional
+      # Agent fails. Pending tasks and the last trustworthy observations must
+      # survive the runner, so the next scheduled run can retry them.
+      - name: Persist observation state
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f observations.json ]]; then
+            echo 'observations.json was not produced; nothing to persist.'
+            exit 0
+          fi
+          git config user.name 'upstream-radar[bot]'
+          git config user.email 'upstream-radar[bot]@users.noreply.github.com'
+          git add observations.json
+          if git diff --cached --quiet; then
+            echo 'No observation point changed; no commit created.'
+            exit 0
+          fi
+          git commit -m 'chore: update upstream observation point [skip ci]'
+          git push

--- a/README.md
+++ b/README.md
@@ -4,13 +4,34 @@
 [![npm](https://img.shields.io/npm/v/upstream-radar)](https://www.npmjs.com/package/upstream-radar)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-**Dependency evidence and upstream-change monitoring for [DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness) plugins.**
+**The upstream dependency radar built into [DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness) plugins.**
 
-Upstream Radar answers a practical question before a plugin enters a DSH profile:
+Upstream Radar is not another package-name vulnerability scanner. It follows one DSH plugin from admission to maintenance:
 
-> Which exact dependency versions does this plugin bring in, which vulnerability or upstream release changed them, and which other plugins will be affected?
+| Product job | What Radar establishes |
+| --- | --- |
+| **DSH compatibility / admission** | Whether the exact published bundle can be registered and loaded by the DSH releases you care about. |
+| **Real dependency graph** | Which exact package versions and physical paths the plugin brings into the DSH profile, including unresolved edges. |
+| **Continuous upstream monitoring** | Whether an advisory, npm release, DSH/Cordis change, or breaking signal changes the old → new situation. |
+| **Author-facing repair** | Which plugin, dependency path, version, lockfile, or DSH declaration gives the author a concrete next fix. |
 
-It reads source trees, lockfiles, exact npm artifacts, saved DSH reports, and public advisory feeds. It does not install a plugin or execute its business code during static review.
+The deterministic scanner establishes package, graph, advisory, and compatibility facts. Only a meaningful affected change is handed to the DSH Agent for read-only, project-specific analysis; the model does not guess version matches or replace the evidence.
+
+## The product loop
+
+```mermaid
+flowchart TD
+  A["DSH plugin source or exact npm artifact"] --> B["DSH compatibility / admission check"]
+  B --> C["Build the real plugin → dependency graph"]
+  C --> D["Monitor advisories, npm, DSH and Cordis changes"]
+  D --> E{"Meaningful affected change?"}
+  E -- "No" --> F["Update observation point and stay quiet"]
+  E -- "Yes" --> G["Calculate exact old → new impact paths"]
+  G --> H["Send bounded evidence to the DSH Agent"]
+  H --> I["Return a repairable action to the plugin author"]
+```
+
+This is the boundary: Radar decides **what changed and which exact path is involved**; DSH decides **what that means for the project**. A later website can visualize the saved graph, but the evidence and impact index are already useful without one.
 
 ## Try it in 60 seconds
 
@@ -23,8 +44,8 @@ npx --yes upstream-radar@0.34.0 scan \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --fail-on never
 
-# Review the exact package users would install, then check two DSH releases
-npx --yes upstream-radar@0.34.0 review dsh-plugin dsh-feishu-bot@0.15.8 \
+# Review a real browser plugin users would install, then check two DSH releases
+npx --yes upstream-radar@0.34.0 review dsh-plugin dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
 
@@ -36,6 +57,7 @@ These are real, reproducible cases in this repository—not synthetic “vulnera
 
 | Case | Finding | Why it matters |
 | --- | --- | --- |
+| [`dsh-cloudflare-browser-run@0.1.1`](examples/reports/dsh-cloudflare-browser-run-0.1.1.txt) | 18 resolved packages, 2 unresolved optional Cordis edges, 0 known vulnerabilities, and DSH rc.6/rc.7 both loaded the bundle | A real browser plugin demonstrates the DSH admission boundary and why incomplete edges stay visible. |
 | [50-plugin batch](examples/dsh/reports/dsh-batch-50-2026-08-17.md) | 0 confirmed runtime dependency vulnerabilities; 3 lockfile root-version mismatches | Monitoring can be wrong even when the vulnerability count is zero. |
 | [`dsh-feishu-bot@0.15.8`](examples/dsh/reports/dsh-feishu-bot-0.15.8-review-2026-08-18.md) | 89-package graph, 12 unresolved optional edges, reachable `protobufjs` `postinstall`, DSH rc.6/rc.7 compatible | “No known CVE” is not the same as “no installation trust boundary.” |
 | [DSH-TUI source vs npm](examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md) | Source has `prepare`; published artifact does not | Source-only and artifact-only reviews answer different questions. |
@@ -43,21 +65,18 @@ These are real, reproducible cases in this repository—not synthetic “vulnera
 
 We report a confirmed vulnerability only when the affected exact version and runtime path are supported by the available evidence. Development-only hits, missing data, and advisory-source outages remain visibly different states.
 
-## The core workflow
+## The dependency graph behind every alert
 
 ```text
-DSH plugin source / npm artifact
-          ↓
-exact dependency graph + DSH compatibility evidence
-          ↓
-saved observation point
-          ↓
-upstream commit, package, or advisory changes
-          ↓
-affected-plugin paths and author-facing next action
-          ↓
-optional DSH Agent analysis only when a meaningful change exists
+plugin@1.0.0
+├── framework@2.4.7
+│   ├── parser@3.2.1
+│   └── archive@1.8.0
+└── logger@4.0.2
+    └── parser@2.9.0  ← the affected physical node
 ```
+
+Two copies of `parser` are different nodes. An alert names the exact version and path that entered the DSH profile; it does not page every plugin that happens to use the same package name.
 
 For a collection of saved reports, build the reverse index that turns an upstream package update into affected plugins:
 


### PR DESCRIPTION
## What changed

- activate the scheduled upstream observer under `.github/workflows/upstream-observer.yml`
- persist `observations.json` after every run, including source or Agent failures
- serialize runs so observation state cannot be overwritten concurrently
- keep DSH Agent analysis optional and retry pending tasks on the next run
- publish the report to the GitHub Job Summary

## Why

This turns the existing observer from an example into the first always-on DSH upstream monitoring loop. No meaningful upstream change means no Agent wake-up. A failed Agent does not erase the static observation.

## Validation

- YAML parsed successfully
- `pnpm test` — 272 passed
- actions are pinned to reviewed commit SHAs

The workflow runs daily at 06:23 UTC and can also be started manually.