### PR TITLE
feat: continuously monitor known DSH findings

### DIFF
--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.37.0
+      - uses: MicroMilo/upstream-radar@v0.38.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/.github/workflows/dsh-finding-watch.yml
+++ b/.github/workflows/dsh-finding-watch.yml
@@ -1,0 +1,98 @@
+name: DSH known finding watch
+
+on:
+  workflow_dispatch:
+  schedule:
+    # The watch is deliberately independent from the broader upstream
+    # observer: it checks the seven already-reported findings every day.
+    - cron: '41 6 * * *'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: upstream-radar-dsh-finding-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out the watch and its targets
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11.3.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Build the checked-out Radar
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm build
+
+      - name: Check known findings
+        id: watch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          WATCH_REPORT: ${{ runner.temp }}/dsh-finding-watch.md
+          WATCH_JSON: ${{ runner.temp }}/dsh-finding-watch.json
+        shell: bash
+        run: |
+          set +e
+          node scripts/monitor-dsh-findings.mjs \
+            --state examples/dsh/finding-watch/state.json \
+            --report "$WATCH_REPORT" \
+            --json-report "$WATCH_JSON"
+          watch_exit=$?
+          set -e
+          if [[ -s "$WATCH_REPORT" ]]; then
+            cat "$WATCH_REPORT" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "exit=$watch_exit" >> "$GITHUB_OUTPUT"
+          exit "$watch_exit"
+        continue-on-error: true
+
+      - name: Upload the machine report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dsh-finding-watch
+          path: |
+            ${{ runner.temp }}/dsh-finding-watch.md
+            ${{ runner.temp }}/dsh-finding-watch.json
+          if-no-files-found: error
+          retention-days: 30
+
+      # A finding is not a workflow failure. The state is committed so the
+      # next run can classify added, resolved, changed and persisting evidence.
+      # Unknown checks also advance only the trusted half of a target; they do
+      # not erase the last successful artifact observation.
+      - name: Persist trusted observation state
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f examples/dsh/finding-watch/state.json ]]; then
+            echo 'state.json was not produced; nothing to persist.'
+            exit 0
+          fi
+          git config user.name 'upstream-radar[bot]'
+          git config user.email 'upstream-radar[bot]@users.noreply.github.com'
+          git add examples/dsh/finding-watch/state.json
+          if git diff --cached --quiet; then
+            echo 'No trusted observation changed; no commit created.'
+            exit 0
+          fi
+          git commit -m 'chore: update DSH finding watch state [skip ci]'
+          git push

--- a/.github/workflows/review-dsh-plugin.yml
+++ b/.github/workflows/review-dsh-plugin.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.37.0
+        uses: MicroMilo/upstream-radar@v0.38.0
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.38.0] - 2026-08-21
+
+### Always-on known finding watch
+
+- Add a focused watch for seven real DSH plugin supply-chain findings, checking source and the exact npm artifact separately.
+- Persist trusted observations and classify findings as added, resolved, changed, persisting, or unknown without treating network failures as fixes.
+- Add a daily GitHub Actions workflow, machine-readable report, author-facing Markdown report, bounded retries, and proxy-aware npm checks.
+
 ## [0.37.0] - 2026-08-19
 
 ### Real DSH dependency corpus

--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ baseline report, and defined in [`schemas/upstream-downstream-ir.schema.json`](s
 
 ```bash
 # No DSH profile, API key, or network state required
-npx --yes upstream-radar@0.37.0 demo
+npx --yes upstream-radar@0.38.0 demo
 
 # Scan a public DSH plugin repository without installing it
-npx --yes upstream-radar@0.37.0 scan \
+npx --yes upstream-radar@0.38.0 scan \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --fail-on never
 
 # Review a real browser plugin users would install, then check two DSH releases
-npx --yes upstream-radar@0.37.0 review dsh-plugin dsh-cloudflare-browser-run@0.1.1 \
+npx --yes upstream-radar@0.38.0 review dsh-plugin dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
 
@@ -91,6 +91,30 @@ These are real, reproducible cases in this repository—not synthetic “vulnera
 
 We report a confirmed vulnerability only when the affected exact version and runtime path are supported by the available evidence. Development-only hits, missing data, and advisory-source outages remain visibly different states.
 
+## Monitor the findings we already found
+
+The repository now has a focused watch for seven real DSH plugins from the first
+batch. It re-runs the source scan and the exact npm artifact review, then stores
+only trusted observations in [`state.json`](examples/dsh/finding-watch/state.json)
+and writes the current author-facing result to
+[`report.md`](examples/dsh/finding-watch/report.md).
+
+```bash
+pnpm run monitor:dsh-findings
+```
+
+The watch distinguishes `persisting`, `added`, `resolved`, `changed`, and
+`unknown`. A failed registry request never becomes “resolved”; a source fix also
+does not erase a finding that remains in the published npm artifact. The same
+loop runs daily in [the dedicated GitHub Actions workflow](.github/workflows/dsh-finding-watch.yml)
+and commits the state only when a trusted observation changes. It does not install
+plugins, execute lifecycle scripts, load DSH, or call an LLM.
+
+The current run is already useful: `dsh-msg-hub@0.1.8` has removed the old source
+lockfile findings, but its npm artifact still reaches `protobufjs@7.6.5` with a
+`postinstall`; `dsh-wsl-workspace` now resolves `koffi@3.1.6`, while the native
+install step remains. The other reviewed install/lifecycle findings persist.
+
 ## The dependency graph behind every alert
 
 ```text
@@ -107,11 +131,11 @@ Two copies of `parser` are different nodes. An alert names the exact version and
 For a collection of saved reports, build the reverse index that turns an upstream package update into affected plugins:
 
 ```bash
-npx --yes upstream-radar@0.37.0 graph reverse ./reports \
+npx --yes upstream-radar@0.38.0 graph reverse ./reports \
   --output reverse-dependency-index.json
 
 # Ask: which plugins currently depend on this exact package?
-npx --yes upstream-radar@0.37.0 graph reverse ./reports \
+npx --yes upstream-radar@0.38.0 graph reverse ./reports \
   --package parser@2.9.0
 
 # Rebuild the checked-in index from the real first 50 DSH plugin reports
@@ -130,7 +154,7 @@ To route an upstream old → new change to that index, pass it to the always-on
 observer:
 
 ```bash
-npx --yes upstream-radar@0.37.0 observe ./targets.yml \
+npx --yes upstream-radar@0.38.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json \
   --report ./upstream-radar-observer.md
@@ -156,7 +180,7 @@ replay baseline → one Agent task → quiet run without network access.
 The repository already contains a reusable, composite Action in [`action.yml`](action.yml). It runs the same frozen Radar check in CI and writes a short Job Summary.
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.37.0
+- uses: MicroMilo/upstream-radar@v0.38.0
   with:
     config: upstream-radar.config.json
     fail-on: high
@@ -180,7 +204,7 @@ See the [consumer workflow](examples/github-actions/consumer/README.md) for conf
 pnpm add upstream-radar
 
 # Generate a reviewable DSH profile inventory from the installed profile
-npx --yes upstream-radar@0.37.0 setup
+npx --yes upstream-radar@0.38.0 setup
 ```
 
 For Feishu/webhook routing, DSH Agent handoff, observer state, report schemas, and troubleshooting, use the [full Chinese guide](docs/README.zh-CN.md). The [architecture notes](docs/architecture.md) explain the boundaries and evidence model.

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.37.0
+    default: 0.38.0
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -48,6 +48,7 @@ npx --yes upstream-radar@latest quickstart
 | --- | --- | --- |
 | 让在线 DSH Agent 持续跟进 | [`setup`](#安装到-dsh) | 自动刷新 profile 里的实际依赖图，只把有变化的事件交给对应项目的 Agent。 |
 | 观察 DSH 插件上游变化 | [`observe`](#观察-dsh-插件的上游变化) | 定时比较 GitHub commit、npm 发布物、manifest 和可选锁文件依赖图，只把重要变化交给 Agent。 |
+| 监控已经发现的问题 | [DSH known finding watch](../examples/dsh/finding-watch/README.md) | 对第一批 7 个真实插件重复检查源码与精确 npm 发布物，把问题标成持续、修复、变化或无法确认。 |
 | 30 秒开始监控一个公开插件 | [最小 GitHub Actions workflow](../examples/github-actions/upstream-observer-minimal.yml) | 复制一个文件、改仓库地址，每天得到报告，不需要安装或构建 Radar。 |
 | 收到第一条告警后知道先做什么 | [`radar next`](#安装到-dsh) | 一个只读命令选出最高优先级事件，并指向 DSH task、已验证分析或下一轮检查。 |
 | 启动 DSH 前检查 profile | [`profile-check`](#启动-dsh-前先检查-profile) | 读取实际锁文件和 patch，提前拦住缺失 loader 包、重复 loader id 以及 release-age 回退风险。 |
@@ -96,7 +97,7 @@ FIRST EPSS estimated exploitation probability: 97.2% (percentile 100.0%)
 想立即检查一个真实发布的 DSH 插件，可以在空目录直接运行：
 
 ```bash
-npx --yes upstream-radar@0.37.0 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.38.0 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 它会直接输出简短的准入结论、覆盖情况、依赖数量、漏洞数量和下一步，不需要先
@@ -109,7 +110,7 @@ npx --yes upstream-radar@0.37.0 inspect dsh-feishu-bot@0.15.8 --deep
 npm 解析环境中目前无法建立完整依赖图：
 
 ```bash
-npx --yes upstream-radar@0.37.0 inspect \
+npx --yes upstream-radar@0.38.0 inspect \
   @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
   --deep --fail-on never
 ```
@@ -280,6 +281,23 @@ OpenAI-compatible 模型，先设置
 这是新的上游变化闭环：Radar 不在每轮都重复做一次大扫描，而是为每个
 插件保存一个观察点，然后回答“从上次观察到现在到底变了什么”。
 
+### 只监控已经发现的问题
+
+如果目标不是重新发现所有问题，而是持续回答“上次报告的这条问题现在还在不在”，运行仓库内置的专用观察清单：
+
+```bash
+pnpm run monitor:dsh-findings
+```
+
+它会对 `examples/dsh/finding-watch/targets.json` 中的 7 个真实 DSH 插件分别做两次检查：
+
+1. 扫描公开 GitHub 源码，不安装依赖、不运行插件；
+2. 按源码当前版本检查精确 npm 发布物，依赖解析使用禁用 lifecycle script 的环境。
+
+它把源码和发布物分开保存，因为维护者可能已经修了 GitHub 仓库，但还没有重新发布 npm 包。每条观察结果只有在检查成功时才会推进；网络失败是 `unknown`，不会被写成“已修复”。状态保存在 [`state.json`](../examples/dsh/finding-watch/state.json)，可读报告在 [`report.md`](../examples/dsh/finding-watch/report.md)，每日 workflow 是 [`dsh-finding-watch.yml`](../.github/workflows/dsh-finding-watch.yml)。
+
+当前真实结果中，`dsh-msg-hub@0.1.8` 的源码侧已经没有旧的 lockfile 图不可用/根版本过期问题，但同版本 npm 发布物仍可达 `protobufjs@7.6.5` 的 `postinstall`；`dsh-wsl-workspace` 由 `koffi@3.1.5` 变成了 `3.1.6`，但安装脚本仍然存在。这个入口的用途是监控这些已知问题的生命周期，不把每次定时运行都伪装成新的漏洞发现。
+
 ```text
 targets.yml
   ↓
@@ -317,9 +335,9 @@ npm：     dsh-feishu-bot@0.15.8
 会继续显示为 `incomplete`，不会被当成已经确认的故障。
 
 ```bash
-npx --yes upstream-radar@0.37.0 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.38.0 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.37.0 observe ./targets.yml \
+npx --yes upstream-radar@0.38.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -357,7 +375,7 @@ Radar 会在三层目录内自动找到它；npm 名称和源码 manifest 不一
 想明确选择锁文件时再加 `--lockfile`：
 
 ```bash
-npx --yes upstream-radar@0.37.0 observe \
+npx --yes upstream-radar@0.38.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -380,7 +398,7 @@ workspace 边保留为未解析证据；不会安装或启动 DSH。
 会额外指定 `--package`：
 
 ```bash
-npx --yes upstream-radar@0.37.0 observe \
+npx --yes upstream-radar@0.38.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -658,7 +676,7 @@ cd my-dsh-plugin
 pnpm install --ignore-scripts
 
 # 把插件放进 DSH profile 前，先读取精确依赖图。
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
 ```
 
 这棵图会保留精确的 DSH 包版本，也会把未解析的可选 peer 明确显示出来；它不会加载生成的插件，也不会运行 lifecycle script。审查后，把下面这个完整 workflow 复制到 `.github/workflows/upstream-radar.yml`：
@@ -680,7 +698,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.37.0
+      - uses: MicroMilo/upstream-radar@v0.38.0
         with:
           fail-on: high
           fail-on-compatibility: breaking
@@ -691,7 +709,7 @@ Action 会自动识别唯一的 `pnpm-lock.yaml`，检查同一棵精确依赖�
 也可以直接检查一个真实发布的 DSH 包：
 
 ```bash
-npx --yes upstream-radar@0.37.0 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.38.0 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 这次检查的结论是 `REVIEW`：registry 完整性、签名、provenance 和 89 个已解析包都
@@ -704,7 +722,7 @@ npx --yes upstream-radar@0.37.0 inspect dsh-feishu-bot@0.15.8 --deep
 如果不想分别执行 `inspect`、打包和 `probe`，可以用一个命令完成一次 DSH 插件审查：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar review dsh-plugin \
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar review dsh-plugin \
   dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
@@ -870,7 +888,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -883,7 +901,7 @@ pnpm dlx --package=upstream-radar@0.37.0 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -909,7 +927,7 @@ pnpm run showcase:dsh-probe
 如果要比较多个 DSH 版本，可以使用矩阵入口：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -927,7 +945,7 @@ JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.37.0
+  - uses: MicroMilo/upstream-radar@v0.38.0
     with:
       fail-on: high
       # 可选：把确定性的 DSH/插件兼容性破坏也作为 CI 失败条件
@@ -936,12 +954,12 @@ steps:
       threat-intel: true
 ```
 
-这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。`threat-intel` 默认是 `false`，这样普通 CI 门禁不会因为额外查询变重；设置为 `true` 后，Job Summary 和原始 JSON 会包含 CISA KEV 与 FIRST EPSS 的优先级证据。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。除了原始 JSON 日志，Action 还会把经过转义的简短摘要写入 GitHub Job Summary，定时任务失败时可以直接看到受影响的包、准确依赖路径、已经发布的修复版本（如果有）、一行优先级证据和建议的下一步。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.37.0` 的发布标签，并根据团队策略固定 checkout Action。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。`threat-intel` 默认是 `false`，这样普通 CI 门禁不会因为额外查询变重；设置为 `true` 后，Job Summary 和原始 JSON 会包含 CISA KEV 与 FIRST EPSS 的优先级证据。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。除了原始 JSON 日志，Action 还会把经过转义的简短摘要写入 GitHub Job Summary，定时任务失败时可以直接看到受影响的包、准确依赖路径、已经发布的修复版本（如果有）、一行优先级证据和建议的下一步。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.38.0` 的发布标签，并根据团队策略固定 checkout Action。
 
 如果仓库还没有提交 Radar 配置，最短接入方式是省略 `config`、`pnpm-lock` 和 `npm-lock`。checkout 之后，Action 会自动使用唯一存在的 `pnpm-lock.yaml` 或 `package-lock.json`，生成临时的审查清单，再执行同一个 frozen 检查：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.37.0
+- uses: MicroMilo/upstream-radar@v0.38.0
   with:
     fail-on: high
 ```
@@ -951,7 +969,7 @@ steps:
 如果要在插件进入 DSH 前审查精确发布物，可以增加 `inspect-package`：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.37.0
+- uses: MicroMilo/upstream-radar@v0.38.0
   with:
     inspect-package: dsh-cloudflare-browser-run@0.1.1
     # review 是安全默认值；只有允许覆盖不完整时才使用 block
@@ -963,7 +981,7 @@ steps:
 如果仓库只有 pnpm 锁文件，还没有提交 Radar 配置，可以让 Action 在同一个 job 中生成配置；可直接复制[pnpm workflow 示例](../examples/github-actions/upstream-radar-pnpm.yml)：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.37.0
+- uses: MicroMilo/upstream-radar@v0.38.0
   with:
     pnpm-lock: pnpm-lock.yaml
     fail-on: high
@@ -977,7 +995,7 @@ npm 项目可以改用 `npm-lock: package-lock.json`；`pnpm-lock` 和 `npm-lock
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -985,7 +1003,7 @@ pnpm dlx --package=upstream-radar@0.37.0 upstream-radar radar check \
 如果还要检查一个已发布插件能否跨多个 DSH 版本加载，可以增加三个 input：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.37.0
+- uses: MicroMilo/upstream-radar@v0.38.0
   id: radar
   with:
     config: upstream-radar.config.json

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -210,7 +210,7 @@ When the native DSH adapter is running, it additionally verifies the exact `@dee
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -224,7 +224,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.37.0
+  - uses: MicroMilo/upstream-radar@v0.38.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -257,7 +257,7 @@ It packs without lifecycle scripts, runs one temporary DSH profile per version, 
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -271,7 +271,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```

--- a/examples/dsh/finding-watch/README.md
+++ b/examples/dsh/finding-watch/README.md
@@ -1,0 +1,40 @@
+# DSH known finding watch
+
+This is the first always-on loop for the seven supply-chain findings discovered
+in the real DSH plugin batch. It does not install a plugin, run a lifecycle
+script, load plugin code, or call a model. It repeats the same two bounded
+checks:
+
+1. scan the public source repository;
+2. inspect the exact npm version currently named by that source package.
+
+The watch keeps the source and published artifact separate. A clean source scan
+does not erase a finding that still exists in the published npm bytes. A failed
+network request is `unknown`, never `resolved`.
+
+## Run locally
+
+```bash
+pnpm run monitor:dsh-findings
+```
+
+The default output is:
+
+- `state.json`: the last trusted source and artifact observations, suitable for
+  the next run;
+- `report.md`: the author-facing result;
+- `report.json`: the machine-readable result.
+
+Override paths when you do not want to change the checked-in observation point:
+
+```bash
+pnpm run monitor:dsh-findings -- \
+  --state "$TMPDIR/dsh-finding-state.json" \
+  --report "$TMPDIR/dsh-finding-report.md" \
+  --json-report "$TMPDIR/dsh-finding-report.json"
+```
+
+The GitHub Actions workflow at `.github/workflows/dsh-finding-watch.yml` runs
+the same command on a schedule and commits `state.json` only when a trusted
+observation changes. Findings are evidence for review, not a claim that every
+install script or native binary is malicious.

--- a/examples/dsh/finding-watch/report.json
+++ b/examples/dsh/finding-watch/report.json
@@ -1,0 +1,1320 @@
+{
+  "schema": "upstream-radar.finding-watch-report/v1alpha1",
+  "checkedAt": "2026-08-21T03:07:08.515Z",
+  "config": "examples/dsh/finding-watch/targets.json",
+  "state": "examples/dsh/finding-watch/state.json",
+  "summary": {
+    "targets": 7,
+    "baseline": 0,
+    "changed": 0,
+    "unchanged": 7,
+    "unknown": 0,
+    "transitions": {
+      "added": 0,
+      "resolved": 0,
+      "changed": 0,
+      "persisting": 42
+    }
+  },
+  "targets": [
+    {
+      "id": "anan-thermal-monitor",
+      "repository": "AmeKrance/anan-thermal-monitor",
+      "package": "anan-thermal-monitor",
+      "watch": [
+        "npm-archive-invalid",
+        "native-binary-present",
+        "npm-provenance-missing"
+      ],
+      "status": "unchanged",
+      "source": {
+        "status": "unchanged",
+        "name": "anan-thermal-monitor",
+        "version": "1.0.4",
+        "digest": "sha256:34a515e6395fe13735b88d1f7a10324068ec4c90d579b4d851c356c51da2063b",
+        "findings": [
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/ja/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/ja/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "e282404035693502882bca0b88e988fe0bff8ace799ce67582bbb1485751b5dd",
+              "size": 10240
+            },
+            "fingerprint": "sha256:05617fc31b4dc9542cf376cdf28b7177d9c99da6da4444959982629092e7ee0d"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/Aga.Controls.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/Aga.Controls.dll",
+              "sha256": "e9f4eb385359a6d51fcf88153c597e3d75b6e64d5f1c3766eaa2deee739e855f",
+              "size": 145920
+            },
+            "fingerprint": "sha256:130dcf195026c91eb52e6851fd3e163c5a0e06f35ba2b1c069e5b81eedb89819"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Text.Encodings.Web.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Text.Encodings.Web.dll",
+              "sha256": "43e6dfb4aa333848be5066dcb3d490afc417d0f896aada2f17b5db5fcbb819fc",
+              "size": 87816
+            },
+            "fingerprint": "sha256:18cc4801aa237e5460cf69ad625faeaa551bc1383d6465a19c26b6c4c1d45084"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/OxyPlot.WindowsForms.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/OxyPlot.WindowsForms.dll",
+              "sha256": "0758b8a4c129730e4585e717d4183d48b1167a78e4955ce704d9e6cc204148b2",
+              "size": 32768
+            },
+            "fingerprint": "sha256:1a7ea3562a15ed7ce6f0ea7d330d51cda823483fea420b5ba173b5cc45ef3051"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/RAMSPDToolkit-NDD.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/RAMSPDToolkit-NDD.dll",
+              "sha256": "b6882354c7c8ec186617e421507743dbfae09c5c1fc24cef76a1d0c0c26651de",
+              "size": 233472
+            },
+            "fingerprint": "sha256:2152ef1580b43c942c60d1cdcec836d1c03e2a95a62c6fb08a2652229ab81008"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Security.Principal.Windows.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Security.Principal.Windows.dll",
+              "sha256": "b4d8e15adc235d0e858e39b5133e5d00a4baa8c94f4f39e3b5e791b0f9c0c806",
+              "size": 18312
+            },
+            "fingerprint": "sha256:2e611e20bd9090473a01664d6516d4df2585dff5c5066e132755b9527c886361"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/tr/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/tr/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "1429cd58467aea880302b369eb802a55411aba008895bd0023376526538fb462",
+              "size": 10240
+            },
+            "fingerprint": "sha256:2fda6f4527c9ddf6883d844f488298c8a3858f6a8fe310b5aae0e52de58d0d11"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/sv/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/sv/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "84ede4a0234ee6cd52329939e696b8bc2758b313dd7225d7a46828ed626d5e36",
+              "size": 9728
+            },
+            "fingerprint": "sha256:300664462284548f477901c79336909593da31a24a07c2ede91f26eda7615711"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/zh-CN/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/zh-CN/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "9f1f40400b3184e162f6606cce12820fabbb7f2a9b67202e91c01595b6dee26a",
+              "size": 9728
+            },
+            "fingerprint": "sha256:3212721ce843e3b8b7bbb9384fd138116ac9ce38cdfe6430cab7bb2ab96b72fd"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/LibreHardwareMonitorLib.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/LibreHardwareMonitorLib.dll",
+              "sha256": "6ebc194316536ba61af5be24508ad9fcbb2ecc685e716c12e787c79530f66bf0",
+              "size": 1203200
+            },
+            "fingerprint": "sha256:3cf40484fe9d0e17eab5127a262493335d5fb0ff7d251f10f18d53397cbdcec1"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Runtime.CompilerServices.Unsafe.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Runtime.CompilerServices.Unsafe.dll",
+              "sha256": "08cbd7278b66f1e68425a82d4b97181a4130d93e3dd91831407aba7212ccdacf",
+              "size": 19256
+            },
+            "fingerprint": "sha256:4368aaca91de839d1cf7b4e41b8f1f1a2c90f59b4137e05ca536cb45099ec6fc"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Collections.Immutable.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Collections.Immutable.dll",
+              "sha256": "8c0f09a8b1fd730da3f3d2c4c831cdd76e3fca6bc588523d8f7eacf16d5a24e9",
+              "size": 253232
+            },
+            "fingerprint": "sha256:4a5a2fc1f8484268bfdfab8e03aa53a5ec86092746e94013d914107c3a1a7f7f"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Formats.Nrbf.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Formats.Nrbf.dll",
+              "sha256": "27514fbffb0776c37ede88ec371310844f7bec55a017627aad60180f268769e4",
+              "size": 71472
+            },
+            "fingerprint": "sha256:535dbea0ce7fbd954344dfed9b390a3ce7656777d2f5679fb66ff0c3a8f03695"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Resources.Extensions.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Resources.Extensions.dll",
+              "sha256": "c3748f17d2f5209cc795a88ad4946c12c3f6ef73b3015dc92c43f932a342b17c",
+              "size": 115984
+            },
+            "fingerprint": "sha256:58b43a6924affc4c97ae071f102589feb50c571cabd116a497ae9ee6153cf69b"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/fr/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/fr/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "4b282ddf1f09e09242ca11a22fd7dfdd069ede751961bdf8d771258071823b51",
+              "size": 10240
+            },
+            "fingerprint": "sha256:5a3aeb5b2166144ddfce749bce9f1e1af93050b8bc1fc7b8ec91aa58c32a3d2a"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/OxyPlot.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/OxyPlot.dll",
+              "sha256": "da767e3d8c10674e6ffa72670952d1274544b453b68e774b29f03b5160a4a034",
+              "size": 700928
+            },
+            "fingerprint": "sha256:5aa8a28453958873a5c6d8940d8c8eee06e3160e75daba302078143f9e07b1f8"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Reflection.Metadata.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Reflection.Metadata.dll",
+              "sha256": "6c1fe5d140f0f21fac0eea7b1d3e3bc2526c0027e857bcf5227af722a9b32a0d",
+              "size": 515336
+            },
+            "fingerprint": "sha256:6a44b4e342d42dd4f2de351a9cb596b2ae2029450894b8fbf5fc00d89ed7d64f"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/es/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/es/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "b417b6a5b5dc7349122a00c43c06897aedf414046af83ba14ba28838f243ca42",
+              "size": 10240
+            },
+            "fingerprint": "sha256:79eead350099350b443ad0a290d29d3f4ba0a7fb4cc018e87236492e22bfccc4"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/LibreHardwareMonitor.exe",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/LibreHardwareMonitor.exe",
+              "sha256": "fe216a48a48a6048156a133a39b960437d781a4c9214e5abc0f26f666f61ba22",
+              "size": 4458496
+            },
+            "fingerprint": "sha256:7e5cdb157f1c702ebe018deb7362625abe565ff03c00a7ddde554aa9a0e0d0fb"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Threading.Tasks.Extensions.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Threading.Tasks.Extensions.dll",
+              "sha256": "af4e13ef418fd89b432de20cd1dfb7fa10a7179c8dd049c9856316e50c5949ca",
+              "size": 27960
+            },
+            "fingerprint": "sha256:83a9e53861e9170ff6bf925ff59bc537d041a21eedf6b14dbe49d34a67ca021a"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/BlackSharp.Core.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/BlackSharp.Core.dll",
+              "sha256": "cafb93afcc8d8a367e21f619673d05c06887d8964867fed1371f02ded1cd3e23",
+              "size": 32768
+            },
+            "fingerprint": "sha256:86b8d459acc1fd55a886a59d20c2a2233793ed0a4399280e7ff5c0d4fc7c28fd"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Security.AccessControl.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Security.AccessControl.dll",
+              "sha256": "ff14c5f628b9a6798d173aefbba0a43d61e66f715108e2576ac0d3dfab9071d0",
+              "size": 35952
+            },
+            "fingerprint": "sha256:880b38cab026845f22a67613137a1c386ea7a4432e7cdea8c8cb5ce87ca9ffca"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/it/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/it/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "24a3040b55de26ce6c8f36f60e1d728ead14416875c01d160d9ffcfbeaa8dcd5",
+              "size": 10240
+            },
+            "fingerprint": "sha256:8bb31a5348007b1b635dc6ffec966bb0596a2667da357a5d39a71b4b8129f093"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Text.Json.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Text.Json.dll",
+              "sha256": "7a7f2e0b942782739551b37546efc842f53c7fce3a8f0f56ad45a5cf78e2c214",
+              "size": 778504
+            },
+            "fingerprint": "sha256:997b98337d88bb4f575a0253d9961f36d6d8e30c173d481978470ed63d4193f3"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/pl/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/pl/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "2ddd5ed4d84e8732334b5f6e08b3d61190da58762d33db72f7e229eb7e4791f0",
+              "size": 10240
+            },
+            "fingerprint": "sha256:a475e17fcc50f0e261f1a16e884f19c008256940b1cb94cf29607156a2acb2fe"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/Microsoft.Bcl.HashCode.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/Microsoft.Bcl.HashCode.dll",
+              "sha256": "3a4e851ee5fc0f6182aa5a3d65dc56fcd6979b65334b5c3b92fbdc791457c0ab",
+              "size": 26920
+            },
+            "fingerprint": "sha256:a8500ac783bb39e6380dac50f7528035f42834683d8307c0244d38d961a77cf1"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/HidSharp.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/HidSharp.dll",
+              "sha256": "d86690efde30ea9179f669320f39148853793b743a98b531afeaf30598e22f54",
+              "size": 262792
+            },
+            "fingerprint": "sha256:b012080312c3e71d31f6a1a2cbdba7e1b4dcafb9f3a4e412cd5011e82a62f74b"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.CodeDom.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.CodeDom.dll",
+              "sha256": "e9bca8ecab5f02df389ee4b306c32a93d7822b524a6eca90e449e13d4b4283a3",
+              "size": 34064
+            },
+            "fingerprint": "sha256:b903638d6d88f5f6b0303b8450496eda3a534cbb29d65f16b789a644a505c205"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Memory.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Memory.dll",
+              "sha256": "d5e8e4866f9cfa66f7765660f84b210198893e55335487afe5ebda342c0e913d",
+              "size": 145200
+            },
+            "fingerprint": "sha256:bef1e999ffad33162de3aad55765849744e298019001e800dae9ae1fa0762978"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.IO.Pipelines.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.IO.Pipelines.dll",
+              "sha256": "52a813c62932462d8f070f001acd1f264c0766a11a78c6d3c4f81ee3b1d67223",
+              "size": 85768
+            },
+            "fingerprint": "sha256:c046375018a043eff573db137dc4b3ff05d179da2d02c64f8bc6089c17c1473d"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/DiskInfoToolkit.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/DiskInfoToolkit.dll",
+              "sha256": "1acbf51b3c10c51c986cf43021680d34a2e38d9a5ba652bcfa9a1b5f7fc09800",
+              "size": 903680
+            },
+            "fingerprint": "sha256:d04b70b2250a83cdcca7ad421fdb2954a30b1f10d114eb13791ff1139b77a9f3"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/de/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/de/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "f54e8a38be8e27f178ac519e7eafa613d0341037bd0f723bf128fcdb94b7b540",
+              "size": 9728
+            },
+            "fingerprint": "sha256:d9cdedf7d3f2535fd9cdfbd7719467a9749b471937bbe74bac7ae9dfa196d6ce"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/ru/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/ru/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "b15e736a0e3c1051becdefaadfeaab68163c2203381e1e782316372a58fcb0c6",
+              "size": 10752
+            },
+            "fingerprint": "sha256:dd6264bda56a9b6af6f72ed113db78a685d0362dcfc5cf83d7b38755b76a9d81"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/zh-Hant/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/zh-Hant/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "a065c666fea783efd1c535bea0f409cdaeeda0f279d339bb120a32537766e1aa",
+              "size": 9728
+            },
+            "fingerprint": "sha256:ee39f4e9a9cb38386ac8ac13952323642d62a306c90ce983a5b9af7c9ab829c5"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Numerics.Vectors.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Numerics.Vectors.dll",
+              "sha256": "20c2fa81b8c70d651099d762954f285fd4f942e63b2d7217c145dab8d4b2f4c9",
+              "size": 110344
+            },
+            "fingerprint": "sha256:efbb36263d34a476e9a81f7c561970fba1b95db71ae865913fcde226034f55ff"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Threading.AccessControl.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Threading.AccessControl.dll",
+              "sha256": "5e3a3902f04f840c0fc1f9c2f249f804f6cfdf7901b2e06778bc2a4603ae4694",
+              "size": 34568
+            },
+            "fingerprint": "sha256:f058f83e7e910a0ae2da8024ff293b9dd4b66bc77c9b989172701f7e67e27e99"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/Microsoft.Win32.TaskScheduler.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/Microsoft.Win32.TaskScheduler.dll",
+              "sha256": "5e64f2b0912f3fd60d62c4907229033ef22a349791843c0a0e748b3260e3fcae",
+              "size": 333312
+            },
+            "fingerprint": "sha256:f19a5c86e379ff74a9993a0cb1c419e674b65248ae94f019eb1a5dddf6994423"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/Microsoft.Bcl.AsyncInterfaces.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/Microsoft.Bcl.AsyncInterfaces.dll",
+              "sha256": "bda069b17261a50f36b3a79a88b0243d7b9f6508725598adf88d42471977720e",
+              "size": 27960
+            },
+            "fingerprint": "sha256:fbbd517238a716d7905f9db2f01517f989c68eff9eb5367ba34a80789c2aaa18"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Buffers.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Buffers.dll",
+              "sha256": "2d78d770c9cb997199154ae8c018b9f1d1efbc86729f7264dde6dbad2a12cac3",
+              "size": 23816
+            },
+            "fingerprint": "sha256:fddf4ddfb0a1ad59218a609fa1b6e067ae3764073136e9ef514278b8b8d7f67b"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "native-binary-present",
+            "status": "persisting",
+            "previousCount": 39,
+            "currentCount": 39
+          },
+          {
+            "code": "npm-archive-invalid",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          }
+        ],
+        "changed": false
+      },
+      "artifact": {
+        "status": "unchanged",
+        "spec": "npm:anan-thermal-monitor@1.0.4",
+        "name": "anan-thermal-monitor",
+        "version": "1.0.4",
+        "digest": "sha256:60291c92aa02796df227578c1233765a07fbe8217d152025f045d6fe33b556d4",
+        "findings": [
+          {
+            "code": "npm-archive-invalid",
+            "severity": "critical",
+            "summary": "npm artifact cannot be parsed safely",
+            "detail": "unsupported PAX size override",
+            "fingerprint": "sha256:23c35d6fa774e6e7368f99181161640380284af919bed398802c901b2e343988"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "native-binary-present",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "npm-archive-invalid",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          }
+        ],
+        "changed": false
+      }
+    },
+    {
+      "id": "dsh-hdc-bridge",
+      "repository": "1na-ko/dsh-hdc-bridge",
+      "package": "dsh-hdc-bridge",
+      "watch": [
+        "dependency-install-script-present",
+        "custom-registry-config",
+        "dependency-graph-unlocked",
+        "npm-provenance-missing"
+      ],
+      "status": "unchanged",
+      "source": {
+        "status": "unchanged",
+        "name": "dsh-hdc-bridge",
+        "version": "0.7.2",
+        "digest": "sha256:2a26a4a2fc3dd0f58cad501e437278809f7398b6d8f3bd33ba2e983de10a2f91",
+        "findings": [
+          {
+            "code": "custom-registry-config",
+            "severity": "medium",
+            "summary": "Package configures a custom npm registry",
+            "detail": "Dependency provenance depends on a registry selected by package-local configuration.",
+            "evidence": {
+              "path": ".npmrc"
+            },
+            "fingerprint": "sha256:8afb78a4e5afa427a6ed3c9f472731f151df40c88d335e6d0399f4d8bf407c4c"
+          },
+          {
+            "code": "dependency-graph-unlocked",
+            "severity": "medium",
+            "summary": "Runtime dependency graph is not locked in the reviewed source tree",
+            "detail": "A future resolution of the same manifest may select different transitive artifacts.",
+            "evidence": {
+              "runtimeDependencyCount": 1
+            },
+            "fingerprint": "sha256:30fb4ab431a5c730344ea899eaed18698e7aa6c77fff4ad01b821eed3ddc256d"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "custom-registry-config",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "dependency-graph-unlocked",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "dependency-install-script-present",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          }
+        ],
+        "changed": false
+      },
+      "artifact": {
+        "status": "unchanged",
+        "spec": "npm:dsh-hdc-bridge@0.7.2",
+        "name": "dsh-hdc-bridge",
+        "version": "0.7.2",
+        "digest": "sha256:0c86a66448efdc1d331a3d8c9d664b0d3087c7e039d0ec6d7b99f421326617be",
+        "findings": [
+          {
+            "code": "dependency-install-script-present",
+            "severity": "high",
+            "summary": "Resolved dependency graph contains install-time scripts",
+            "detail": "The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.",
+            "evidence": {
+              "packages": [
+                "@deveco/deveco-cli@1.3.0"
+              ],
+              "scripts": [
+                "@deveco/deveco-cli@1.3.0 postinstall: node scripts/postinstall.mjs",
+                "@deveco/deveco-cli@1.3.0 prepare: husky"
+              ]
+            },
+            "fingerprint": "sha256:3c013c563c024e16451b6d20c902f72a2a9b44b2df6924c331f4a581a3b77d6a"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "custom-registry-config",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "dependency-graph-unlocked",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "dependency-install-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          }
+        ],
+        "changed": false
+      }
+    },
+    {
+      "id": "dsh-msg-hub",
+      "repository": "AbcdefgXW/dsh-msg-hub",
+      "package": "dsh-msg-hub",
+      "watch": [
+        "dependency-install-script-present",
+        "dependency-graph-unavailable",
+        "lockfile-root-metadata-stale",
+        "npm-provenance-missing"
+      ],
+      "status": "unchanged",
+      "source": {
+        "status": "unchanged",
+        "name": "dsh-msg-hub",
+        "version": "0.1.8",
+        "digest": "sha256:2b04fa077cf4b61ccce4937328c1b75a41d04dde626c61d7fedd1ddd92897e15",
+        "findings": [],
+        "transitions": [
+          {
+            "code": "dependency-graph-unavailable",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "dependency-install-script-present",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "lockfile-root-metadata-stale",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          }
+        ],
+        "changed": false
+      },
+      "artifact": {
+        "status": "unchanged",
+        "spec": "npm:dsh-msg-hub@0.1.8",
+        "name": "dsh-msg-hub",
+        "version": "0.1.8",
+        "digest": "sha256:dc1251f3ce953a57a92e7abcb7a0644eaca09d0c7a6ba4876f95bbf3049c934a",
+        "findings": [
+          {
+            "code": "dependency-install-script-present",
+            "severity": "high",
+            "summary": "Resolved dependency graph contains install-time scripts",
+            "detail": "The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.",
+            "evidence": {
+              "packages": [
+                "protobufjs@7.6.5"
+              ],
+              "scripts": [
+                "protobufjs@7.6.5 postinstall: node scripts/postinstall"
+              ]
+            },
+            "fingerprint": "sha256:e52d9339a71c4614955dd2bfb04751dc5d287d2e8ef2355acc450f575c287fe3"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "dependency-graph-unavailable",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "dependency-install-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "lockfile-root-metadata-stale",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          }
+        ],
+        "changed": false
+      }
+    },
+    {
+      "id": "dsh-spotlight",
+      "repository": "0xsline/dsh-spotlight",
+      "package": "@0xsline/dsh-spotlight",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ],
+      "status": "unchanged",
+      "source": {
+        "status": "unchanged",
+        "name": "@0xsline/dsh-spotlight",
+        "version": "0.0.2",
+        "digest": "sha256:cebe7dd8cd5df591b5d48101f13072274a48b3f9b518fc21208bdf8726f4ad72",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "node scripts/prepare.mjs"
+            },
+            "fingerprint": "sha256:ac290e7268074bbd0e416ccf8258071435cecf5331d87dfb65cc8246948aefb4"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "lifecycle-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          }
+        ],
+        "changed": false
+      },
+      "artifact": {
+        "status": "unchanged",
+        "spec": "npm:@0xsline/dsh-spotlight@0.0.2",
+        "name": "@0xsline/dsh-spotlight",
+        "version": "0.0.2",
+        "digest": "sha256:d68ef1ec060b2b6a2eeac1430d5c9748abc01fb3d8a008412bac841f8d4a165e",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "node scripts/prepare.mjs"
+            },
+            "fingerprint": "sha256:ac290e7268074bbd0e416ccf8258071435cecf5331d87dfb65cc8246948aefb4"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "lifecycle-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          }
+        ],
+        "changed": false
+      }
+    },
+    {
+      "id": "dsh-verification-receipt",
+      "repository": "030611/dsh-verification-receipt",
+      "package": "dsh-verification-receipt",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ],
+      "status": "unchanged",
+      "source": {
+        "status": "unchanged",
+        "name": "dsh-verification-receipt",
+        "version": "0.1.0",
+        "digest": "sha256:01ab83c4c6af508c3eb8e6cc0bf6d659ee1267f6d542e64d025c9bbd3884c10d",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "pnpm run build"
+            },
+            "fingerprint": "sha256:51f89a0e546a2dd68c1e9b27aa40daa0766b3fb9d9f5b87993deb7c6004b6ca6"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "lifecycle-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          }
+        ],
+        "changed": false
+      },
+      "artifact": {
+        "status": "unchanged",
+        "spec": "npm:dsh-verification-receipt@0.1.0",
+        "name": "dsh-verification-receipt",
+        "version": "0.1.0",
+        "digest": "sha256:8179996503491b2e8cc757eeaf779e92995c7d3bace732f76e56c6d0812a1a0d",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "pnpm run build"
+            },
+            "fingerprint": "sha256:51f89a0e546a2dd68c1e9b27aa40daa0766b3fb9d9f5b87993deb7c6004b6ca6"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "lifecycle-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          }
+        ],
+        "changed": false
+      }
+    },
+    {
+      "id": "dsh-voice",
+      "repository": "3274375092/dsh-voice",
+      "package": "@nn12138/dsh-voice",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ],
+      "status": "unchanged",
+      "source": {
+        "status": "unchanged",
+        "name": "@nn12138/dsh-voice",
+        "version": "0.2.5",
+        "digest": "sha256:d1c038e3d0717420bed2c2c1be5e59942e689cfc1173aa2e90c5001785b9b44e",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "npm run build"
+            },
+            "fingerprint": "sha256:bc52e50bc84e4ea3f23e710f580b338850e9e0f46e15886daa702389f34c5751"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "lifecycle-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          }
+        ],
+        "changed": false
+      },
+      "artifact": {
+        "status": "unchanged",
+        "spec": "npm:@nn12138/dsh-voice@0.2.5",
+        "name": "@nn12138/dsh-voice",
+        "version": "0.2.5",
+        "digest": "sha256:591e9d7bec499d499f36cd8a32c835010f7c1f94a6ee18dc90af2f25ad0a8075",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "npm run build"
+            },
+            "fingerprint": "sha256:bc52e50bc84e4ea3f23e710f580b338850e9e0f46e15886daa702389f34c5751"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "lifecycle-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          }
+        ],
+        "changed": false
+      }
+    },
+    {
+      "id": "dsh-wsl-workspace",
+      "repository": "6Mikao9/dsh-wsl-workspace",
+      "package": "dsh-wsl-workspace",
+      "watch": [
+        "dependency-install-script-present",
+        "floating-dependency-spec",
+        "dependency-graph-unlocked",
+        "npm-provenance-missing"
+      ],
+      "status": "unchanged",
+      "source": {
+        "status": "unchanged",
+        "name": "dsh-wsl-workspace",
+        "version": "0.2.3",
+        "digest": "sha256:ef63492e49e30e8caec27101365a9000bc4188ac3f14d229683c996bfa518c74",
+        "findings": [
+          {
+            "code": "dependency-graph-unlocked",
+            "severity": "medium",
+            "summary": "Runtime dependency graph is not locked in the reviewed source tree",
+            "detail": "A future resolution of the same manifest may select different transitive artifacts.",
+            "evidence": {
+              "runtimeDependencyCount": 6
+            },
+            "fingerprint": "sha256:e7f8d9d424f38b21a49bb290700f8cc277f2b4d6009c036c97f84b93a212f635"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-timeout uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-timeout",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:1090ff2f221f8f8180999b51b6b65a2efdabbef3d01f14ce368820bd4987ce8a"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-fs-local uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-fs-local",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:25835acc9ed96b843a0b7724dc8080b1398124f3da94468d781c0ee50bc8236b"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-fs uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-fs",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:495b59a339e6b1e949a28eb783839abf550e2bf4575421a704e49f4452bf8c36"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-shell uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-shell",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:57d05d8789b8ef53a0ccdaef41333a5bdc499f3469dd0c443b77a642502c1152"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/cordis uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/cordis",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:6b16a9d4b248e07468c2ff6317daea5cd65d0d2fb4c2f006ce94479ed1a5684e"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-subprocess uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-subprocess",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:886a6bbf60fecf14541260fa486768c39fab22f5c1b420176aac2082a33c1dee"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "dependency-graph-unlocked",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "dependency-install-script-present",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "floating-dependency-spec",
+            "status": "persisting",
+            "previousCount": 6,
+            "currentCount": 6
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          }
+        ],
+        "changed": false
+      },
+      "artifact": {
+        "status": "unchanged",
+        "spec": "npm:dsh-wsl-workspace@0.2.3",
+        "name": "dsh-wsl-workspace",
+        "version": "0.2.3",
+        "digest": "sha256:831b9bab04b9eed73203fd9024cf4f335f5c0f079cd7de3191611ea73edf6081",
+        "findings": [
+          {
+            "code": "dependency-install-script-present",
+            "severity": "high",
+            "summary": "Resolved dependency graph contains install-time scripts",
+            "detail": "The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.",
+            "evidence": {
+              "packages": [
+                "koffi@3.1.6"
+              ],
+              "scripts": [
+                "koffi@3.1.6 install: node ./cnoke.cjs -P . -D src/koffi --prebuild --release"
+              ]
+            },
+            "fingerprint": "sha256:19464641cb76149ddfd541b25cfd61d4ed02ca435ec7a21051b417ff35cc6dea"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-timeout uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-timeout",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:1090ff2f221f8f8180999b51b6b65a2efdabbef3d01f14ce368820bd4987ce8a"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-fs-local uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-fs-local",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:25835acc9ed96b843a0b7724dc8080b1398124f3da94468d781c0ee50bc8236b"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-fs uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-fs",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:495b59a339e6b1e949a28eb783839abf550e2bf4575421a704e49f4452bf8c36"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-shell uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-shell",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:57d05d8789b8ef53a0ccdaef41333a5bdc499f3469dd0c443b77a642502c1152"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/cordis uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/cordis",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:6b16a9d4b248e07468c2ff6317daea5cd65d0d2fb4c2f006ce94479ed1a5684e"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-subprocess uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-subprocess",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:886a6bbf60fecf14541260fa486768c39fab22f5c1b420176aac2082a33c1dee"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ],
+        "transitions": [
+          {
+            "code": "dependency-graph-unlocked",
+            "status": "persisting",
+            "previousCount": 0,
+            "currentCount": 0
+          },
+          {
+            "code": "dependency-install-script-present",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          },
+          {
+            "code": "floating-dependency-spec",
+            "status": "persisting",
+            "previousCount": 6,
+            "currentCount": 6
+          },
+          {
+            "code": "npm-provenance-missing",
+            "status": "persisting",
+            "previousCount": 1,
+            "currentCount": 1
+          }
+        ],
+        "changed": false
+      }
+    }
+  ]
+}

--- a/examples/dsh/finding-watch/report.md
+++ b/examples/dsh/finding-watch/report.md
@@ -1,0 +1,129 @@
+# DSH known finding watch
+
+Checked: 2026-08-21T03:07:08.515Z
+
+This report watches previously reported supply-chain findings on both the public source repository and the exact npm artifact. `unknown` means the check could not establish a current result; it is never treated as `resolved`.
+
+## Summary
+
+- targets: 7
+- baseline: 0
+- changed: 0
+- unchanged: 7
+- unknown: 0
+- transitions: {"added":0,"resolved":0,"changed":0,"persisting":42}
+
+## Current status
+
+| Plugin | Overall | Source | Exact npm artifact |
+| --- | --- | --- | --- |
+| [anan-thermal-monitor](https://github.com/AmeKrance/anan-thermal-monitor) | unchanged | unchanged: anan-thermal-monitor@1.0.4 | unchanged: npm:anan-thermal-monitor@1.0.4 |
+| [dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | unchanged | unchanged: dsh-hdc-bridge@0.7.2 | unchanged: npm:dsh-hdc-bridge@0.7.2 |
+| [dsh-msg-hub](https://github.com/AbcdefgXW/dsh-msg-hub) | unchanged | unchanged: dsh-msg-hub@0.1.8 | unchanged: npm:dsh-msg-hub@0.1.8 |
+| [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) | unchanged | unchanged: @0xsline/dsh-spotlight@0.0.2 | unchanged: npm:@0xsline/dsh-spotlight@0.0.2 |
+| [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) | unchanged | unchanged: dsh-verification-receipt@0.1.0 | unchanged: npm:dsh-verification-receipt@0.1.0 |
+| [dsh-voice](https://github.com/3274375092/dsh-voice) | unchanged | unchanged: @nn12138/dsh-voice@0.2.5 | unchanged: npm:@nn12138/dsh-voice@0.2.5 |
+| [dsh-wsl-workspace](https://github.com/6Mikao9/dsh-wsl-workspace) | unchanged | unchanged: dsh-wsl-workspace@0.2.3 | unchanged: npm:dsh-wsl-workspace@0.2.3 |
+
+## Details
+
+### anan-thermal-monitor
+
+- repository: https://github.com/AmeKrance/anan-thermal-monitor
+- overall: **unchanged**
+- source: unchanged — anan-thermal-monitor@1.0.4
+- exact npm artifact: unchanged — npm:anan-thermal-monitor@1.0.4
+- source active finding: `native-binary-present` (high) × 39 — Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.
+  - evidence: `{"path":"assets/LibreHardwareMonitor/ja/Microsoft.Win32.TaskScheduler.resources.dll","sha256":"e282404035693502882bca0b88e988fe0bff8ace799ce67582bbb1485751b5dd","size":10240}`
+  - evidence: `{"path":"assets/LibreHardwareMonitor/Aga.Controls.dll","sha256":"e9f4eb385359a6d51fcf88153c597e3d75b6e64d5f1c3766eaa2deee739e855f","size":145920}`
+  - evidence: `{"path":"assets/LibreHardwareMonitor/System.Text.Encodings.Web.dll","sha256":"43e6dfb4aa333848be5066dcb3d490afc417d0f896aada2f17b5db5fcbb819fc","size":87816}`
+  - 36 more evidence records are in the machine report
+- artifact active finding: `npm-archive-invalid` (critical) × 1 — unsupported PAX size override
+- artifact active finding: `npm-provenance-missing` (medium) × 1 — The published bytes are not cryptographically linked to a declared source commit and build workflow.
+
+### dsh-hdc-bridge
+
+- repository: https://github.com/1na-ko/dsh-hdc-bridge
+- overall: **unchanged**
+- source: unchanged — dsh-hdc-bridge@0.7.2
+- exact npm artifact: unchanged — npm:dsh-hdc-bridge@0.7.2
+- source active finding: `custom-registry-config` (medium) × 1 — Dependency provenance depends on a registry selected by package-local configuration.
+  - evidence: `{"path":".npmrc"}`
+- source active finding: `dependency-graph-unlocked` (medium) × 1 — A future resolution of the same manifest may select different transitive artifacts.
+  - evidence: `{"runtimeDependencyCount":1}`
+- artifact active finding: `dependency-install-script-present` (high) × 1 — The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.
+  - evidence: `{"packages":["@deveco/deveco-cli@1.3.0"],"scripts":["@deveco/deveco-cli@1.3.0 postinstall: node scripts/postinstall.mjs","@deveco/deveco-cli@1.3.0 prepare: husky"]}`
+- artifact active finding: `npm-provenance-missing` (medium) × 1 — The published bytes are not cryptographically linked to a declared source commit and build workflow.
+
+### dsh-msg-hub
+
+- repository: https://github.com/AbcdefgXW/dsh-msg-hub
+- overall: **unchanged**
+- source: unchanged — dsh-msg-hub@0.1.8
+- exact npm artifact: unchanged — npm:dsh-msg-hub@0.1.8
+- source active watched findings: none
+- artifact active finding: `dependency-install-script-present` (high) × 1 — The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.
+  - evidence: `{"packages":["protobufjs@7.6.5"],"scripts":["protobufjs@7.6.5 postinstall: node scripts/postinstall"]}`
+- artifact active finding: `npm-provenance-missing` (medium) × 1 — The published bytes are not cryptographically linked to a declared source commit and build workflow.
+
+### dsh-spotlight
+
+- repository: https://github.com/0xsline/dsh-spotlight
+- overall: **unchanged**
+- source: unchanged — @0xsline/dsh-spotlight@0.0.2
+- exact npm artifact: unchanged — npm:@0xsline/dsh-spotlight@0.0.2
+- source active finding: `lifecycle-script-present` (high) × 1 — Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.
+  - evidence: `{"script":"prepare","command":"node scripts/prepare.mjs"}`
+- artifact active finding: `lifecycle-script-present` (high) × 1 — Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.
+  - evidence: `{"script":"prepare","command":"node scripts/prepare.mjs"}`
+- artifact active finding: `npm-provenance-missing` (medium) × 1 — The published bytes are not cryptographically linked to a declared source commit and build workflow.
+
+### dsh-verification-receipt
+
+- repository: https://github.com/030611/dsh-verification-receipt
+- overall: **unchanged**
+- source: unchanged — dsh-verification-receipt@0.1.0
+- exact npm artifact: unchanged — npm:dsh-verification-receipt@0.1.0
+- source active finding: `lifecycle-script-present` (high) × 1 — Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.
+  - evidence: `{"script":"prepare","command":"pnpm run build"}`
+- artifact active finding: `lifecycle-script-present` (high) × 1 — Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.
+  - evidence: `{"script":"prepare","command":"pnpm run build"}`
+- artifact active finding: `npm-provenance-missing` (medium) × 1 — The published bytes are not cryptographically linked to a declared source commit and build workflow.
+
+### dsh-voice
+
+- repository: https://github.com/3274375092/dsh-voice
+- overall: **unchanged**
+- source: unchanged — @nn12138/dsh-voice@0.2.5
+- exact npm artifact: unchanged — npm:@nn12138/dsh-voice@0.2.5
+- source active finding: `lifecycle-script-present` (high) × 1 — Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.
+  - evidence: `{"script":"prepare","command":"npm run build"}`
+- artifact active finding: `lifecycle-script-present` (high) × 1 — Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.
+  - evidence: `{"script":"prepare","command":"npm run build"}`
+- artifact active finding: `npm-provenance-missing` (medium) × 1 — The published bytes are not cryptographically linked to a declared source commit and build workflow.
+
+### dsh-wsl-workspace
+
+- repository: https://github.com/6Mikao9/dsh-wsl-workspace
+- overall: **unchanged**
+- source: unchanged — dsh-wsl-workspace@0.2.3
+- exact npm artifact: unchanged — npm:dsh-wsl-workspace@0.2.3
+- source active finding: `dependency-graph-unlocked` (medium) × 1 — A future resolution of the same manifest may select different transitive artifacts.
+  - evidence: `{"runtimeDependencyCount":6}`
+- source active finding: `floating-dependency-spec` (medium) × 6 — The same manifest can resolve to a different artifact without a source change.
+  - evidence: `{"dependency":"@deepseek-ai/dsh-timeout","scope":"peerDependency","spec":"*"}`
+  - evidence: `{"dependency":"@deepseek-ai/dsh-fs-local","scope":"peerDependency","spec":"*"}`
+  - evidence: `{"dependency":"@deepseek-ai/dsh-fs","scope":"peerDependency","spec":"*"}`
+  - 3 more evidence records are in the machine report
+- artifact active finding: `dependency-install-script-present` (high) × 1 — The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.
+  - evidence: `{"packages":["koffi@3.1.6"],"scripts":["koffi@3.1.6 install: node ./cnoke.cjs -P . -D src/koffi --prebuild --release"]}`
+- artifact active finding: `floating-dependency-spec` (medium) × 6 — The same manifest can resolve to a different artifact without a source change.
+  - evidence: `{"dependency":"@deepseek-ai/dsh-timeout","scope":"peerDependency","spec":"*"}`
+  - evidence: `{"dependency":"@deepseek-ai/dsh-fs-local","scope":"peerDependency","spec":"*"}`
+  - evidence: `{"dependency":"@deepseek-ai/dsh-fs","scope":"peerDependency","spec":"*"}`
+  - 3 more evidence records are in the machine report
+- artifact active finding: `npm-provenance-missing` (medium) × 1 — The published bytes are not cryptographically linked to a declared source commit and build workflow.
+
+## Interpretation
+
+These are bounded static and exact-artifact observations. An install script, native binary, missing provenance record, or floating dependency is not automatically malicious; each item tells the plugin author what to review or fix. A source fix can land before the npm artifact is republished, so the two sides remain separate.

--- a/examples/dsh/finding-watch/state.json
+++ b/examples/dsh/finding-watch/state.json
@@ -1,0 +1,989 @@
+{
+  "schema": "upstream-radar.finding-watch-state/v1alpha1",
+  "targets": {
+    "anan-thermal-monitor": {
+      "id": "anan-thermal-monitor",
+      "repository": "AmeKrance/anan-thermal-monitor",
+      "package": "anan-thermal-monitor",
+      "watch": [
+        "npm-archive-invalid",
+        "native-binary-present",
+        "npm-provenance-missing"
+      ],
+      "source": {
+        "name": "anan-thermal-monitor",
+        "version": "1.0.4",
+        "digest": "sha256:34a515e6395fe13735b88d1f7a10324068ec4c90d579b4d851c356c51da2063b",
+        "findings": [
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/ja/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/ja/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "e282404035693502882bca0b88e988fe0bff8ace799ce67582bbb1485751b5dd",
+              "size": 10240
+            },
+            "fingerprint": "sha256:05617fc31b4dc9542cf376cdf28b7177d9c99da6da4444959982629092e7ee0d"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/Aga.Controls.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/Aga.Controls.dll",
+              "sha256": "e9f4eb385359a6d51fcf88153c597e3d75b6e64d5f1c3766eaa2deee739e855f",
+              "size": 145920
+            },
+            "fingerprint": "sha256:130dcf195026c91eb52e6851fd3e163c5a0e06f35ba2b1c069e5b81eedb89819"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Text.Encodings.Web.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Text.Encodings.Web.dll",
+              "sha256": "43e6dfb4aa333848be5066dcb3d490afc417d0f896aada2f17b5db5fcbb819fc",
+              "size": 87816
+            },
+            "fingerprint": "sha256:18cc4801aa237e5460cf69ad625faeaa551bc1383d6465a19c26b6c4c1d45084"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/OxyPlot.WindowsForms.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/OxyPlot.WindowsForms.dll",
+              "sha256": "0758b8a4c129730e4585e717d4183d48b1167a78e4955ce704d9e6cc204148b2",
+              "size": 32768
+            },
+            "fingerprint": "sha256:1a7ea3562a15ed7ce6f0ea7d330d51cda823483fea420b5ba173b5cc45ef3051"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/RAMSPDToolkit-NDD.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/RAMSPDToolkit-NDD.dll",
+              "sha256": "b6882354c7c8ec186617e421507743dbfae09c5c1fc24cef76a1d0c0c26651de",
+              "size": 233472
+            },
+            "fingerprint": "sha256:2152ef1580b43c942c60d1cdcec836d1c03e2a95a62c6fb08a2652229ab81008"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Security.Principal.Windows.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Security.Principal.Windows.dll",
+              "sha256": "b4d8e15adc235d0e858e39b5133e5d00a4baa8c94f4f39e3b5e791b0f9c0c806",
+              "size": 18312
+            },
+            "fingerprint": "sha256:2e611e20bd9090473a01664d6516d4df2585dff5c5066e132755b9527c886361"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/tr/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/tr/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "1429cd58467aea880302b369eb802a55411aba008895bd0023376526538fb462",
+              "size": 10240
+            },
+            "fingerprint": "sha256:2fda6f4527c9ddf6883d844f488298c8a3858f6a8fe310b5aae0e52de58d0d11"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/sv/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/sv/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "84ede4a0234ee6cd52329939e696b8bc2758b313dd7225d7a46828ed626d5e36",
+              "size": 9728
+            },
+            "fingerprint": "sha256:300664462284548f477901c79336909593da31a24a07c2ede91f26eda7615711"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/zh-CN/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/zh-CN/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "9f1f40400b3184e162f6606cce12820fabbb7f2a9b67202e91c01595b6dee26a",
+              "size": 9728
+            },
+            "fingerprint": "sha256:3212721ce843e3b8b7bbb9384fd138116ac9ce38cdfe6430cab7bb2ab96b72fd"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/LibreHardwareMonitorLib.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/LibreHardwareMonitorLib.dll",
+              "sha256": "6ebc194316536ba61af5be24508ad9fcbb2ecc685e716c12e787c79530f66bf0",
+              "size": 1203200
+            },
+            "fingerprint": "sha256:3cf40484fe9d0e17eab5127a262493335d5fb0ff7d251f10f18d53397cbdcec1"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Runtime.CompilerServices.Unsafe.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Runtime.CompilerServices.Unsafe.dll",
+              "sha256": "08cbd7278b66f1e68425a82d4b97181a4130d93e3dd91831407aba7212ccdacf",
+              "size": 19256
+            },
+            "fingerprint": "sha256:4368aaca91de839d1cf7b4e41b8f1f1a2c90f59b4137e05ca536cb45099ec6fc"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Collections.Immutable.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Collections.Immutable.dll",
+              "sha256": "8c0f09a8b1fd730da3f3d2c4c831cdd76e3fca6bc588523d8f7eacf16d5a24e9",
+              "size": 253232
+            },
+            "fingerprint": "sha256:4a5a2fc1f8484268bfdfab8e03aa53a5ec86092746e94013d914107c3a1a7f7f"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Formats.Nrbf.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Formats.Nrbf.dll",
+              "sha256": "27514fbffb0776c37ede88ec371310844f7bec55a017627aad60180f268769e4",
+              "size": 71472
+            },
+            "fingerprint": "sha256:535dbea0ce7fbd954344dfed9b390a3ce7656777d2f5679fb66ff0c3a8f03695"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Resources.Extensions.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Resources.Extensions.dll",
+              "sha256": "c3748f17d2f5209cc795a88ad4946c12c3f6ef73b3015dc92c43f932a342b17c",
+              "size": 115984
+            },
+            "fingerprint": "sha256:58b43a6924affc4c97ae071f102589feb50c571cabd116a497ae9ee6153cf69b"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/fr/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/fr/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "4b282ddf1f09e09242ca11a22fd7dfdd069ede751961bdf8d771258071823b51",
+              "size": 10240
+            },
+            "fingerprint": "sha256:5a3aeb5b2166144ddfce749bce9f1e1af93050b8bc1fc7b8ec91aa58c32a3d2a"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/OxyPlot.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/OxyPlot.dll",
+              "sha256": "da767e3d8c10674e6ffa72670952d1274544b453b68e774b29f03b5160a4a034",
+              "size": 700928
+            },
+            "fingerprint": "sha256:5aa8a28453958873a5c6d8940d8c8eee06e3160e75daba302078143f9e07b1f8"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Reflection.Metadata.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Reflection.Metadata.dll",
+              "sha256": "6c1fe5d140f0f21fac0eea7b1d3e3bc2526c0027e857bcf5227af722a9b32a0d",
+              "size": 515336
+            },
+            "fingerprint": "sha256:6a44b4e342d42dd4f2de351a9cb596b2ae2029450894b8fbf5fc00d89ed7d64f"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/es/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/es/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "b417b6a5b5dc7349122a00c43c06897aedf414046af83ba14ba28838f243ca42",
+              "size": 10240
+            },
+            "fingerprint": "sha256:79eead350099350b443ad0a290d29d3f4ba0a7fb4cc018e87236492e22bfccc4"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/LibreHardwareMonitor.exe",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/LibreHardwareMonitor.exe",
+              "sha256": "fe216a48a48a6048156a133a39b960437d781a4c9214e5abc0f26f666f61ba22",
+              "size": 4458496
+            },
+            "fingerprint": "sha256:7e5cdb157f1c702ebe018deb7362625abe565ff03c00a7ddde554aa9a0e0d0fb"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Threading.Tasks.Extensions.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Threading.Tasks.Extensions.dll",
+              "sha256": "af4e13ef418fd89b432de20cd1dfb7fa10a7179c8dd049c9856316e50c5949ca",
+              "size": 27960
+            },
+            "fingerprint": "sha256:83a9e53861e9170ff6bf925ff59bc537d041a21eedf6b14dbe49d34a67ca021a"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/BlackSharp.Core.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/BlackSharp.Core.dll",
+              "sha256": "cafb93afcc8d8a367e21f619673d05c06887d8964867fed1371f02ded1cd3e23",
+              "size": 32768
+            },
+            "fingerprint": "sha256:86b8d459acc1fd55a886a59d20c2a2233793ed0a4399280e7ff5c0d4fc7c28fd"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Security.AccessControl.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Security.AccessControl.dll",
+              "sha256": "ff14c5f628b9a6798d173aefbba0a43d61e66f715108e2576ac0d3dfab9071d0",
+              "size": 35952
+            },
+            "fingerprint": "sha256:880b38cab026845f22a67613137a1c386ea7a4432e7cdea8c8cb5ce87ca9ffca"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/it/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/it/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "24a3040b55de26ce6c8f36f60e1d728ead14416875c01d160d9ffcfbeaa8dcd5",
+              "size": 10240
+            },
+            "fingerprint": "sha256:8bb31a5348007b1b635dc6ffec966bb0596a2667da357a5d39a71b4b8129f093"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Text.Json.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Text.Json.dll",
+              "sha256": "7a7f2e0b942782739551b37546efc842f53c7fce3a8f0f56ad45a5cf78e2c214",
+              "size": 778504
+            },
+            "fingerprint": "sha256:997b98337d88bb4f575a0253d9961f36d6d8e30c173d481978470ed63d4193f3"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/pl/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/pl/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "2ddd5ed4d84e8732334b5f6e08b3d61190da58762d33db72f7e229eb7e4791f0",
+              "size": 10240
+            },
+            "fingerprint": "sha256:a475e17fcc50f0e261f1a16e884f19c008256940b1cb94cf29607156a2acb2fe"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/Microsoft.Bcl.HashCode.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/Microsoft.Bcl.HashCode.dll",
+              "sha256": "3a4e851ee5fc0f6182aa5a3d65dc56fcd6979b65334b5c3b92fbdc791457c0ab",
+              "size": 26920
+            },
+            "fingerprint": "sha256:a8500ac783bb39e6380dac50f7528035f42834683d8307c0244d38d961a77cf1"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/HidSharp.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/HidSharp.dll",
+              "sha256": "d86690efde30ea9179f669320f39148853793b743a98b531afeaf30598e22f54",
+              "size": 262792
+            },
+            "fingerprint": "sha256:b012080312c3e71d31f6a1a2cbdba7e1b4dcafb9f3a4e412cd5011e82a62f74b"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.CodeDom.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.CodeDom.dll",
+              "sha256": "e9bca8ecab5f02df389ee4b306c32a93d7822b524a6eca90e449e13d4b4283a3",
+              "size": 34064
+            },
+            "fingerprint": "sha256:b903638d6d88f5f6b0303b8450496eda3a534cbb29d65f16b789a644a505c205"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Memory.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Memory.dll",
+              "sha256": "d5e8e4866f9cfa66f7765660f84b210198893e55335487afe5ebda342c0e913d",
+              "size": 145200
+            },
+            "fingerprint": "sha256:bef1e999ffad33162de3aad55765849744e298019001e800dae9ae1fa0762978"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.IO.Pipelines.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.IO.Pipelines.dll",
+              "sha256": "52a813c62932462d8f070f001acd1f264c0766a11a78c6d3c4f81ee3b1d67223",
+              "size": 85768
+            },
+            "fingerprint": "sha256:c046375018a043eff573db137dc4b3ff05d179da2d02c64f8bc6089c17c1473d"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/DiskInfoToolkit.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/DiskInfoToolkit.dll",
+              "sha256": "1acbf51b3c10c51c986cf43021680d34a2e38d9a5ba652bcfa9a1b5f7fc09800",
+              "size": 903680
+            },
+            "fingerprint": "sha256:d04b70b2250a83cdcca7ad421fdb2954a30b1f10d114eb13791ff1139b77a9f3"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/de/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/de/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "f54e8a38be8e27f178ac519e7eafa613d0341037bd0f723bf128fcdb94b7b540",
+              "size": 9728
+            },
+            "fingerprint": "sha256:d9cdedf7d3f2535fd9cdfbd7719467a9749b471937bbe74bac7ae9dfa196d6ce"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/ru/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/ru/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "b15e736a0e3c1051becdefaadfeaab68163c2203381e1e782316372a58fcb0c6",
+              "size": 10752
+            },
+            "fingerprint": "sha256:dd6264bda56a9b6af6f72ed113db78a685d0362dcfc5cf83d7b38755b76a9d81"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/zh-Hant/Microsoft.Win32.TaskScheduler.resources.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/zh-Hant/Microsoft.Win32.TaskScheduler.resources.dll",
+              "sha256": "a065c666fea783efd1c535bea0f409cdaeeda0f279d339bb120a32537766e1aa",
+              "size": 9728
+            },
+            "fingerprint": "sha256:ee39f4e9a9cb38386ac8ac13952323642d62a306c90ce983a5b9af7c9ab829c5"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Numerics.Vectors.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Numerics.Vectors.dll",
+              "sha256": "20c2fa81b8c70d651099d762954f285fd4f942e63b2d7217c145dab8d4b2f4c9",
+              "size": 110344
+            },
+            "fingerprint": "sha256:efbb36263d34a476e9a81f7c561970fba1b95db71ae865913fcde226034f55ff"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Threading.AccessControl.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Threading.AccessControl.dll",
+              "sha256": "5e3a3902f04f840c0fc1f9c2f249f804f6cfdf7901b2e06778bc2a4603ae4694",
+              "size": 34568
+            },
+            "fingerprint": "sha256:f058f83e7e910a0ae2da8024ff293b9dd4b66bc77c9b989172701f7e67e27e99"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/Microsoft.Win32.TaskScheduler.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/Microsoft.Win32.TaskScheduler.dll",
+              "sha256": "5e64f2b0912f3fd60d62c4907229033ef22a349791843c0a0e748b3260e3fcae",
+              "size": 333312
+            },
+            "fingerprint": "sha256:f19a5c86e379ff74a9993a0cb1c419e674b65248ae94f019eb1a5dddf6994423"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/Microsoft.Bcl.AsyncInterfaces.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/Microsoft.Bcl.AsyncInterfaces.dll",
+              "sha256": "bda069b17261a50f36b3a79a88b0243d7b9f6508725598adf88d42471977720e",
+              "size": 27960
+            },
+            "fingerprint": "sha256:fbbd517238a716d7905f9db2f01517f989c68eff9eb5367ba34a80789c2aaa18"
+          },
+          {
+            "code": "native-binary-present",
+            "severity": "high",
+            "summary": "Native executable artifact found: assets/LibreHardwareMonitor/System.Buffers.dll",
+            "detail": "Native artifacts cannot be fully explained by JavaScript source review and require provenance or sandbox analysis.",
+            "evidence": {
+              "path": "assets/LibreHardwareMonitor/System.Buffers.dll",
+              "sha256": "2d78d770c9cb997199154ae8c018b9f1d1efbc86729f7264dde6dbad2a12cac3",
+              "size": 23816
+            },
+            "fingerprint": "sha256:fddf4ddfb0a1ad59218a609fa1b6e067ae3764073136e9ef514278b8b8d7f67b"
+          }
+        ]
+      },
+      "artifact": {
+        "spec": "npm:anan-thermal-monitor@1.0.4",
+        "name": "anan-thermal-monitor",
+        "version": "1.0.4",
+        "digest": "sha256:60291c92aa02796df227578c1233765a07fbe8217d152025f045d6fe33b556d4",
+        "findings": [
+          {
+            "code": "npm-archive-invalid",
+            "severity": "critical",
+            "summary": "npm artifact cannot be parsed safely",
+            "detail": "unsupported PAX size override",
+            "fingerprint": "sha256:23c35d6fa774e6e7368f99181161640380284af919bed398802c901b2e343988"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ]
+      }
+    },
+    "dsh-hdc-bridge": {
+      "id": "dsh-hdc-bridge",
+      "repository": "1na-ko/dsh-hdc-bridge",
+      "package": "dsh-hdc-bridge",
+      "watch": [
+        "dependency-install-script-present",
+        "custom-registry-config",
+        "dependency-graph-unlocked",
+        "npm-provenance-missing"
+      ],
+      "source": {
+        "name": "dsh-hdc-bridge",
+        "version": "0.7.2",
+        "digest": "sha256:2a26a4a2fc3dd0f58cad501e437278809f7398b6d8f3bd33ba2e983de10a2f91",
+        "findings": [
+          {
+            "code": "custom-registry-config",
+            "severity": "medium",
+            "summary": "Package configures a custom npm registry",
+            "detail": "Dependency provenance depends on a registry selected by package-local configuration.",
+            "evidence": {
+              "path": ".npmrc"
+            },
+            "fingerprint": "sha256:8afb78a4e5afa427a6ed3c9f472731f151df40c88d335e6d0399f4d8bf407c4c"
+          },
+          {
+            "code": "dependency-graph-unlocked",
+            "severity": "medium",
+            "summary": "Runtime dependency graph is not locked in the reviewed source tree",
+            "detail": "A future resolution of the same manifest may select different transitive artifacts.",
+            "evidence": {
+              "runtimeDependencyCount": 1
+            },
+            "fingerprint": "sha256:30fb4ab431a5c730344ea899eaed18698e7aa6c77fff4ad01b821eed3ddc256d"
+          }
+        ]
+      },
+      "artifact": {
+        "spec": "npm:dsh-hdc-bridge@0.7.2",
+        "name": "dsh-hdc-bridge",
+        "version": "0.7.2",
+        "digest": "sha256:0c86a66448efdc1d331a3d8c9d664b0d3087c7e039d0ec6d7b99f421326617be",
+        "findings": [
+          {
+            "code": "dependency-install-script-present",
+            "severity": "high",
+            "summary": "Resolved dependency graph contains install-time scripts",
+            "detail": "The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.",
+            "evidence": {
+              "packages": [
+                "@deveco/deveco-cli@1.3.0"
+              ],
+              "scripts": [
+                "@deveco/deveco-cli@1.3.0 postinstall: node scripts/postinstall.mjs",
+                "@deveco/deveco-cli@1.3.0 prepare: husky"
+              ]
+            },
+            "fingerprint": "sha256:3c013c563c024e16451b6d20c902f72a2a9b44b2df6924c331f4a581a3b77d6a"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ]
+      }
+    },
+    "dsh-msg-hub": {
+      "id": "dsh-msg-hub",
+      "repository": "AbcdefgXW/dsh-msg-hub",
+      "package": "dsh-msg-hub",
+      "watch": [
+        "dependency-install-script-present",
+        "dependency-graph-unavailable",
+        "lockfile-root-metadata-stale",
+        "npm-provenance-missing"
+      ],
+      "source": {
+        "name": "dsh-msg-hub",
+        "version": "0.1.8",
+        "digest": "sha256:2b04fa077cf4b61ccce4937328c1b75a41d04dde626c61d7fedd1ddd92897e15",
+        "findings": []
+      },
+      "artifact": {
+        "spec": "npm:dsh-msg-hub@0.1.8",
+        "name": "dsh-msg-hub",
+        "version": "0.1.8",
+        "digest": "sha256:dc1251f3ce953a57a92e7abcb7a0644eaca09d0c7a6ba4876f95bbf3049c934a",
+        "findings": [
+          {
+            "code": "dependency-install-script-present",
+            "severity": "high",
+            "summary": "Resolved dependency graph contains install-time scripts",
+            "detail": "The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.",
+            "evidence": {
+              "packages": [
+                "protobufjs@7.6.5"
+              ],
+              "scripts": [
+                "protobufjs@7.6.5 postinstall: node scripts/postinstall"
+              ]
+            },
+            "fingerprint": "sha256:e52d9339a71c4614955dd2bfb04751dc5d287d2e8ef2355acc450f575c287fe3"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ]
+      }
+    },
+    "dsh-spotlight": {
+      "id": "dsh-spotlight",
+      "repository": "0xsline/dsh-spotlight",
+      "package": "@0xsline/dsh-spotlight",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ],
+      "source": {
+        "name": "@0xsline/dsh-spotlight",
+        "version": "0.0.2",
+        "digest": "sha256:cebe7dd8cd5df591b5d48101f13072274a48b3f9b518fc21208bdf8726f4ad72",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "node scripts/prepare.mjs"
+            },
+            "fingerprint": "sha256:ac290e7268074bbd0e416ccf8258071435cecf5331d87dfb65cc8246948aefb4"
+          }
+        ]
+      },
+      "artifact": {
+        "spec": "npm:@0xsline/dsh-spotlight@0.0.2",
+        "name": "@0xsline/dsh-spotlight",
+        "version": "0.0.2",
+        "digest": "sha256:d68ef1ec060b2b6a2eeac1430d5c9748abc01fb3d8a008412bac841f8d4a165e",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "node scripts/prepare.mjs"
+            },
+            "fingerprint": "sha256:ac290e7268074bbd0e416ccf8258071435cecf5331d87dfb65cc8246948aefb4"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ]
+      }
+    },
+    "dsh-verification-receipt": {
+      "id": "dsh-verification-receipt",
+      "repository": "030611/dsh-verification-receipt",
+      "package": "dsh-verification-receipt",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ],
+      "source": {
+        "name": "dsh-verification-receipt",
+        "version": "0.1.0",
+        "digest": "sha256:01ab83c4c6af508c3eb8e6cc0bf6d659ee1267f6d542e64d025c9bbd3884c10d",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "pnpm run build"
+            },
+            "fingerprint": "sha256:51f89a0e546a2dd68c1e9b27aa40daa0766b3fb9d9f5b87993deb7c6004b6ca6"
+          }
+        ]
+      },
+      "artifact": {
+        "spec": "npm:dsh-verification-receipt@0.1.0",
+        "name": "dsh-verification-receipt",
+        "version": "0.1.0",
+        "digest": "sha256:8179996503491b2e8cc757eeaf779e92995c7d3bace732f76e56c6d0812a1a0d",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "pnpm run build"
+            },
+            "fingerprint": "sha256:51f89a0e546a2dd68c1e9b27aa40daa0766b3fb9d9f5b87993deb7c6004b6ca6"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ]
+      }
+    },
+    "dsh-voice": {
+      "id": "dsh-voice",
+      "repository": "3274375092/dsh-voice",
+      "package": "@nn12138/dsh-voice",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ],
+      "source": {
+        "name": "@nn12138/dsh-voice",
+        "version": "0.2.5",
+        "digest": "sha256:d1c038e3d0717420bed2c2c1be5e59942e689cfc1173aa2e90c5001785b9b44e",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "npm run build"
+            },
+            "fingerprint": "sha256:bc52e50bc84e4ea3f23e710f580b338850e9e0f46e15886daa702389f34c5751"
+          }
+        ]
+      },
+      "artifact": {
+        "spec": "npm:@nn12138/dsh-voice@0.2.5",
+        "name": "@nn12138/dsh-voice",
+        "version": "0.2.5",
+        "digest": "sha256:591e9d7bec499d499f36cd8a32c835010f7c1f94a6ee18dc90af2f25ad0a8075",
+        "findings": [
+          {
+            "code": "lifecycle-script-present",
+            "severity": "high",
+            "summary": "Lifecycle script prepare executes during installation",
+            "detail": "Lifecycle scripts run before a plugin is admitted into DSH and therefore require review.",
+            "evidence": {
+              "script": "prepare",
+              "command": "npm run build"
+            },
+            "fingerprint": "sha256:bc52e50bc84e4ea3f23e710f580b338850e9e0f46e15886daa702389f34c5751"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ]
+      }
+    },
+    "dsh-wsl-workspace": {
+      "id": "dsh-wsl-workspace",
+      "repository": "6Mikao9/dsh-wsl-workspace",
+      "package": "dsh-wsl-workspace",
+      "watch": [
+        "dependency-install-script-present",
+        "floating-dependency-spec",
+        "dependency-graph-unlocked",
+        "npm-provenance-missing"
+      ],
+      "source": {
+        "name": "dsh-wsl-workspace",
+        "version": "0.2.3",
+        "digest": "sha256:ef63492e49e30e8caec27101365a9000bc4188ac3f14d229683c996bfa518c74",
+        "findings": [
+          {
+            "code": "dependency-graph-unlocked",
+            "severity": "medium",
+            "summary": "Runtime dependency graph is not locked in the reviewed source tree",
+            "detail": "A future resolution of the same manifest may select different transitive artifacts.",
+            "evidence": {
+              "runtimeDependencyCount": 6
+            },
+            "fingerprint": "sha256:e7f8d9d424f38b21a49bb290700f8cc277f2b4d6009c036c97f84b93a212f635"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-timeout uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-timeout",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:1090ff2f221f8f8180999b51b6b65a2efdabbef3d01f14ce368820bd4987ce8a"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-fs-local uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-fs-local",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:25835acc9ed96b843a0b7724dc8080b1398124f3da94468d781c0ee50bc8236b"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-fs uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-fs",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:495b59a339e6b1e949a28eb783839abf550e2bf4575421a704e49f4452bf8c36"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-shell uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-shell",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:57d05d8789b8ef53a0ccdaef41333a5bdc499f3469dd0c443b77a642502c1152"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/cordis uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/cordis",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:6b16a9d4b248e07468c2ff6317daea5cd65d0d2fb4c2f006ce94479ed1a5684e"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-subprocess uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-subprocess",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:886a6bbf60fecf14541260fa486768c39fab22f5c1b420176aac2082a33c1dee"
+          }
+        ]
+      },
+      "artifact": {
+        "spec": "npm:dsh-wsl-workspace@0.2.3",
+        "name": "dsh-wsl-workspace",
+        "version": "0.2.3",
+        "digest": "sha256:831b9bab04b9eed73203fd9024cf4f335f5c0f079cd7de3191611ea73edf6081",
+        "findings": [
+          {
+            "code": "dependency-install-script-present",
+            "severity": "high",
+            "summary": "Resolved dependency graph contains install-time scripts",
+            "detail": "The exact npm lockfile marks one or more reachable dependencies as having an install-time lifecycle script. Scripts were disabled during this review; a normal DSH installation may execute or stop on these scripts.",
+            "evidence": {
+              "packages": [
+                "koffi@3.1.6"
+              ],
+              "scripts": [
+                "koffi@3.1.6 install: node ./cnoke.cjs -P . -D src/koffi --prebuild --release"
+              ]
+            },
+            "fingerprint": "sha256:19464641cb76149ddfd541b25cfd61d4ed02ca435ec7a21051b417ff35cc6dea"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-timeout uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-timeout",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:1090ff2f221f8f8180999b51b6b65a2efdabbef3d01f14ce368820bd4987ce8a"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-fs-local uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-fs-local",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:25835acc9ed96b843a0b7724dc8080b1398124f3da94468d781c0ee50bc8236b"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-fs uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-fs",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:495b59a339e6b1e949a28eb783839abf550e2bf4575421a704e49f4452bf8c36"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-shell uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-shell",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:57d05d8789b8ef53a0ccdaef41333a5bdc499f3469dd0c443b77a642502c1152"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/cordis uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/cordis",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:6b16a9d4b248e07468c2ff6317daea5cd65d0d2fb4c2f006ce94479ed1a5684e"
+          },
+          {
+            "code": "floating-dependency-spec",
+            "severity": "medium",
+            "summary": "Dependency @deepseek-ai/dsh-subprocess uses a floating version",
+            "detail": "The same manifest can resolve to a different artifact without a source change.",
+            "evidence": {
+              "dependency": "@deepseek-ai/dsh-subprocess",
+              "scope": "peerDependency",
+              "spec": "*"
+            },
+            "fingerprint": "sha256:886a6bbf60fecf14541260fa486768c39fab22f5c1b420176aac2082a33c1dee"
+          },
+          {
+            "code": "npm-provenance-missing",
+            "severity": "medium",
+            "summary": "npm artifact has no build provenance",
+            "detail": "The published bytes are not cryptographically linked to a declared source commit and build workflow.",
+            "fingerprint": "sha256:8213fb7b557a0549cc2f89474f4fdcb1010c8775a30a819d060589744662c58f"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/examples/dsh/finding-watch/targets.json
+++ b/examples/dsh/finding-watch/targets.json
@@ -1,0 +1,76 @@
+{
+  "schema": "upstream-radar.finding-watch/v1alpha1",
+  "description": "Known supply-chain findings from the first real DSH plugin batch. Each code is observed separately on the source repository and the exact published npm artifact.",
+  "targets": [
+    {
+      "id": "anan-thermal-monitor",
+      "repository": "AmeKrance/anan-thermal-monitor",
+      "package": "anan-thermal-monitor",
+      "watch": [
+        "npm-archive-invalid",
+        "native-binary-present",
+        "npm-provenance-missing"
+      ]
+    },
+    {
+      "id": "dsh-hdc-bridge",
+      "repository": "1na-ko/dsh-hdc-bridge",
+      "package": "dsh-hdc-bridge",
+      "watch": [
+        "dependency-install-script-present",
+        "custom-registry-config",
+        "dependency-graph-unlocked",
+        "npm-provenance-missing"
+      ]
+    },
+    {
+      "id": "dsh-msg-hub",
+      "repository": "AbcdefgXW/dsh-msg-hub",
+      "package": "dsh-msg-hub",
+      "watch": [
+        "dependency-install-script-present",
+        "dependency-graph-unavailable",
+        "lockfile-root-metadata-stale",
+        "npm-provenance-missing"
+      ]
+    },
+    {
+      "id": "dsh-spotlight",
+      "repository": "0xsline/dsh-spotlight",
+      "package": "@0xsline/dsh-spotlight",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ]
+    },
+    {
+      "id": "dsh-verification-receipt",
+      "repository": "030611/dsh-verification-receipt",
+      "package": "dsh-verification-receipt",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ]
+    },
+    {
+      "id": "dsh-voice",
+      "repository": "3274375092/dsh-voice",
+      "package": "@nn12138/dsh-voice",
+      "watch": [
+        "lifecycle-script-present",
+        "npm-provenance-missing"
+      ]
+    },
+    {
+      "id": "dsh-wsl-workspace",
+      "repository": "6Mikao9/dsh-wsl-workspace",
+      "package": "dsh-wsl-workspace",
+      "watch": [
+        "dependency-install-script-present",
+        "floating-dependency-spec",
+        "dependency-graph-unlocked",
+        "npm-provenance-missing"
+      ]
+    }
+  ]
+}

--- a/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
+++ b/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
@@ -19,7 +19,7 @@ From a clean checkout, the finding is reproducible without installing or
 executing the plugin:
 
 ```bash
-npx --yes upstream-radar@0.37.0 scan . --json
+npx --yes upstream-radar@0.38.0 scan . --json
 ```
 
 The current static scan reports:

--- a/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
+++ b/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
@@ -43,5 +43,5 @@ graph, the unresolved peer boundary, the vulnerability result, and the two
 remaining review actions in one report.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.37.0`. Review the Draft PR before relying on the fallback
+`upstream-radar@0.38.0`. Review the Draft PR before relying on the fallback
 resolver from npm.

--- a/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
+++ b/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
@@ -21,7 +21,7 @@ Reproduce it with:
 
 ```bash
 npm pack --ignore-scripts --pack-destination /tmp dsh-feishu-bot@0.15.4
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar probe dsh-matrix \
   /tmp/dsh-feishu-bot-0.15.4.tgz \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```

--- a/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
+++ b/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
@@ -8,7 +8,7 @@ graph without installing anything.
 ## Reproduction
 
 ```bash
-npx --yes upstream-radar@0.37.0 scan \
+npx --yes upstream-radar@0.38.0 scan \
   https://github.com/2008924/dsh-progress-viz \
   --fail-on never
 ```
@@ -22,7 +22,7 @@ query an advisory service, or call an LLM.
 
 ```text
 Reading 2008924/dsh-progress-viz (plugin directory: plugin) without installing dependencies or running code...
-Upstream Radar 0.37.0
+Upstream Radar 0.38.0
 Target: dsh-progress-viz-plugin@0.1.0
 Artifact: sha256:c9b6b2dc31a458b480587f6200772fe72d4af5451b1e71d41594c5017be929c5
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
+++ b/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
@@ -13,11 +13,11 @@ No DSH profile, plugin code, lifecycle script, or LLM was started.
 ## Commands
 
 ```bash
-npx --yes upstream-radar@0.37.0 scan \
+npx --yes upstream-radar@0.38.0 scan \
   https://github.com/ccch1mneyyy/dsh-TUI \
   --fail-on never
 
-npx --yes upstream-radar@0.37.0 inspect \
+npx --yes upstream-radar@0.38.0 inspect \
   npm:@deepseek-harness-tui/dsh-tui@0.8.0 \
   --deep --fail-on never
 ```

--- a/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
+++ b/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
@@ -8,7 +8,7 @@ release.
 ## Rechecked with the public CLI
 
 Each repository was cloned at its current public `main` commit and scanned with
-`upstream-radar@0.37.0`. No package was installed, loaded, or executed.
+`upstream-radar@0.38.0`. No package was installed, loaded, or executed.
 
 | Repository | Commit | `package.json` | `package-lock.json` root | Result |
 | --- | --- | ---: | ---: | --- |

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -40,7 +40,7 @@ The optional probe is load-only. It packs with `--ignore-scripts`, uses a tempor
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.37.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.38.0 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.37.0
+      - uses: MicroMilo/upstream-radar@v0.38.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/dsh-plugin-review-minimal.yml
+++ b/examples/github-actions/dsh-plugin-review-minimal.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.37.0
+        uses: MicroMilo/upstream-radar@v0.38.0
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/examples/github-actions/upstream-observer-minimal.yml
+++ b/examples/github-actions/upstream-observer-minimal.yml
@@ -53,7 +53,7 @@ jobs:
           llm_env_file="$RUNNER_TEMP/issue-locator.env"
           trap 'rm -f "$llm_env_file"' EXIT
           observe_args=(
-            npx --yes upstream-radar@0.37.0 observe "$repository"
+            npx --yes upstream-radar@0.38.0 observe "$repository"
             --ref "$ref"
             --state observations.json
             --report "$report"

--- a/examples/github-actions/upstream-radar-npm.yml
+++ b/examples/github-actions/upstream-radar-npm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.37.0
+      - uses: MicroMilo/upstream-radar@v0.38.0
         with:
           npm-lock: package-lock.json
           fail-on: high

--- a/examples/github-actions/upstream-radar-pnpm.yml
+++ b/examples/github-actions/upstream-radar-pnpm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.37.0
+      - uses: MicroMilo/upstream-radar@v0.38.0
         with:
           pnpm-lock: pnpm-lock.yaml
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.37.0
+      - uses: MicroMilo/upstream-radar@v0.38.0
         with:
           # The Action auto-detects one pnpm-lock.yaml or package-lock.json.
           fail-on: high

--- a/examples/github-actions/upstream-scan-minimal.yml
+++ b/examples/github-actions/upstream-scan-minimal.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           report="$RUNNER_TEMP/upstream-radar-scan.json"
-          npx --yes upstream-radar@0.37.0 scan \
+          npx --yes upstream-radar@0.38.0 scan \
             "$OBSERVER_REPOSITORY_INPUT" \
             --json --fail-on never > "$report"
           if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/examples/upstream-observer/README.md
+++ b/examples/upstream-observer/README.md
@@ -24,7 +24,7 @@ Replace it with the repositories your team depends on.
 For one repository, the shortest path skips YAML and lockfile configuration entirely:
 
 ```bash
-npx --yes upstream-radar@0.37.0 observe \
+npx --yes upstream-radar@0.38.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -35,7 +35,7 @@ Radar automatically chooses the committed `pnpm-lock.yaml` or
 the explicit form below adds `--package`:
 
 ```bash
-npx --yes upstream-radar@0.37.0 observe \
+npx --yes upstream-radar@0.38.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -75,9 +75,9 @@ Build one index from saved DSH plugin scan/review/config JSON, then give it to
 the observer:
 
 ```bash
-npx --yes upstream-radar@0.37.0 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.38.0 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.37.0 observe ./targets.yml \
+npx --yes upstream-radar@0.38.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -99,7 +99,7 @@ and run `pnpm run showcase:observer` to replay a real
 The scheduled workflow uses the checked-in index directly:
 
 ```bash
-npx --yes upstream-radar@0.37.0 observe ./targets.yml \
+npx --yes upstream-radar@0.38.0 observe ./targets.yml \
   --reverse-index ../dsh/first-batch/reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -126,7 +126,7 @@ Run it from any directory with the published CLI:
 
 ```bash
 export GITHUB_TOKEN='a read-only token with repository metadata access'
-npx --yes upstream-radar@0.37.0 observe \
+npx --yes upstream-radar@0.38.0 observe \
   /path/to/targets.yml \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md

--- a/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
+++ b/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
@@ -30,5 +30,5 @@ than silently monitoring the repository root. Local `workspace:` links remain
 explicitly unresolved; Radar does not guess their published versions.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.37.0`. Review the Draft PR before using the auto-discovery
+`upstream-radar@0.38.0`. Review the Draft PR before using the auto-discovery
 path from npm.

--- a/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
+++ b/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
@@ -10,12 +10,12 @@ The baseline was taken at the commit that produced the published `0.5.4`
 artifact, then the same state was checked against the current `master`:
 
 ```bash
-npx --yes upstream-radar@0.37.0 observe \
+npx --yes upstream-radar@0.38.0 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref aa5f4efc7827176cce27c73f73a2f42514da1ebf \
   --state observations.json --report baseline.md --json
 
-npx --yes upstream-radar@0.37.0 observe \
+npx --yes upstream-radar@0.38.0 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref master \
   --state observations.json --report repair.md --json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
   "type": "module",
   "license": "Apache-2.0",
@@ -95,6 +95,7 @@
     "showcase:dsh-case": "pnpm run build && node scripts/dsh-case-showcase.mjs",
     "showcase:dsh-case:report": "pnpm run build && node scripts/dsh-case-showcase.mjs --write-report",
     "showcase:observer": "pnpm run build && node scripts/upstream-observer-showcase.mjs",
+    "monitor:dsh-findings": "pnpm run build && node scripts/monitor-dsh-findings.mjs",
     "refresh:dsh-batch": "pnpm run build && node scripts/refresh-dsh-batch-index.mjs",
     "showcase:pnpm-lock": "pnpm run build && node scripts/pnpm-lock-showcase.mjs",
     "showcase:pnpm-lock:monitor": "pnpm run build && node scripts/pnpm-lock-monitor-showcase.mjs",

--- a/scripts/monitor-dsh-findings.mjs
+++ b/scripts/monitor-dsh-findings.mjs
@@ -1,0 +1,510 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { compareFindings, FINDING_WATCH_SCHEMA, normalizeFindings } from '../dist/src/finding-watch.js'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const STATE_SCHEMA = 'upstream-radar.finding-watch-state/v1alpha1'
+const REPORT_SCHEMA = 'upstream-radar.finding-watch-report/v1alpha1'
+const MAX_TARGETS = 50
+const MAX_CONFIG_BYTES = 256 * 1024
+const MAX_STATE_BYTES = 16 * 1024 * 1024
+const MAX_OUTPUT_BYTES = 32 * 1024 * 1024
+const DEFAULT_TIMEOUT_MS = 180_000
+const DEFAULT_CONCURRENCY = 2
+const ACCEPTED_SCAN_EXIT_CODES = new Set([0, 2])
+
+function pathFromRoot(value) {
+  return isAbsolute(value) ? value : resolve(ROOT, value)
+}
+
+function parseArgs(argv) {
+  const values = {
+    config: 'examples/dsh/finding-watch/targets.json',
+    state: 'examples/dsh/finding-watch/state.json',
+    report: 'examples/dsh/finding-watch/report.md',
+    jsonReport: 'examples/dsh/finding-watch/report.json',
+    concurrency: Number(process.env.FINDING_WATCH_CONCURRENCY ?? DEFAULT_CONCURRENCY),
+    timeoutMs: Number(process.env.FINDING_WATCH_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS),
+    quiet: false,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--quiet') {
+      values.quiet = true
+      continue
+    }
+    const rawKey = argument.startsWith('--') ? argument.slice(2) : undefined
+    const key = rawKey === 'json-report' ? 'jsonReport' : rawKey === 'timeout-ms' ? 'timeoutMs' : rawKey
+    if (key === undefined || !(key in values) || key === 'quiet') throw new Error(`unknown argument: ${argument}`)
+    const next = argv[index + 1]
+    if (next === undefined || next.startsWith('--')) throw new Error(`missing value for --${key}`)
+    index += 1
+    if (key === 'concurrency' || key === 'timeoutMs') values[key] = Number(next)
+    else values[key] = next
+  }
+  values.concurrency = Math.max(1, Math.min(8, Number.isFinite(values.concurrency) ? Math.floor(values.concurrency) : DEFAULT_CONCURRENCY))
+  values.timeoutMs = Math.max(5_000, Math.min(600_000, Number.isFinite(values.timeoutMs) ? Math.floor(values.timeoutMs) : DEFAULT_TIMEOUT_MS))
+  return values
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringValue(value) {
+  return typeof value === 'string' && value !== '' ? value : undefined
+}
+
+function safeText(value, maxLength = 2_048) {
+  const secrets = [process.env.GITHUB_TOKEN, process.env.NPM_TOKEN, process.env.ISSUE_LOCATOR_LLM_API_KEY].filter(item => typeof item === 'string' && item !== '')
+  let text = String(value ?? '')
+  for (const secret of secrets) text = text.replaceAll(secret, '[REDACTED]')
+  return text.replace(/[\u0000-\u001f\u007f-\u009f]/g, character => `\\u${character.codePointAt(0)?.toString(16).padStart(4, '0') ?? '0000'}`).slice(-maxLength)
+}
+
+async function readJson(path, maxBytes, missingValue) {
+  try {
+    const text = await readFile(path, 'utf8')
+    if (Buffer.byteLength(text) > maxBytes) throw new Error(`${relative(ROOT, path)} is larger than ${maxBytes} bytes`)
+    return JSON.parse(text)
+  } catch (error) {
+    if (error?.code === 'ENOENT') return missingValue
+    throw new Error(`cannot read ${relative(ROOT, path)}: ${safeText(error.message ?? error)}`)
+  }
+}
+
+async function writeIfChanged(path, value) {
+  const next = `${JSON.stringify(value, null, 2)}\n`
+  return writeTextIfChanged(path, next)
+}
+
+async function writeTextIfChanged(path, next) {
+  let previous
+  try {
+    previous = await readFile(path, 'utf8')
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+  }
+  if (previous === next) return false
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, next)
+  return true
+}
+
+function parseJsonOutput(stdout, label) {
+  const text = stdout.trim()
+  if (text === '') throw new Error(`${label} returned no JSON`)
+  try {
+    return JSON.parse(text)
+  } catch {
+    const start = text.indexOf('{')
+    const end = text.lastIndexOf('}')
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(text.slice(start, end + 1))
+      } catch {
+        // Fall through to the bounded error below.
+      }
+    }
+    throw new Error(`${label} returned invalid JSON`)
+  }
+}
+
+function runCli(args, timeoutMs) {
+  return new Promise(resolveRun => {
+    const child = spawn(process.execPath, [join(ROOT, 'dist/src/cli.js'), ...args], {
+      cwd: ROOT,
+      // Node's fetch does not use HTTP(S)_PROXY/SOCKS proxy variables unless
+      // this opt-in is present. In a developer environment that can make a
+      // reachable npm registry look like an unknown artifact.
+      env: { ...process.env, NODE_USE_ENV_PROXY: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    let outputOverflow = false
+    let timedOut = false
+    let timer
+    const append = (current, chunk) => {
+      const next = `${current}${String(chunk)}`
+      if (Buffer.byteLength(next) > MAX_OUTPUT_BYTES) {
+        outputOverflow = true
+        return next.slice(0, MAX_OUTPUT_BYTES)
+      }
+      return next
+    }
+    child.stdout.on('data', chunk => { stdout = append(stdout, chunk) })
+    child.stderr.on('data', chunk => { stderr = append(stderr, chunk) })
+    timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+      setTimeout(() => child.kill('SIGKILL'), 2_000).unref()
+    }, timeoutMs)
+    child.on('error', error => {
+      clearTimeout(timer)
+      resolveRun({ code: 1, stdout, stderr: `${stderr}${error.message}`, timedOut, outputOverflow })
+    })
+    child.on('close', code => {
+      clearTimeout(timer)
+      resolveRun({ code: code ?? 1, stdout, stderr, timedOut, outputOverflow })
+    })
+  })
+}
+
+function transientFailure(result) {
+  if (result.timedOut) return true
+  const text = `${result.stderr}\n${result.stdout}`
+  return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|network|HTTP 5\d\d/i.test(text)
+}
+
+function delay(milliseconds) {
+  return new Promise(resolveDelay => setTimeout(resolveDelay, milliseconds))
+}
+
+async function runCliWithRetry(args, timeoutMs, attempts = 3) {
+  let result
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    result = await runCli(args, timeoutMs)
+    if (!transientFailure(result) || attempt === attempts) return result
+    await delay(500 * attempt)
+  }
+  return result
+}
+
+function validateConfig(input) {
+  if (!isRecord(input) || input.schema !== FINDING_WATCH_SCHEMA || !Array.isArray(input.targets)) {
+    throw new Error(`config must use ${FINDING_WATCH_SCHEMA}`)
+  }
+  if (input.targets.length === 0 || input.targets.length > MAX_TARGETS) throw new Error(`config must contain 1-${MAX_TARGETS} targets`)
+  const ids = new Set()
+  return input.targets.map((raw, index) => {
+    if (!isRecord(raw)) throw new Error(`target ${index + 1} is not an object`)
+    const id = stringValue(raw.id)
+    const repository = stringValue(raw.repository)
+    const packageName = stringValue(raw.package)
+    const watch = Array.isArray(raw.watch) ? raw.watch.filter(item => typeof item === 'string' && item !== '') : []
+    if (id === undefined || repository === undefined || packageName === undefined || watch.length === 0) {
+      throw new Error(`target ${index + 1} needs id, repository, package and watch`)
+    }
+    if (ids.has(id)) throw new Error(`duplicate target id: ${id}`)
+    ids.add(id)
+    return { id, repository, packageName, watch: [...new Set(watch)] }
+  })
+}
+
+function validateState(input) {
+  if (input === undefined) return { schema: STATE_SCHEMA, targets: {} }
+  if (!isRecord(input) || input.schema !== STATE_SCHEMA || !isRecord(input.targets)) throw new Error(`state must use ${STATE_SCHEMA}`)
+  return input
+}
+
+function reportTarget(report) {
+  if (!isRecord(report) || !isRecord(report.target) || !Array.isArray(report.findings)) throw new Error('scan output has no target or findings array')
+  const target = report.target
+  const name = stringValue(target.name)
+  const version = stringValue(target.version)
+  if (name === undefined || version === undefined) throw new Error('scan output has no exact target name/version')
+  return {
+    name,
+    version,
+    digest: stringValue(target.artifactDigest),
+    spec: stringValue(target.spec),
+    findings: report.findings,
+  }
+}
+
+function errorFromRun(label, result) {
+  const suffix = result.timedOut ? `timed out after ${result.timeoutMs ?? 'the configured limit'}ms` : `exit ${result.code}`
+  const output = result.stderr.trim() || result.stdout.trim().slice(-1_000)
+  return safeText(`${label}: ${suffix}${output === '' ? '' : ` — ${output}`}`)
+}
+
+async function observeTarget(target, timeoutMs) {
+  const sourceResult = await runCliWithRetry(['scan', `https://github.com/${target.repository}`, '--json'], timeoutMs)
+  let source
+  let sourceError
+  if (!ACCEPTED_SCAN_EXIT_CODES.has(sourceResult.code) || sourceResult.timedOut || sourceResult.outputOverflow) {
+    sourceError = errorFromRun(`${target.id} source scan`, { ...sourceResult, timeoutMs })
+  } else {
+    try {
+      const parsed = reportTarget(parseJsonOutput(sourceResult.stdout, `${target.id} source scan`))
+      source = {
+        available: true,
+        name: parsed.name,
+        version: parsed.version,
+        digest: parsed.digest,
+        findings: normalizeFindings(parsed.findings, target.watch),
+      }
+    } catch (error) {
+      sourceError = safeText(`${target.id} source scan: ${error.message ?? error}`)
+    }
+  }
+
+  let artifact
+  let artifactError
+  if (source === undefined) {
+    artifactError = 'not attempted because the source scan is unknown'
+  } else {
+    const spec = `npm:${target.packageName}@${source.version}`
+    const artifactResult = await runCliWithRetry(['inspect', spec, '--deep', '--json'], timeoutMs)
+    if (!ACCEPTED_SCAN_EXIT_CODES.has(artifactResult.code) || artifactResult.timedOut || artifactResult.outputOverflow) {
+      artifactError = errorFromRun(`${target.id} artifact review`, { ...artifactResult, timeoutMs })
+    } else {
+      try {
+        const parsed = reportTarget(parseJsonOutput(artifactResult.stdout, `${target.id} artifact review`))
+        artifact = {
+          available: true,
+          spec: stringValue(parsed.spec) ?? spec,
+          name: parsed.name,
+          version: parsed.version,
+          digest: parsed.digest,
+          findings: normalizeFindings(parsed.findings, target.watch),
+        }
+      } catch (error) {
+        artifactError = safeText(`${target.id} artifact review: ${error.message ?? error}`)
+      }
+    }
+  }
+  return {
+    target,
+    source: source ?? { available: false, error: sourceError ?? 'source scan is unknown' },
+    artifact: artifact ?? { available: false, error: artifactError ?? 'artifact review is unknown' },
+  }
+}
+
+async function mapWithConcurrency(items, concurrency, worker) {
+  const results = []
+  let next = 0
+  async function consume() {
+    while (true) {
+      const index = next
+      next += 1
+      if (index >= items.length) return
+      results[index] = await worker(items[index], index)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, consume))
+  return results
+}
+
+function compactSource(source) {
+  if (!source?.available) return undefined
+  return {
+    name: source.name,
+    version: source.version,
+    ...(source.digest === undefined ? {} : { digest: source.digest }),
+    findings: source.findings,
+  }
+}
+
+function compactArtifact(artifact) {
+  if (!artifact?.available) return undefined
+  return {
+    spec: artifact.spec,
+    name: artifact.name,
+    version: artifact.version,
+    ...(artifact.digest === undefined ? {} : { digest: artifact.digest }),
+    findings: artifact.findings,
+  }
+}
+
+function identityChanged(previous, current, keys) {
+  if (!previous || !current) return false
+  return keys.some(key => previous[key] !== current[key])
+}
+
+function partResult(current, previous, watch, kind) {
+  const currentAvailable = current.available === true
+  const previousPart = previous?.[kind]
+  const currentPart = currentAvailable ? (kind === 'source' ? compactSource(current) : compactArtifact(current)) : undefined
+  const comparable = currentPart !== undefined && previousPart !== undefined
+  let delta
+  let identity = false
+  if (comparable) {
+    delta = compareFindings(previousPart.findings, currentPart.findings, watch)
+    identity = kind === 'source'
+      ? identityChanged(previousPart, currentPart, ['name', 'version', 'digest'])
+      : identityChanged(previousPart, currentPart, ['spec', 'name', 'version', 'digest'])
+  }
+  const changed = comparable && (identity || delta.changed)
+  return {
+    status: !currentAvailable ? 'unknown' : !comparable ? 'baseline' : changed ? 'changed' : 'unchanged',
+    ...(currentPart === undefined ? {} : currentPart),
+    ...(delta === undefined ? {} : { transitions: delta.transitions }),
+    ...(identity ? { identityChanged: true } : {}),
+    ...(currentAvailable ? {} : { error: current.error ?? `${kind} observation is unknown` }),
+    changed,
+  }
+}
+
+function activeFindings(part) {
+  return Array.isArray(part?.findings) ? part.findings : []
+}
+
+function stateEntry(observed, previous) {
+  const target = observed.target
+  const source = compactSource(observed.source) ?? previous?.source
+  const artifact = compactArtifact(observed.artifact) ?? previous?.artifact
+  return {
+    id: target.id,
+    repository: target.repository,
+    package: target.packageName,
+    watch: target.watch,
+    ...(source === undefined ? {} : { source }),
+    ...(artifact === undefined ? {} : { artifact }),
+  }
+}
+
+function transitionCounts(targets) {
+  const counts = { added: 0, resolved: 0, changed: 0, persisting: 0 }
+  for (const target of targets) {
+    for (const part of [target.source, target.artifact]) {
+      for (const transition of part.transitions ?? []) counts[transition.status] += 1
+    }
+  }
+  return counts
+}
+
+function markdownEvidence(value) {
+  if (value === undefined) return ''
+  const text = JSON.stringify(value)
+  return text.length > 700 ? `${text.slice(0, 697)}...` : text
+}
+
+function groupedFindings(findings) {
+  const groups = new Map()
+  for (const finding of findings) {
+    const group = groups.get(finding.code) ?? []
+    group.push(finding)
+    groups.set(finding.code, group)
+  }
+  return [...groups.values()].sort((left, right) => left[0].code.localeCompare(right[0].code))
+}
+
+function coordinate(part, artifact = false) {
+  if (!part || part.status === 'unknown') return 'unknown'
+  if (artifact) return part.spec ?? `${part.name ?? 'unknown'}@${part.version ?? 'unknown'}`
+  return `${part.name ?? 'unknown'}@${part.version ?? 'unknown'}`
+}
+
+function renderMarkdown(result) {
+  const lines = [
+    '# DSH known finding watch',
+    '',
+    `Checked: ${result.checkedAt}`,
+    '',
+    'This report watches previously reported supply-chain findings on both the public source repository and the exact npm artifact. `unknown` means the check could not establish a current result; it is never treated as `resolved`.',
+    '',
+    '## Summary',
+    '',
+    `- targets: ${result.summary.targets}`,
+    `- baseline: ${result.summary.baseline}`,
+    `- changed: ${result.summary.changed}`,
+    `- unchanged: ${result.summary.unchanged}`,
+    `- unknown: ${result.summary.unknown}`,
+    `- transitions: ${JSON.stringify(result.summary.transitions)}`,
+    '',
+    '## Current status',
+    '',
+    '| Plugin | Overall | Source | Exact npm artifact |',
+    '| --- | --- | --- | --- |',
+  ]
+  for (const target of result.targets) {
+    lines.push(`| [${target.id}](https://github.com/${target.repository}) | ${target.status} | ${target.source.status}: ${coordinate(target.source)} | ${target.artifact.status}: ${coordinate(target.artifact, true)} |`)
+  }
+  lines.push('', '## Details', '')
+  for (const target of result.targets) {
+    lines.push(`### ${target.id}`, '', `- repository: https://github.com/${target.repository}`, `- overall: **${target.status}**`, `- source: ${target.source.status} — ${coordinate(target.source)}`, `- exact npm artifact: ${target.artifact.status} — ${coordinate(target.artifact, true)}`)
+    for (const [label, part] of [['source', target.source], ['artifact', target.artifact]]) {
+      if (part.error) lines.push(`- ${label} error: ${part.error}`)
+      if (part.identityChanged) lines.push(`- ${label} identity changed since the previous trusted observation`)
+      const transitions = (part.transitions ?? []).filter(item => item.status !== 'persisting')
+      for (const transition of transitions) lines.push(`- ${label} transition: \`${transition.code}\` **${transition.status}** (${transition.previousCount} → ${transition.currentCount})`)
+      const findings = activeFindings(part)
+      if (findings.length === 0 && part.status !== 'unknown') lines.push(`- ${label} active watched findings: none`)
+      for (const group of groupedFindings(findings)) {
+        const first = group[0]
+        lines.push(`- ${label} active finding: \`${first.code}\` (${first.severity}) × ${group.length} — ${first.detail ?? first.summary}`)
+        for (const finding of group.slice(0, 3)) {
+          const evidence = markdownEvidence(finding.evidence)
+          if (evidence !== '') lines.push(`  - evidence: \`${evidence}\``)
+        }
+        if (group.length > 3) lines.push(`  - ${group.length - 3} more evidence records are in the machine report`)
+      }
+    }
+    lines.push('')
+  }
+  lines.push('## Interpretation', '', 'These are bounded static and exact-artifact observations. An install script, native binary, missing provenance record, or floating dependency is not automatically malicious; each item tells the plugin author what to review or fix. A source fix can land before the npm artifact is republished, so the two sides remain separate.', '')
+  return `${lines.join('\n').trimEnd()}\n`
+}
+
+const options = parseArgs(process.argv.slice(2))
+const configPath = pathFromRoot(options.config)
+const statePath = pathFromRoot(options.state)
+const reportPath = pathFromRoot(options.report)
+const jsonReportPath = options.jsonReport === undefined ? undefined : pathFromRoot(options.jsonReport)
+const config = await readJson(configPath, MAX_CONFIG_BYTES)
+const targets = validateConfig(config)
+const previousState = validateState(await readJson(statePath, MAX_STATE_BYTES, undefined))
+const observed = await mapWithConcurrency(targets, options.concurrency, target => observeTarget(target, options.timeoutMs))
+const checkedAt = new Date().toISOString()
+const reportTargets = []
+const nextStateTargets = {}
+
+for (const item of observed) {
+  const previous = isRecord(previousState.targets[item.target.id]) ? previousState.targets[item.target.id] : undefined
+  const source = partResult(item.source, previous, item.target.watch, 'source')
+  const artifact = partResult(item.artifact, previous, item.target.watch, 'artifact')
+  const hasUnknown = source.status === 'unknown' || artifact.status === 'unknown'
+  const hasChange = source.changed || artifact.changed
+  const hasPreviousComparableObservation = previous?.source !== undefined || previous?.artifact !== undefined
+  const status = hasUnknown ? 'unknown' : hasChange ? 'changed' : hasPreviousComparableObservation ? 'unchanged' : 'baseline'
+  const reportTargetValue = {
+    id: item.target.id,
+    repository: item.target.repository,
+    package: item.target.packageName,
+    watch: item.target.watch,
+    status,
+    source,
+    artifact,
+  }
+  reportTargets.push(reportTargetValue)
+  nextStateTargets[item.target.id] = stateEntry(item, previous)
+}
+
+const summary = {
+  targets: reportTargets.length,
+  baseline: reportTargets.filter(item => item.status === 'baseline').length,
+  changed: reportTargets.filter(item => item.status === 'changed').length,
+  unchanged: reportTargets.filter(item => item.status === 'unchanged').length,
+  unknown: reportTargets.filter(item => item.status === 'unknown').length,
+  transitions: transitionCounts(reportTargets),
+}
+const report = {
+  schema: REPORT_SCHEMA,
+  checkedAt,
+  config: relative(ROOT, configPath),
+  state: relative(ROOT, statePath),
+  summary,
+  targets: reportTargets,
+}
+const nextState = {
+  schema: STATE_SCHEMA,
+  targets: nextStateTargets,
+}
+const stateChanged = await writeIfChanged(statePath, nextState)
+await writeTextIfChanged(reportPath, renderMarkdown(report))
+if (jsonReportPath !== undefined) await writeIfChanged(jsonReportPath, report)
+
+if (!options.quiet) {
+  console.log(`DSH known finding watch: ${summary.targets} targets`)
+  console.log(`  baseline=${summary.baseline} changed=${summary.changed} unchanged=${summary.unchanged} unknown=${summary.unknown}`)
+  console.log(`  transitions=${JSON.stringify(summary.transitions)}`)
+  console.log(`  state ${stateChanged ? 'updated' : 'unchanged'}: ${relative(ROOT, statePath)}`)
+  console.log(`  report: ${relative(ROOT, reportPath)}`)
+}
+process.exitCode = summary.unknown > 0 ? 1 : 0

--- a/src/finding-watch.ts
+++ b/src/finding-watch.ts
@@ -1,0 +1,105 @@
+import { createHash } from 'node:crypto'
+
+export const FINDING_WATCH_SCHEMA = 'upstream-radar.finding-watch/v1alpha1' as const
+
+export type FindingWatchTransitionStatus = 'added' | 'resolved' | 'changed' | 'persisting'
+
+export interface FindingWatchRecord {
+  code: string
+  severity: string
+  summary: string
+  detail?: string
+  evidence?: unknown
+  fingerprint: string
+}
+
+export interface FindingWatchTransition {
+  code: string
+  status: FindingWatchTransitionStatus
+  previousCount: number
+  currentCount: number
+}
+
+export interface FindingWatchDelta {
+  changed: boolean
+  transitions: FindingWatchTransition[]
+}
+
+export interface FindingWatchInput {
+  code?: unknown
+  severity?: unknown
+  summary?: unknown
+  detail?: unknown
+  evidence?: unknown
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (typeof value !== 'object' || value === null) return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonicalize(item)]),
+  )
+}
+
+function fingerprint(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex')}`
+}
+
+export function normalizeFinding(input: FindingWatchInput): FindingWatchRecord | undefined {
+  if (typeof input.code !== 'string' || input.code === '') return undefined
+  const severity = typeof input.severity === 'string' && input.severity !== '' ? input.severity : 'unknown'
+  const summary = typeof input.summary === 'string' && input.summary !== '' ? input.summary : input.code
+  const detail = typeof input.detail === 'string' && input.detail !== '' ? input.detail : undefined
+  const evidence = input.evidence
+  const identity = { code: input.code, severity, summary, ...(detail === undefined ? {} : { detail }), ...(evidence === undefined ? {} : { evidence }) }
+  return {
+    ...identity,
+    fingerprint: fingerprint(identity),
+  }
+}
+
+export function normalizeFindings(inputs: readonly FindingWatchInput[], watchedCodes: readonly string[]): FindingWatchRecord[] {
+  const watched = new Set(watchedCodes)
+  return inputs
+    .map(normalizeFinding)
+    .filter((finding): finding is FindingWatchRecord => finding !== undefined && watched.has(finding.code))
+    .sort((left, right) => left.code.localeCompare(right.code) || left.fingerprint.localeCompare(right.fingerprint))
+}
+
+function groupedFingerprints(findings: readonly FindingWatchRecord[]): Map<string, string[]> {
+  const groups = new Map<string, string[]>()
+  for (const finding of findings) {
+    const current = groups.get(finding.code) ?? []
+    current.push(finding.fingerprint)
+    groups.set(finding.code, current)
+  }
+  for (const values of groups.values()) values.sort()
+  return groups
+}
+
+export function compareFindings(
+  previous: readonly FindingWatchRecord[] | undefined,
+  current: readonly FindingWatchRecord[],
+  watchedCodes: readonly string[],
+): FindingWatchDelta {
+  const oldGroups = groupedFingerprints(previous ?? [])
+  const currentGroups = groupedFingerprints(current)
+  const codes = [...new Set([...watchedCodes, ...oldGroups.keys(), ...currentGroups.keys()])].sort()
+  const transitions: FindingWatchTransition[] = []
+  for (const code of codes) {
+    const oldValues = oldGroups.get(code) ?? []
+    const currentValues = currentGroups.get(code) ?? []
+    let status: FindingWatchTransitionStatus
+    if (oldValues.length === 0 && currentValues.length > 0) status = 'added'
+    else if (oldValues.length > 0 && currentValues.length === 0) status = 'resolved'
+    else if (JSON.stringify(oldValues) !== JSON.stringify(currentValues)) status = 'changed'
+    else status = 'persisting'
+    transitions.push({ code, status, previousCount: oldValues.length, currentCount: currentValues.length })
+  }
+  return {
+    changed: transitions.some(item => item.status !== 'persisting'),
+    transitions,
+  }
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.37.0'
+export const TOOL_VERSION = '0.38.0'

--- a/test/finding-watch.test.ts
+++ b/test/finding-watch.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { compareFindings, normalizeFindings } from '../src/finding-watch.js'
+
+describe('known finding watch', () => {
+  it('keeps finding identity stable when evidence key order changes', () => {
+    const previous = normalizeFindings([{
+      code: 'dependency-install-script-present',
+      severity: 'high',
+      summary: 'Install script',
+      detail: 'Review before install',
+      evidence: { scripts: ['dep@1.0.0 install: node postinstall'], packages: ['dep@1.0.0'] },
+    }], ['dependency-install-script-present'])
+    const current = normalizeFindings([{
+      code: 'dependency-install-script-present',
+      severity: 'high',
+      summary: 'Install script',
+      detail: 'Review before install',
+      evidence: { packages: ['dep@1.0.0'], scripts: ['dep@1.0.0 install: node postinstall'] },
+    }], ['dependency-install-script-present'])
+    assert.equal(previous[0]?.fingerprint, current[0]?.fingerprint)
+    assert.deepEqual(compareFindings(previous, current, ['dependency-install-script-present']).transitions, [{
+      code: 'dependency-install-script-present',
+      status: 'persisting',
+      previousCount: 1,
+      currentCount: 1,
+    }])
+  })
+
+  it('distinguishes an upstream fix, a new finding, and changed evidence', () => {
+    const watched = ['dependency-graph-unavailable', 'lifecycle-script-present', 'npm-provenance-missing']
+    const previous = normalizeFindings([
+      { code: 'dependency-graph-unavailable', severity: 'info', summary: 'Graph unavailable' },
+      { code: 'lifecycle-script-present', severity: 'high', summary: 'Lifecycle script', evidence: { scripts: ['prepare: old'] } },
+    ], watched)
+    const current = normalizeFindings([
+      { code: 'lifecycle-script-present', severity: 'high', summary: 'Lifecycle script', evidence: { scripts: ['prepare: new'] } },
+      { code: 'npm-provenance-missing', severity: 'medium', summary: 'No provenance' },
+    ], watched)
+    const delta = compareFindings(previous, current, watched)
+    assert.equal(delta.changed, true)
+    assert.deepEqual(delta.transitions, [
+      { code: 'dependency-graph-unavailable', status: 'resolved', previousCount: 1, currentCount: 0 },
+      { code: 'lifecycle-script-present', status: 'changed', previousCount: 1, currentCount: 1 },
+      { code: 'npm-provenance-missing', status: 'added', previousCount: 0, currentCount: 1 },
+    ])
+  })
+
+  it('does not let an unlisted finding enter the watch result', () => {
+    const findings = normalizeFindings([
+      { code: 'unrelated-signal', severity: 'medium', summary: 'Not in this watch' },
+    ], ['npm-provenance-missing'])
+    assert.deepEqual(findings, [])
+  })
+})

--- a/test/release-preflight.test.ts
+++ b/test/release-preflight.test.ts
@@ -23,7 +23,7 @@ describe('release preflight', () => {
       checks: Array<{ status: string }>
     }
     assert.equal(report.schema, 'upstream-radar.release-preflight/v1alpha1')
-    assert.equal(report.version, '0.37.0')
+    assert.equal(report.version, '0.38.0')
     assert.equal(report.passed, true)
     assert.equal(report.publishedCheck, false)
     assert.ok(report.checks.length >= 4)


### PR DESCRIPTION
## Summary

- add a dedicated always-on watch for the seven real DSH supply-chain findings from the first batch;
- check each public source repository and the exact npm artifact separately;
- persist trusted observations and classify added, resolved, changed, persisting, and unknown states;
- add bounded retries, proxy-aware Node fetches, machine-readable/Markdown reports, tests, and a daily GitHub Actions workflow;
- publish the repository as `v0.38.0` after release preflight and 283/283 tests pass.

## Live result

The latest real run checked all 7 targets successfully: `0 unknown`, `7 unchanged`, with 42 persisting source/artifact transitions. The report keeps the actionable evidence, including the source-side cleanup in `dsh-msg-hub@0.1.8` while its npm artifact still reaches `protobufjs@7.6.5` with a `postinstall`, and the `koffi@3.1.6` install step in `dsh-wsl-workspace`.

## Safety boundary

The watch does not install plugins, execute lifecycle scripts, load DSH, or call an LLM. Network failures remain `unknown` and never erase the last trusted observation.

## Verification

- `pnpm test`
- `pnpm run release:check`
- real `node scripts/monitor-dsh-findings.mjs --quiet` run against 7 public repositories and exact npm artifacts
