### PR TITLE
fix: make DeepSeek JSON agent output reliable

### DIFF
--- a/src/upstream-observer.ts
+++ b/src/upstream-observer.ts
@@ -1689,6 +1689,15 @@ function llmCompletionEndpoints(baseUrl: string): string[] {
   return [...new Set(bases)].map(base => `${base}/chat/completions`)
 }
 
+function isDeepSeekJsonModel(baseUrl: string, model: string): boolean {
+  if (model === 'deepseek-v4-flash' || model === 'deepseek-v4-pro' || model === 'deepseek-chat' || model === 'deepseek-reasoner') return true
+  try {
+    return new URL(baseUrl).hostname === 'api.deepseek.com'
+  } catch {
+    return false
+  }
+}
+
 /**
  * Call an explicit OpenAI-compatible model without requiring users to write a
  * DSH wrapper. The env file is read for this invocation only; the key and
@@ -1736,14 +1745,17 @@ export async function runOpenAiCompatibleAgent(
         body: JSON.stringify({
           model,
           messages: [
-            { role: 'system', content: '只返回严格 JSON，不要输出 Markdown。' },
+            { role: 'system', content: '只返回一个严格 JSON 对象。不要输出 Markdown、解释、前缀或后缀；输出必须以 { 开始并以 } 结束。' },
             { role: 'user', content: prompt },
           ],
           temperature: 0,
+          // DeepSeek V4 enables thinking by default. For this machine-readable
+          // contract, disable it so the output budget is reserved for the JSON
+          // conclusion instead of an optional reasoning stream.
+          ...(isDeepSeekJsonModel(baseUrl, model) ? { thinking: { type: 'disabled' } } : {}),
           response_format: { type: 'json_object' },
-          // GLM-5.1 reports its reasoning tokens against the completion budget;
-          // without an explicit budget it can spend the whole response on
-          // reasoning and return an empty `content` field.
+          // Keep an explicit output budget so the JSON conclusion is not
+          // truncated by a provider default.
           max_tokens: DEFAULT_LLM_MAX_TOKENS,
         }),
         signal: AbortSignal.timeout(timeoutMs),

--- a/test/upstream-observer.test.ts
+++ b/test/upstream-observer.test.ts
@@ -816,7 +816,7 @@ targets:
       await writeFile(envFile, [
         `ISSUE_LOCATOR_LLM_BASE_URL=http://127.0.0.1:${address.port}/llm/v1`,
         'ISSUE_LOCATOR_LLM_API_KEY=test-only',
-        'MODEL=test-model',
+        'MODEL=deepseek-v4-flash',
         '',
       ].join('\n'))
       const invocation = await runOpenAiCompatibleAgent(task, 'read-only task prompt', { envFile })
@@ -825,7 +825,9 @@ targets:
       assert.equal((invocation.parsedOutput as { breaking_change: boolean }).breaking_change, false)
       assert.deepEqual((invocation.parsedOutput as { evidence: string[] }).evidence, ['source: ["src/index.ts"]'])
       assert.equal(requestBodies.length, 1)
-      assert.equal(JSON.parse(requestBodies[0]!).model, 'test-model')
+      assert.equal(JSON.parse(requestBodies[0]!).model, 'deepseek-v4-flash')
+      assert.deepEqual(JSON.parse(requestBodies[0]!).thinking, { type: 'disabled' })
+      assert.match(JSON.parse(requestBodies[0]!).messages[0].content, /严格 JSON 对象/)
       assert.equal(JSON.parse(requestBodies[0]!).max_tokens, 2_048)
       assert.match(JSON.parse(requestBodies[0]!).messages[1].content, /read-only task prompt/)
     } finally {


### PR DESCRIPTION
## What changed

DeepSeek V4 enables thinking by default. For this machine-readable observer contract, that can leave the final `message.content` empty even when JSON Output is requested.

This change:
- disables DeepSeek thinking only for DeepSeek model IDs / the official endpoint;
- strengthens the JSON-only system instruction;
- keeps the existing strict eight-field validation;
- adds a regression assertion for the request body.

## Evidence

- Local test suite: 283 tests passed.
- Real GitHub Actions validation: https://github.com/MicroMilo/upstream-radar/actions/runs/32445500875
- Result: `configured=true`, `attempted=1`, `succeeded=1`, `failed=0`, `pendingTasks=[]`.
- No API key is stored in the repository or included in the report.

The validation consumed the remaining DSH upstream change task and produced a structured result for the DSH rc.8 migration and new exports.
