### PR TITLE
feat: observe DSH plugin installs in isolation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+*
+!.npmrc
+!package.json
+!pnpm-lock.yaml
+!tsconfig.json
+!src
+!src/**
+!test
+!test/**

--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.38.0
+      - uses: MicroMilo/upstream-radar@v0.39.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/.github/workflows/observe-dsh-plugin-install.yml
+++ b/.github/workflows/observe-dsh-plugin-install.yml
@@ -1,0 +1,196 @@
+name: Observe one DSH plugin install
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: Exact npm plugin package, for example dsh-feishu-bot@0.16.0
+        required: true
+        default: dsh-feishu-bot@0.16.0
+        type: string
+      dsh_version:
+        description: Exact DSH version used for the install and load
+        required: true
+        default: 0.1.0-rc.8
+        type: string
+      case_id:
+        description: Short artifact label
+        required: true
+        default: manual
+        type: string
+      timeout_seconds:
+        description: Per-stage timeout from 30 to 600 seconds
+        required: true
+        default: '180'
+        type: string
+  workflow_call:
+    inputs:
+      plugin:
+        required: true
+        type: string
+      dsh_version:
+        required: true
+        type: string
+      case_id:
+        required: true
+        type: string
+      timeout_seconds:
+        required: false
+        default: '180'
+        type: string
+
+# The target package executes arbitrary lifecycle and load code. This workflow
+# deliberately has no write permission and declares no secrets.
+permissions:
+  contents: read
+
+jobs:
+  observe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out only the trusted observer implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Validate exact coordinates
+        shell: bash
+        env:
+          RADAR_PLUGIN: ${{ inputs.plugin }}
+          RADAR_DSH_VERSION: ${{ inputs.dsh_version }}
+          RADAR_CASE_ID: ${{ inputs.case_id }}
+          RADAR_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+        run: |
+          set -euo pipefail
+          exact_package='^(@[^/@[:space:]]+/[^@/[:space:]]+|[^@/[:space:]]+)@[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+          exact_version='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+          case_id='^[a-z0-9][a-z0-9._-]{0,63}$'
+          if [[ ! "$RADAR_PLUGIN" =~ $exact_package ]]; then
+            echo 'plugin must be an exact npm package such as dsh-feishu-bot@0.16.0' >&2
+            exit 1
+          fi
+          if [[ ! "$RADAR_DSH_VERSION" =~ $exact_version ]]; then
+            echo 'dsh_version must be an exact semantic version' >&2
+            exit 1
+          fi
+          if [[ ! "$RADAR_CASE_ID" =~ $case_id ]]; then
+            echo 'case_id must be a short lowercase label' >&2
+            exit 1
+          fi
+          if [[ ! "$RADAR_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || (( RADAR_TIMEOUT_SECONDS < 30 || RADAR_TIMEOUT_SECONDS > 600 )); then
+            echo 'timeout_seconds must be an integer between 30 and 600' >&2
+            exit 1
+          fi
+
+      - name: Build the pinned observer image
+        shell: bash
+        run: docker build --file docker/dsh-install-observer.Dockerfile --tag upstream-radar-install-observer:${{ github.run_id }} .
+
+      - name: Install and load inside the restricted container
+        id: observe
+        continue-on-error: true
+        shell: bash
+        env:
+          RADAR_PLUGIN: ${{ inputs.plugin }}
+          RADAR_DSH_VERSION: ${{ inputs.dsh_version }}
+          RADAR_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+          RADAR_IMAGE: upstream-radar-install-observer:${{ github.run_id }}
+          RADAR_REPORT_DIRECTORY: ${{ runner.temp }}/upstream-radar-install-observation
+          RADAR_CONTAINER_NAME: upstream-radar-install-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RADAR_REPORT_DIRECTORY"
+          chmod 0777 "$RADAR_REPORT_DIRECTORY"
+          cleanup() {
+            docker rm --force "$RADAR_CONTAINER_NAME" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          set +e
+          timeout --signal=KILL 15m docker run --rm \
+            --name "$RADAR_CONTAINER_NAME" \
+            --read-only \
+            --user "$(id -u):$(id -g)" \
+            --network bridge \
+            --cap-drop ALL \
+            --cap-add SYS_PTRACE \
+            --security-opt no-new-privileges=true \
+            --pids-limit 256 \
+            --memory 4g \
+            --cpus 2 \
+            --ulimit nofile=4096:4096 \
+            --tmpfs /sandbox:rw,exec,nosuid,nodev,size=4g,mode=1777 \
+            --mount "type=bind,src=$RADAR_REPORT_DIRECTORY,dst=/output" \
+            --env UPSTREAM_RADAR_ISOLATED_RUNNER=1 \
+            --env TMPDIR=/sandbox \
+            --env LANG=C.UTF-8 \
+            "$RADAR_IMAGE" \
+            "$RADAR_PLUGIN" \
+            --dsh-version "$RADAR_DSH_VERSION" \
+            --isolation-provider github-actions-hosted-runner \
+            --timeout "$RADAR_TIMEOUT_SECONDS" \
+            --execute \
+            --report /output/report.json \
+            --json | tee "$RADAR_REPORT_DIRECTORY/stdout.json"
+          observer_exit=${PIPESTATUS[0]}
+          set -e
+          printf 'exit=%s\n' "$observer_exit" >> "$GITHUB_OUTPUT"
+          exit "$observer_exit"
+
+      - name: Write bounded evidence to the Job Summary
+        if: always()
+        shell: bash
+        env:
+          RADAR_PLUGIN: ${{ inputs.plugin }}
+          RADAR_DSH_VERSION: ${{ inputs.dsh_version }}
+          RADAR_OBSERVER_EXIT: ${{ steps.observe.outputs.exit }}
+          RADAR_REPORT: ${{ runner.temp }}/upstream-radar-install-observation/report.json
+        run: |
+          node --input-type=module <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          import { existsSync, readFileSync } from 'node:fs'
+          const inline = value => String(value ?? 'unknown').replace(/[\u0000-\u001f\u007f`]/g, ' ').slice(0, 300)
+          const count = events => Array.isArray(events) ? events.reduce((sum, event) => sum + Number(event?.count ?? 0), 0) : 0
+          const lines = [
+            '## Upstream Radar — isolated DSH install observation',
+            '',
+            `- Plugin: \`${inline(process.env.RADAR_PLUGIN)}\``,
+            `- DSH: \`${inline(process.env.RADAR_DSH_VERSION)}\``,
+            `- Observer exit: \`${inline(process.env.RADAR_OBSERVER_EXIT)}\``,
+          ]
+          if (!existsSync(process.env.RADAR_REPORT)) {
+            lines.push('- Result: `unknown` — no machine-readable report survived the bounded run.')
+          } else {
+            let report
+            try { report = JSON.parse(readFileSync(process.env.RADAR_REPORT, 'utf8')) } catch {}
+            if (report === undefined) {
+              lines.push('- Result: `unknown` — report JSON was invalid.')
+            } else {
+              lines.push(
+                `- Result: \`${inline(report.result)}\` — ${inline(report.reason)}`,
+                `- Exact artifact: \`sha256:${inline(report.artifact?.sha256)}\``,
+                `- Declared lifecycle scripts: \`${inline(report.artifact?.lifecycleScripts?.join(', ') || 'none')}\``,
+                `- Install behavior: ${count(report.observations?.install?.processes)} process exec(s), ${count(report.observations?.install?.network)} network attempt(s), ${count(report.observations?.install?.fileWrites)} file-write syscall(s)`,
+                `- Load behavior: ${count(report.observations?.load?.processes)} process exec(s), ${count(report.observations?.load?.network)} network attempt(s), ${count(report.observations?.load?.fileWrites)} file-write syscall(s)`,
+                `- Trace coverage: install \`${inline(report.observations?.install?.coverage?.status)}\`, load \`${inline(report.observations?.load?.coverage?.status)}\``,
+                `- Isolation: \`${inline(report.boundary?.isolationProviderClaim)}\`; no repository secrets were passed into the container.`,
+              )
+              const endpoints = (report.observations?.install?.network ?? []).slice(0, 5)
+              if (endpoints.length > 0) {
+                lines.push('- First observed install destinations:')
+                for (const event of endpoints) lines.push(`  - \`${inline(`${event.address}${event.port === undefined ? '' : `:${event.port}`}`)}\` (${inline(event.operation)}, count ${inline(event.count)})`)
+              }
+            }
+          }
+          lines.push('', 'This is bounded behavior evidence from a disposable VM plus restricted container. It is not a proof that adversarial code is safe.', '')
+          process.stdout.write(lines.join('\n'))
+          NODE
+
+      - name: Keep the machine-readable observation
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: upstream-radar-install-${{ inputs.case_id }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/upstream-radar-install-observation
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/review-dsh-plugin.yml
+++ b/.github/workflows/review-dsh-plugin.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.38.0
+        uses: MicroMilo/upstream-radar@v0.39.0
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/.github/workflows/upstream-observer.yml
+++ b/.github/workflows/upstream-observer.yml
@@ -20,6 +20,10 @@ jobs:
   observe:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      run_install_observation: ${{ steps.install-plan.outputs.run }}
+      install_dsh_version: ${{ steps.install-plan.outputs.dsh_version }}
+      install_matrix: ${{ steps.install-plan.outputs.matrix }}
     steps:
       - name: Check out the observer and its targets
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -96,6 +100,16 @@ jobs:
           echo "exit=$observer_exit" >> "$GITHUB_OUTPUT"
           exit "$observer_exit"
 
+      - name: Plan isolated install observations only for changed coordinates
+        id: install-plan
+        env:
+          OBSERVER_JSON: ${{ runner.temp }}/upstream-radar-observer.json
+        run: |
+          node scripts/write-dsh-install-plan.mjs \
+            examples/dsh/install-observer/targets.json \
+            observations.json \
+            "$OBSERVER_JSON"
+
       # The state is written even when an upstream source or the optional
       # Agent fails. Pending tasks and the last trustworthy observations must
       # survive the runner, so the next scheduled run can retry them.
@@ -117,3 +131,20 @@ jobs:
           fi
           git commit -m 'chore: update upstream observation point [skip ci]'
           git push
+
+  # Every matrix entry gets a fresh GitHub-hosted VM. The reusable workflow
+  # adds a restricted container and never receives the observer's model key.
+  install-observation:
+    needs: observe
+    if: needs.observe.outputs.run_install_observation == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.observe.outputs.install_matrix) }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/observe-dsh-plugin-install.yml
+    with:
+      plugin: ${{ matrix.plugin }}
+      dsh_version: ${{ needs.observe.outputs.install_dsh_version }}
+      case_id: ${{ matrix.id }}
+      timeout_seconds: '180'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## [0.39.0] - 2026-08-21
+
+### Isolated DSH install and load observation
+
+- Add an explicit `probe dsh-install` lane that binds one exact npm tarball to one exact DSH release, then records install and load process, network, file-write, registration, and filesystem evidence.
+- Require explicit execution consent and an externally declared disposable Linux boundary; keep ordinary graph, artifact, and observer collection non-executing.
+- Add a secret-free reusable GitHub Actions workflow using a fresh hosted VM and restricted container for each plugin, with bounded JSON evidence and honest trace-coverage states.
+- Observe the official `@deepseek-ai/dsh` coordinate and fan out a maintained three-plugin matrix only when DSH or a mapped plugin's exact published coordinate changes.
+- Add the dynamic result schema, tested plan builder, public execution-boundary documentation, and a Firecracker migration boundary for future adversarial tamper resistance.
+
 ## [0.38.0] - 2026-08-21
 
 ### Always-on known finding watch

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Upstream Radar is not another package-name vulnerability scanner. It follows one
 
 | Product job | What Radar establishes |
 | --- | --- |
-| **DSH compatibility / admission** | Whether the exact published bundle can be registered and loaded by the DSH releases you care about. |
+| **DSH compatibility / admission** | Whether the exact published bundle can be installed, registered, and loaded by the DSH releases you care about, with an isolated execution lane for behavior evidence. |
 | **Real dependency graph** | Which exact package versions and physical paths the plugin brings into the DSH profile, including unresolved edges. |
 | **Continuous upstream monitoring** | Whether an advisory, npm release, DSH/Cordis change, or breaking signal changes the old → new situation. |
 | **Author-facing repair** | Which plugin, dependency path, version, lockfile, or DSH declaration gives the author a concrete next fix. |
@@ -21,7 +21,7 @@ The deterministic scanner establishes package, graph, advisory, and compatibilit
 
 ```mermaid
 flowchart TD
-  A["DSH plugin source or exact npm artifact"] --> B["DSH compatibility / admission check"]
+  A["DSH plugin source or exact npm artifact"] --> B["Static review + DSH compatibility check"]
   B --> C["Build the real plugin → dependency graph"]
   C --> D["Monitor advisories, npm, DSH and Cordis changes"]
   D --> E{"Meaningful affected change?"}
@@ -63,19 +63,53 @@ baseline report, and defined in [`schemas/upstream-downstream-ir.schema.json`](s
 
 ```bash
 # No DSH profile, API key, or network state required
-npx --yes upstream-radar@0.38.0 demo
+npx --yes upstream-radar@0.39.0 demo
 
 # Scan a public DSH plugin repository without installing it
-npx --yes upstream-radar@0.38.0 scan \
+npx --yes upstream-radar@0.39.0 scan \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --fail-on never
 
 # Review a real browser plugin users would install, then check two DSH releases
-npx --yes upstream-radar@0.38.0 review dsh-plugin dsh-cloudflare-browser-run@0.1.1 \
+npx --yes upstream-radar@0.39.0 review dsh-plugin dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
 
 The important output is evidence, not a green badge: exact package identity, dependency paths, unresolved edges, install-time scripts, npm integrity/signature/provenance, advisory matches, and DSH load results.
+
+## The isolated execution lane
+
+Static metadata tells us that a lifecycle script exists; it cannot tell us what
+actually ran. The new [`dsh-install` workflow](.github/workflows/observe-dsh-plugin-install.yml)
+therefore uses a separate, deliberately untrusted lane:
+
+```text
+fresh GitHub-hosted VM (no secrets, read-only repository token)
+  → restricted container (no host workspace or Docker socket)
+  → npm pack exact package@version with scripts disabled
+  → DSH installs that same tarball with scripts enabled
+  → strace records child processes, network destinations and file writes
+  → DSH loads the registered bundle under the same exact release
+  → bounded JSON report survives; the container and VM are discarded
+```
+
+Use **Actions → Observe one DSH plugin install** and supply one exact plugin and
+one exact DSH version. The CLI also exposes `probe dsh-install`, but it refuses
+to run unless both `--execute` and `UPSTREAM_RADAR_ISOLATED_RUNNER=1` are present;
+it is not intended as a normal laptop command.
+
+This lane is wired into the always-on observer. Radar now watches the official
+`@deepseek-ai/dsh` coordinate. A new exact DSH publication fans out the small
+[maintained plugin corpus](examples/dsh/install-observer/targets.json), one fresh
+VM per plugin. A mapped plugin publication retests only that plugin. Unchanged
+commits stay quiet, and the DSH Agent/API key never enters the execution job.
+
+The first implementation is intentionally honest about its limit: a container
+shares the hosted VM's kernel, and same-container `strace` evidence is not
+tamper-proof against determined malicious code. The outer VM is disposable and
+secret-free; a Firecracker collector is the later high-assurance backend, not a
+claim made by this report. See the [execution boundary and result semantics](examples/dsh/install-observer/README.md)
+and [`dsh-install-observation.schema.json`](schemas/dsh-install-observation.schema.json).
 
 ## What we have already found
 
@@ -131,11 +165,11 @@ Two copies of `parser` are different nodes. An alert names the exact version and
 For a collection of saved reports, build the reverse index that turns an upstream package update into affected plugins:
 
 ```bash
-npx --yes upstream-radar@0.38.0 graph reverse ./reports \
+npx --yes upstream-radar@0.39.0 graph reverse ./reports \
   --output reverse-dependency-index.json
 
 # Ask: which plugins currently depend on this exact package?
-npx --yes upstream-radar@0.38.0 graph reverse ./reports \
+npx --yes upstream-radar@0.39.0 graph reverse ./reports \
   --package parser@2.9.0
 
 # Rebuild the checked-in index from the real first 50 DSH plugin reports
@@ -154,7 +188,7 @@ To route an upstream old → new change to that index, pass it to the always-on
 observer:
 
 ```bash
-npx --yes upstream-radar@0.38.0 observe ./targets.yml \
+npx --yes upstream-radar@0.39.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json \
   --report ./upstream-radar-observer.md
@@ -180,7 +214,7 @@ replay baseline → one Agent task → quiet run without network access.
 The repository already contains a reusable, composite Action in [`action.yml`](action.yml). It runs the same frozen Radar check in CI and writes a short Job Summary.
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.38.0
+- uses: MicroMilo/upstream-radar@v0.39.0
   with:
     config: upstream-radar.config.json
     fail-on: high
@@ -194,8 +228,9 @@ See the [consumer workflow](examples/github-actions/consumer/README.md) for conf
 | --- | --- |
 | Reconstruct exact npm/pnpm dependency paths | An empty finding list is a safety certificate |
 | Query OSV and GitHub Advisory evidence for exact versions | A missing provenance statement proves maliciousness |
-| Compare source and published artifact evidence | Static review replaces sandboxing or runtime testing |
-| Check DSH bundle/profile compatibility without business execution | “Compatible” means the plugin is secure |
+| Compare source and published artifact evidence | Static review replaces runtime evidence |
+| Observe exact install/load behavior in a disposable VM and restricted container | One observed run proves adversarial code is safe |
+| Check DSH bundle/profile compatibility without business actions | “Compatible” means the plugin is secure |
 | Monitor old → new upstream observations | An LLM can repair evidence that was never collected |
 
 ## Install and connect to DSH
@@ -204,7 +239,7 @@ See the [consumer workflow](examples/github-actions/consumer/README.md) for conf
 pnpm add upstream-radar
 
 # Generate a reviewable DSH profile inventory from the installed profile
-npx --yes upstream-radar@0.38.0 setup
+npx --yes upstream-radar@0.39.0 setup
 ```
 
 For Feishu/webhook routing, DSH Agent handoff, observer state, report schemas, and troubleshooting, use the [full Chinese guide](docs/README.zh-CN.md). The [architecture notes](docs/architecture.md) explain the boundaries and evidence model.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,7 @@ Report vulnerabilities through GitHub's **Security → Report a vulnerability** 
 - unchanged events produce an unbounded alert or model-call loop;
 - a compatibility heuristic is promoted to a confirmed break without evidence;
 - target package code executes during graph or static collection;
+- target package code escapes the explicit install-observation container, receives a repository/model secret, or persists onto another plugin's worker;
 - archive/path/symlink escape in the supporting scanner;
 - credentials, proprietary source, or local paths leak into an unintended report or destination;
 - configured bounds can be bypassed to exhaust disk, memory, network, or model quota.
@@ -26,4 +27,11 @@ A compatibility signal establishes a manifest/version difference or definite ran
 
 DSH Agent analysis is model-generated reasoning. It must cite project evidence and preserve uncertainty; it is not a replacement for deterministic matching or tests.
 
-Deep npm collection runs in a fresh temporary project with lifecycle scripts disabled, a scrubbed environment, and controlled npm/Git configuration. It is not a hardened sandbox and should process public artifacts only until disposable worker isolation lands.
+Deep npm collection remains static: it runs in a fresh temporary project with lifecycle scripts disabled, a scrubbed environment, and controlled npm/Git configuration.
+
+The separately named `probe dsh-install` path intentionally executes package
+and load code. Its supported workflow gives each target a fresh GitHub-hosted
+VM plus a restricted container, passes no model/repository secret into that
+container, and binds evidence to one exact tarball. This is bounded behavior
+evidence, not a hardened malware-analysis claim: the container shares the VM
+kernel and same-container trace/output evidence is not tamper-proof.

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.38.0
+    default: 0.39.0
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docker/dsh-install-observer.Dockerfile
+++ b/docker/dsh-install-observer.Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-bookworm-slim AS build
+
+RUN corepack enable \
+  && corepack prepare pnpm@11.3.0 --activate
+
+WORKDIR /build
+COPY package.json pnpm-lock.yaml tsconfig.json .npmrc ./
+RUN pnpm install --frozen-lockfile --ignore-scripts
+COPY src ./src
+COPY test ./test
+RUN pnpm run build
+
+FROM node:22-bookworm-slim AS runtime
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends ca-certificates git strace \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm install --global --ignore-scripts pnpm@11.3.0 \
+  && useradd --create-home --uid 10001 --shell /usr/sbin/nologin observer
+
+WORKDIR /radar
+COPY --from=build /build/dist/src ./dist/src
+COPY package.json ./package.json
+
+USER observer
+ENTRYPOINT ["node", "/radar/dist/src/cli.js", "probe", "dsh-install"]

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -58,6 +58,7 @@ npx --yes upstream-radar@latest quickstart
 | 从 GitHub Actions 立即扫描 | [一次性扫描 workflow](../examples/github-actions/upstream-scan-minimal.yml) | 输入公开仓库 URL，马上看到结果并下载 JSON，不需要本地安装。 |
 | 审查一个精确的发布物 | `upstream-radar inspect <包名>@<精确版本> --deep` | 查看单个版本的包、依赖、漏洞和 provenance 证据。 |
 | 用两个 DSH 版本检查一个插件 | [可复制的 review workflow](../examples/github-actions/dsh-plugin-review-minimal.yml) | 输入 `package@version` 和两个 DSH 版本，同时得到发布物审计与真实 bundle-load 矩阵，不需要本地 DSH profile 或 LLM。 |
+| 在隔离环境真实安装/加载插件 | [隔离安装 workflow](../.github/workflows/observe-dsh-plugin-install.yml) | 每个插件使用一台新的 GitHub 托管虚拟机和受限容器，开启安装脚本并记录进程、联网、文件写入、登记和加载结果；模型密钥不会进入执行环境。 |
 | 发布和维护 DSH 插件 | [插件作者路径](#dsh-插件作者) | 从真实 DSH 脚手架开始，先审查锁定的依赖图，再在用户安装前接入两步 CI 门禁。 |
 | 把变化通知到飞书 | [飞书与 HTTPS 通知](#飞书与-https-通知) | 原生飞书 V2 文本、只从环境读取密钥、持久确认和失败重试。 |
 
@@ -97,7 +98,7 @@ FIRST EPSS estimated exploitation probability: 97.2% (percentile 100.0%)
 想立即检查一个真实发布的 DSH 插件，可以在空目录直接运行：
 
 ```bash
-npx --yes upstream-radar@0.38.0 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.39.0 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 它会直接输出简短的准入结论、覆盖情况、依赖数量、漏洞数量和下一步，不需要先
@@ -110,7 +111,7 @@ npx --yes upstream-radar@0.38.0 inspect dsh-feishu-bot@0.15.8 --deep
 npm 解析环境中目前无法建立完整依赖图：
 
 ```bash
-npx --yes upstream-radar@0.38.0 inspect \
+npx --yes upstream-radar@0.39.0 inspect \
   @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
   --deep --fail-on never
 ```
@@ -335,9 +336,9 @@ npm：     dsh-feishu-bot@0.15.8
 会继续显示为 `incomplete`，不会被当成已经确认的故障。
 
 ```bash
-npx --yes upstream-radar@0.38.0 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.39.0 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.38.0 observe ./targets.yml \
+npx --yes upstream-radar@0.39.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -375,7 +376,7 @@ Radar 会在三层目录内自动找到它；npm 名称和源码 manifest 不一
 想明确选择锁文件时再加 `--lockfile`：
 
 ```bash
-npx --yes upstream-radar@0.38.0 observe \
+npx --yes upstream-radar@0.39.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -398,7 +399,7 @@ workspace 边保留为未解析证据；不会安装或启动 DSH。
 会额外指定 `--package`：
 
 ```bash
-npx --yes upstream-radar@0.38.0 observe \
+npx --yes upstream-radar@0.39.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -676,7 +677,7 @@ cd my-dsh-plugin
 pnpm install --ignore-scripts
 
 # 把插件放进 DSH profile 前，先读取精确依赖图。
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
 ```
 
 这棵图会保留精确的 DSH 包版本，也会把未解析的可选 peer 明确显示出来；它不会加载生成的插件，也不会运行 lifecycle script。审查后，把下面这个完整 workflow 复制到 `.github/workflows/upstream-radar.yml`：
@@ -698,7 +699,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.38.0
+      - uses: MicroMilo/upstream-radar@v0.39.0
         with:
           fail-on: high
           fail-on-compatibility: breaking
@@ -709,7 +710,7 @@ Action 会自动识别唯一的 `pnpm-lock.yaml`，检查同一棵精确依赖�
 也可以直接检查一个真实发布的 DSH 包：
 
 ```bash
-npx --yes upstream-radar@0.38.0 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.39.0 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 这次检查的结论是 `REVIEW`：registry 完整性、签名、provenance 和 89 个已解析包都
@@ -722,7 +723,7 @@ npx --yes upstream-radar@0.38.0 inspect dsh-feishu-bot@0.15.8 --deep
 如果不想分别执行 `inspect`、打包和 `probe`，可以用一个命令完成一次 DSH 插件审查：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar review dsh-plugin \
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar review dsh-plugin \
   dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
@@ -888,7 +889,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -901,7 +902,7 @@ pnpm dlx --package=upstream-radar@0.38.0 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -927,7 +928,7 @@ pnpm run showcase:dsh-probe
 如果要比较多个 DSH 版本，可以使用矩阵入口：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -945,7 +946,7 @@ JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.38.0
+  - uses: MicroMilo/upstream-radar@v0.39.0
     with:
       fail-on: high
       # 可选：把确定性的 DSH/插件兼容性破坏也作为 CI 失败条件
@@ -954,12 +955,12 @@ steps:
       threat-intel: true
 ```
 
-这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。`threat-intel` 默认是 `false`，这样普通 CI 门禁不会因为额外查询变重；设置为 `true` 后，Job Summary 和原始 JSON 会包含 CISA KEV 与 FIRST EPSS 的优先级证据。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。除了原始 JSON 日志，Action 还会把经过转义的简短摘要写入 GitHub Job Summary，定时任务失败时可以直接看到受影响的包、准确依赖路径、已经发布的修复版本（如果有）、一行优先级证据和建议的下一步。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.38.0` 的发布标签，并根据团队策略固定 checkout Action。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。`threat-intel` 默认是 `false`，这样普通 CI 门禁不会因为额外查询变重；设置为 `true` 后，Job Summary 和原始 JSON 会包含 CISA KEV 与 FIRST EPSS 的优先级证据。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。除了原始 JSON 日志，Action 还会把经过转义的简短摘要写入 GitHub Job Summary，定时任务失败时可以直接看到受影响的包、准确依赖路径、已经发布的修复版本（如果有）、一行优先级证据和建议的下一步。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.39.0` 的发布标签，并根据团队策略固定 checkout Action。
 
 如果仓库还没有提交 Radar 配置，最短接入方式是省略 `config`、`pnpm-lock` 和 `npm-lock`。checkout 之后，Action 会自动使用唯一存在的 `pnpm-lock.yaml` 或 `package-lock.json`，生成临时的审查清单，再执行同一个 frozen 检查：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.38.0
+- uses: MicroMilo/upstream-radar@v0.39.0
   with:
     fail-on: high
 ```
@@ -969,7 +970,7 @@ steps:
 如果要在插件进入 DSH 前审查精确发布物，可以增加 `inspect-package`：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.38.0
+- uses: MicroMilo/upstream-radar@v0.39.0
   with:
     inspect-package: dsh-cloudflare-browser-run@0.1.1
     # review 是安全默认值；只有允许覆盖不完整时才使用 block
@@ -981,7 +982,7 @@ steps:
 如果仓库只有 pnpm 锁文件，还没有提交 Radar 配置，可以让 Action 在同一个 job 中生成配置；可直接复制[pnpm workflow 示例](../examples/github-actions/upstream-radar-pnpm.yml)：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.38.0
+- uses: MicroMilo/upstream-radar@v0.39.0
   with:
     pnpm-lock: pnpm-lock.yaml
     fail-on: high
@@ -995,7 +996,7 @@ npm 项目可以改用 `npm-lock: package-lock.json`；`pnpm-lock` 和 `npm-lock
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -1003,7 +1004,7 @@ pnpm dlx --package=upstream-radar@0.38.0 upstream-radar radar check \
 如果还要检查一个已发布插件能否跨多个 DSH 版本加载，可以增加三个 input：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.38.0
+- uses: MicroMilo/upstream-radar@v0.39.0
   id: radar
   with:
     config: upstream-radar.config.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,6 +106,41 @@ stable interface, a wrapper is the integration point until the official DSH
 headless contract is fixed; failed conclusions remain pending instead of being
 marked complete.
 
+## Isolated install/load observation
+
+The upstream observer's static job and the dynamic execution job are separate
+trust domains. The static job watches the official `@deepseek-ai/dsh` package
+and maintained plugin coordinates. A baseline, source-only commit, or unchanged
+published coordinate does nothing. A new exact DSH publication selects the
+maintained plugin corpus; a mapped plugin publication selects only that plugin.
+
+Each selected matrix entry starts on a fresh GitHub-hosted VM. The target code
+then runs inside a restricted container that receives no repository/model
+secret, host workspace, or Docker socket. Radar first packs the exact npm
+coordinate with lifecycle scripts disabled and verifies its identity and DSH
+bundle declaration. DSH installs that local tarball with lifecycle scripts
+enabled, registers it, and loads it with `--dump-config`. Linux `strace` evidence
+and before/after filesystem snapshots are kept separately for install and load.
+
+```text
+exact DSH/plugin coordinate change
+  -> deterministic install plan
+  -> one fresh hosted VM per plugin
+  -> restricted container
+  -> exact tarball SHA-256
+  -> traced DSH install
+  -> registration check
+  -> traced DSH load
+  -> bounded JSON artifact
+```
+
+The result vocabulary separates `install-failed`, `load-failed`, `compatible`,
+and `unknown`; missing or truncated tracing never becomes a clean result. This
+backend is useful compatibility and behavior evidence, not hostile-code proof.
+Docker shares the hosted VM kernel, and code in the same container may attempt
+to tamper with its trace/output. Moving the collector outside a Firecracker
+guest is the later high-assurance boundary.
+
 ## Vulnerability cycle
 
 1. Deduplicate all installed npm `name@version` pairs.

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -210,7 +210,7 @@ When the native DSH adapter is running, it additionally verifies the exact `@dee
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -224,7 +224,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.38.0
+  - uses: MicroMilo/upstream-radar@v0.39.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -257,7 +257,7 @@ It packs without lifecycle scripts, runs one temporary DSH profile per version, 
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -271,7 +271,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -9,6 +9,7 @@ Upstream Radar protects two connected outcomes:
 3. A model conclusion is written back only when it is tied to the exact Radar delivery and DSH session, is emitted by the model, and matches the fixed JSON result contract.
 4. An optional external notification receives only changed events, with delivery failures remaining visible and retryable.
 5. Human follow-up does not silently cover a newer upstream fact; an optional deadline is visible when it expires.
+6. Explicit dynamic install/load evidence is collected only in a disposable, secret-free execution job and stays bound to the exact npm artifact and DSH release.
 
 The supporting pre-install scanner additionally protects exact-artifact evidence collection.
 
@@ -40,6 +41,7 @@ The supporting pre-install scanner additionally protects exact-artifact evidence
 12. A malicious package attacks the supporting static scanner through archives, paths, links, parsers, lifecycle scripts, or native code.
 13. A configured notification endpoint is unavailable, redirects unexpectedly, or receives more data than the operator intended.
 14. A long-running monitor grows its local state without bound, or a retry records the same transition repeatedly.
+15. Executed package code escapes its container, steals a runner credential, persists into another target, or tampers with same-container evidence.
 
 ## Trust boundaries
 
@@ -48,6 +50,7 @@ The supporting pre-install scanner additionally protects exact-artifact evidence
 - **Model analysis plane:** DSH and its tools. It may interpret project context but may not redefine the deterministic match.
 - **Operator configuration:** project locations, owners, channels, polling interval, and alternate OSV endpoint. Configuration errors fail visibly.
 - **Notification boundary:** an operator-selected HTTPS endpoint receives bounded event summaries; the endpoint is not trusted to influence Radar state or DSH analysis.
+- **Dynamic execution plane:** an explicitly selected exact tarball runs in a fresh hosted VM and restricted container with no Agent/model secret. This plane may produce evidence; it never becomes the deterministic matcher or a safety certificate.
 
 ## Security invariants
 
@@ -62,7 +65,7 @@ The supporting pre-install scanner additionally protects exact-artifact evidence
 9. Missing, malformed, or failed source/state checks cannot silently become clean.
 10. Compatibility heuristics retain their confidence class.
 11. Network bodies, graph sizes, path counts, state size, text length, and time are bounded.
-12. Target-controlled package code and lifecycle scripts are not executed during collection.
+12. Static graph, advisory, artifact, and repository collection never executes target-controlled code. The separately named `probe dsh-install` path requires explicit execution consent and an externally supplied disposable boundary.
 13. Webhook URLs must use HTTPS and are read from runtime configuration or an explicit CLI argument; only a SHA-256 fingerprint, delivered event ids, and a bounded copy of waiting event evidence are persisted. A Feishu/Lark V2 signing secret is read only from `UPSTREAM_RADAR_FEISHU_SECRET`, never from config or state.
 14. A webhook is sent only for a changed event, and a non-2xx response or notification policy hold does not mark it delivered; delivery is at-least-once across a crash window.
 15. The transition ledger is bounded and deduplicated by stable event id; losing old history never changes the active incident state.
@@ -71,6 +74,7 @@ The supporting pre-install scanner additionally protects exact-artifact evidence
 18. A project webhook target receives only events for its declared project ids; the global endpoint is the only explicit broadcast path.
 19. A project webhook route is rejected when its URL variable is missing, its URL is not HTTPS, or the same Feishu endpoint is paired with conflicting secrets.
 20. Project webhook ledgers are keyed by endpoint fingerprint and processed independently, so acknowledging one endpoint cannot acknowledge another project's event.
+21. A dynamic install job receives no repository write token, model key, host workspace, or Docker socket; each selected plugin uses a fresh hosted VM, and only bounded report files cross out of the target container.
 
 ## Delivery semantics
 
@@ -96,3 +100,4 @@ The optional webhook follows the same bias: Radar persists the changed incident 
 - The prompt establishes a read-only contract, but enforcement still depends on the DSH Agent's configured tools and permission policy.
 - Feed failures are reported by the cycle; OSV failures preserve the last confirmed matches and pending tasks, and three consecutive failures create a durable source-health alert. The local transition ledger is intentionally bounded to the most recent 1,000 events; it is an audit convenience, not a complete historical database. Provider-native Feishu V2 text formatting is supported; the generic endpoint remains the stable JSON contract, and delivery acknowledgement stays endpoint-fingerprint based. Global and project-specific webhook routes are supported, but URL variables and secrets must be present in the process environment at runtime. Notification policy is currently limited to per-project minimum vulnerability severity and quiet hours; explicit external owner routing and dev-only scopes remain future work. Follow-up deadlines are currently surfaced by the local `status`/`next` views rather than emitted as a new vulnerability event.
 - The scanner uses the host npm CLI with scripts disabled; it is not a microVM detonation boundary.
+- The dynamic observer's first backend is a restricted container inside a disposable GitHub-hosted VM. Containers share the VM kernel, and same-container `strace`/report files are best-effort rather than adversarially tamper-proof; Firecracker-grade guest/collector separation remains future work.

--- a/examples/dsh/install-observer/README.md
+++ b/examples/dsh/install-observer/README.md
@@ -1,0 +1,75 @@
+# DSH isolated install observer
+
+This directory is the maintained dynamic-test corpus for Upstream Radar. It is
+small on purpose: static checks can cover the wider plugin inventory every day;
+code execution happens only after an exact DSH or mapped plugin publication
+changes.
+
+## What runs where
+
+The reusable workflow runs each plugin in a fresh GitHub-hosted Linux VM. The
+job has a read-only repository token, declares no secrets, and never passes the
+GitHub token, DSH Agent model key, workspace, or Docker socket into the target
+container.
+
+Inside the restricted container, Radar:
+
+1. downloads one exact npm artifact with lifecycle scripts disabled;
+2. verifies the tarball's package identity and DSH bundle declaration;
+3. binds the report to the tarball SHA-256;
+4. initializes one exact DSH release with scripts disabled;
+5. installs the local tarball through DSH with lifecycle scripts enabled;
+6. verifies that DSH registered the bundle;
+7. loads the profile with `--dump-config`;
+8. records install and load process execution, network destinations, write-like
+   file syscalls, and final filesystem changes; and
+9. destroys the container and hosted VM after preserving bounded JSON.
+
+The container is read-only except for a memory-backed sandbox and one output
+directory. It runs without the host workspace, without a Docker socket, with a
+PID limit, memory/CPU limits, `no-new-privileges`, all capabilities dropped
+except the `SYS_PTRACE` capability needed by `strace`, and a hard outer timeout.
+
+## When the matrix runs
+
+[`targets.json`](targets.json) is not a popularity list. It is the set of exact
+plugins whose install/load behavior we commit to retesting.
+
+- A new exact `@deepseek-ai/dsh` package tests every enabled corpus entry.
+- A new exact package for a plugin mapped by `observerTargetId` tests only that
+  plugin, using the newly observed version.
+- A source-only commit, unchanged package coordinate, baseline, or unrelated
+  target does not execute plugin code.
+- Every selected plugin receives a separate hosted VM through the workflow
+  matrix.
+
+## Result semantics
+
+| Result | Meaning |
+| --- | --- |
+| `compatible` | The exact tarball installed, registered, and loaded under the exact DSH release, with readable bounded traces. |
+| `install-failed` | The traced install failed or DSH did not register the plugin. |
+| `load-failed` | Installation and registration passed, but the traced profile load failed. |
+| `unknown` | The artifact, DSH bootstrap, timeout/output bound, tracer, or collector could not establish a reliable result. |
+
+The report separately preserves `captured`, `truncated`, and `missing` trace
+coverage. A failed attempt is not silently converted into a compatibility
+result.
+
+## Security boundary
+
+This is useful behavior evidence, not a malware-analysis certificate. Docker
+containers share the VM kernel, network destinations are IP/socket evidence
+rather than guaranteed domain attribution, and code running in the same
+container may try to tamper with its own trace or output. The disposable outer
+VM and absence of secrets limit the consequence of that gap. A future
+Firecracker backend can move tracing outside the guest when adversarial
+tamper-resistance becomes a product requirement.
+
+The workflow follows GitHub's warning that downloaded third-party code can
+compromise a runner and therefore gives that runner no secret worth stealing:
+
+- <https://docs.github.com/en/actions/concepts/security/compromised-runners>
+- <https://docs.github.com/en/actions/concepts/runners/github-hosted-runners>
+- <https://docs.docker.com/engine/containers/run/>
+- <https://strace.io/>

--- a/examples/dsh/install-observer/targets.json
+++ b/examples/dsh/install-observer/targets.json
@@ -1,0 +1,23 @@
+{
+  "schema": "upstream-radar.dsh-install-targets/v1alpha1",
+  "plugins": [
+    {
+      "id": "feishu-bot",
+      "spec": "dsh-feishu-bot@0.16.0",
+      "observerTargetId": "dsh-feishu-bot",
+      "reason": "A real messaging plugin with a large DSH dependency surface and a reachable protobuf build step."
+    },
+    {
+      "id": "cloudflare-browser",
+      "spec": "dsh-cloudflare-browser-run@0.1.1",
+      "observerTargetId": "dsh-cloudflare-browser-run",
+      "reason": "A browser-facing plugin already used by the public static and load-only showcase."
+    },
+    {
+      "id": "wsl-workspace",
+      "spec": "dsh-wsl-workspace@0.2.3",
+      "observerTargetId": "dsh-wsl-workspace",
+      "reason": "A plugin whose native dependency makes install behavior materially different from manifest-only review."
+    }
+  ]
+}

--- a/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
+++ b/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
@@ -19,7 +19,7 @@ From a clean checkout, the finding is reproducible without installing or
 executing the plugin:
 
 ```bash
-npx --yes upstream-radar@0.38.0 scan . --json
+npx --yes upstream-radar@0.39.0 scan . --json
 ```
 
 The current static scan reports:

--- a/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
+++ b/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
@@ -43,5 +43,5 @@ graph, the unresolved peer boundary, the vulnerability result, and the two
 remaining review actions in one report.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.38.0`. Review the Draft PR before relying on the fallback
+`upstream-radar@0.39.0`. Review the Draft PR before relying on the fallback
 resolver from npm.

--- a/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
+++ b/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
@@ -21,7 +21,7 @@ Reproduce it with:
 
 ```bash
 npm pack --ignore-scripts --pack-destination /tmp dsh-feishu-bot@0.15.4
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar probe dsh-matrix \
   /tmp/dsh-feishu-bot-0.15.4.tgz \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```

--- a/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
+++ b/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
@@ -8,7 +8,7 @@ graph without installing anything.
 ## Reproduction
 
 ```bash
-npx --yes upstream-radar@0.38.0 scan \
+npx --yes upstream-radar@0.39.0 scan \
   https://github.com/2008924/dsh-progress-viz \
   --fail-on never
 ```
@@ -22,7 +22,7 @@ query an advisory service, or call an LLM.
 
 ```text
 Reading 2008924/dsh-progress-viz (plugin directory: plugin) without installing dependencies or running code...
-Upstream Radar 0.38.0
+Upstream Radar 0.39.0
 Target: dsh-progress-viz-plugin@0.1.0
 Artifact: sha256:c9b6b2dc31a458b480587f6200772fe72d4af5451b1e71d41594c5017be929c5
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
+++ b/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
@@ -13,11 +13,11 @@ No DSH profile, plugin code, lifecycle script, or LLM was started.
 ## Commands
 
 ```bash
-npx --yes upstream-radar@0.38.0 scan \
+npx --yes upstream-radar@0.39.0 scan \
   https://github.com/ccch1mneyyy/dsh-TUI \
   --fail-on never
 
-npx --yes upstream-radar@0.38.0 inspect \
+npx --yes upstream-radar@0.39.0 inspect \
   npm:@deepseek-harness-tui/dsh-tui@0.8.0 \
   --deep --fail-on never
 ```

--- a/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
+++ b/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
@@ -8,7 +8,7 @@ release.
 ## Rechecked with the public CLI
 
 Each repository was cloned at its current public `main` commit and scanned with
-`upstream-radar@0.38.0`. No package was installed, loaded, or executed.
+`upstream-radar@0.39.0`. No package was installed, loaded, or executed.
 
 | Repository | Commit | `package.json` | `package-lock.json` root | Result |
 | --- | --- | ---: | ---: | --- |

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -40,7 +40,7 @@ The optional probe is load-only. It packs with `--ignore-scripts`, uses a tempor
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.38.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.39.0 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.38.0
+      - uses: MicroMilo/upstream-radar@v0.39.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/dsh-plugin-review-minimal.yml
+++ b/examples/github-actions/dsh-plugin-review-minimal.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.38.0
+        uses: MicroMilo/upstream-radar@v0.39.0
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/examples/github-actions/upstream-observer-minimal.yml
+++ b/examples/github-actions/upstream-observer-minimal.yml
@@ -53,7 +53,7 @@ jobs:
           llm_env_file="$RUNNER_TEMP/issue-locator.env"
           trap 'rm -f "$llm_env_file"' EXIT
           observe_args=(
-            npx --yes upstream-radar@0.38.0 observe "$repository"
+            npx --yes upstream-radar@0.39.0 observe "$repository"
             --ref "$ref"
             --state observations.json
             --report "$report"

--- a/examples/github-actions/upstream-radar-npm.yml
+++ b/examples/github-actions/upstream-radar-npm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.38.0
+      - uses: MicroMilo/upstream-radar@v0.39.0
         with:
           npm-lock: package-lock.json
           fail-on: high

--- a/examples/github-actions/upstream-radar-pnpm.yml
+++ b/examples/github-actions/upstream-radar-pnpm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.38.0
+      - uses: MicroMilo/upstream-radar@v0.39.0
         with:
           pnpm-lock: pnpm-lock.yaml
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.38.0
+      - uses: MicroMilo/upstream-radar@v0.39.0
         with:
           # The Action auto-detects one pnpm-lock.yaml or package-lock.json.
           fail-on: high

--- a/examples/github-actions/upstream-scan-minimal.yml
+++ b/examples/github-actions/upstream-scan-minimal.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           report="$RUNNER_TEMP/upstream-radar-scan.json"
-          npx --yes upstream-radar@0.38.0 scan \
+          npx --yes upstream-radar@0.39.0 scan \
             "$OBSERVER_REPOSITORY_INPUT" \
             --json --fail-on never > "$report"
           if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/examples/upstream-observer/README.md
+++ b/examples/upstream-observer/README.md
@@ -24,7 +24,7 @@ Replace it with the repositories your team depends on.
 For one repository, the shortest path skips YAML and lockfile configuration entirely:
 
 ```bash
-npx --yes upstream-radar@0.38.0 observe \
+npx --yes upstream-radar@0.39.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -35,7 +35,7 @@ Radar automatically chooses the committed `pnpm-lock.yaml` or
 the explicit form below adds `--package`:
 
 ```bash
-npx --yes upstream-radar@0.38.0 observe \
+npx --yes upstream-radar@0.39.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -75,9 +75,9 @@ Build one index from saved DSH plugin scan/review/config JSON, then give it to
 the observer:
 
 ```bash
-npx --yes upstream-radar@0.38.0 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.39.0 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.38.0 observe ./targets.yml \
+npx --yes upstream-radar@0.39.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -99,7 +99,7 @@ and run `pnpm run showcase:observer` to replay a real
 The scheduled workflow uses the checked-in index directly:
 
 ```bash
-npx --yes upstream-radar@0.38.0 observe ./targets.yml \
+npx --yes upstream-radar@0.39.0 observe ./targets.yml \
   --reverse-index ../dsh/first-batch/reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -111,11 +111,11 @@ the same old → new run now reviews `dsh-feishu-bot@0.15.8`, finds its reachabl
 `protobufjs@7.6.5` install script, and keeps the DSH task pending because no
 DSH LLM is configured.
 
-The checked-in DSH target also sets `dshVersions` to `0.1.0-rc.6` and
-`0.1.0-rc.7`. On a meaningful change, the observer loads the same exact npm
+The checked-in DSH target now sets `dshVersions` to `0.1.0-rc.7` and
+`0.1.0-rc.8`. On a meaningful change, the observer loads the same exact npm
 artifact in both disposable profiles and writes the matrix into the same
-report. The live replay loaded both versions successfully (`2/2`); this is a
-bundle-load compatibility result, not a safety certificate.
+report. The linked historical replay loaded rc.6 and rc.7 successfully (`2/2`);
+that remains a bundle-load compatibility result, not a safety certificate.
 
 To replay the complete state machine without network access, run
 `pnpm run showcase:observer`. It prints a baseline alignment mismatch, one
@@ -126,7 +126,7 @@ Run it from any directory with the published CLI:
 
 ```bash
 export GITHUB_TOKEN='a read-only token with repository metadata access'
-npx --yes upstream-radar@0.38.0 observe \
+npx --yes upstream-radar@0.39.0 observe \
   /path/to/targets.yml \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md

--- a/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
+++ b/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
@@ -30,5 +30,5 @@ than silently monitoring the repository root. Local `workspace:` links remain
 explicitly unresolved; Radar does not guess their published versions.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.38.0`. Review the Draft PR before using the auto-discovery
+`upstream-radar@0.39.0`. Review the Draft PR before using the auto-discovery
 path from npm.

--- a/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
+++ b/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
@@ -10,12 +10,12 @@ The baseline was taken at the commit that produced the published `0.5.4`
 artifact, then the same state was checked against the current `master`:
 
 ```bash
-npx --yes upstream-radar@0.38.0 observe \
+npx --yes upstream-radar@0.39.0 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref aa5f4efc7827176cce27c73f73a2f42514da1ebf \
   --state observations.json --report baseline.md --json
 
-npx --yes upstream-radar@0.38.0 observe \
+npx --yes upstream-radar@0.39.0 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref master \
   --state observations.json --report repair.md --json

--- a/examples/upstream-observer/targets.yml
+++ b/examples/upstream-observer/targets.yml
@@ -1,5 +1,16 @@
 schema: upstream-radar.observer-targets/v1alpha1
 targets:
+  # The upstream runtime itself. A new exact @deepseek-ai/dsh publication is
+  # the trigger for re-running the maintained install-observation corpus.
+  - id: deepseek-harness
+    ecosystem: dsh
+    repository: deepseek-ai/deepseek-harness
+    ref: master
+    package: '@deepseek-ai/dsh'
+    packagePath: apps/cli/package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+
   # A real public DSH/Feishu plugin. Replace it with the plugin repositories
   # your team actually depends on.
   - id: dsh-feishu-bot
@@ -10,7 +21,23 @@ targets:
     packagePath: package.json
     lockfile: pnpm-lock.yaml
     lockfileType: pnpm
-    dshVersions: ["0.1.0-rc.6", "0.1.0-rc.7"]
+    dshVersions: ["0.1.0-rc.7", "0.1.0-rc.8"]
+
+  - id: dsh-cloudflare-browser-run
+    ecosystem: dsh
+    repository: RealAlexandreAI/dsh-cloudflare-browser-run
+    ref: main
+    package: dsh-cloudflare-browser-run
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+
+  - id: dsh-wsl-workspace
+    ecosystem: dsh
+    repository: 6Mikao9/dsh-wsl-workspace
+    ref: main
+    package: dsh-wsl-workspace
+    packagePath: package.json
 
   # A real maintainer-repair case. This repository has no committed lockfile;
   # the observer still watches the source manifest and the published npm release.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "upstream-radar",
-  "version": "0.38.0",
-  "description": "Always-on dependency security monitoring for DeepSeek Harness (DSH) plugins: find exact installed or candidate transitive vulnerable paths and breaking updates, then route evidence to a DSH Agent.",
+  "version": "0.39.0",
+  "description": "Always-on dependency and compatibility monitoring for DeepSeek Harness plugins, including exact paths, upstream changes, and isolated install/load evidence.",
   "type": "module",
   "license": "Apache-2.0",
   "author": "MicroMilo",

--- a/schemas/dsh-install-observation.schema.json
+++ b/schemas/dsh-install-observation.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MicroMilo/upstream-radar/blob/main/schemas/dsh-install-observation.schema.json",
+  "title": "Upstream Radar DSH install observation",
+  "description": "Bounded process, network and filesystem evidence from installing and loading one exact npm artifact under one exact DSH version in an externally supplied disposable environment.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "tool", "probe", "scope", "startedAt", "completedAt", "dshVersion", "artifact", "stages", "observations", "filesystem", "result", "reason", "boundary"],
+  "properties": {
+    "schema": { "const": "upstream-radar.dsh-install-observation/v1alpha1" },
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "const": "upstream-radar" },
+        "version": { "type": "string", "minLength": 1, "maxLength": 256 }
+      }
+    },
+    "probe": { "const": "dsh-install" },
+    "scope": { "const": "install-and-load-behavior" },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "completedAt": { "type": "string", "format": "date-time" },
+    "dshVersion": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$" },
+    "artifact": { "$ref": "#/$defs/artifact" },
+    "stages": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact", "profile", "install", "registration", "load"],
+      "properties": {
+        "artifact": { "$ref": "#/$defs/stage" },
+        "profile": { "$ref": "#/$defs/stage" },
+        "install": { "$ref": "#/$defs/stage" },
+        "registration": { "$ref": "#/$defs/stage" },
+        "load": { "$ref": "#/$defs/stage" }
+      }
+    },
+    "observations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["install", "load"],
+      "properties": {
+        "install": { "$ref": "#/$defs/trace" },
+        "load": { "$ref": "#/$defs/trace" }
+      }
+    },
+    "filesystem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["install", "load"],
+      "properties": {
+        "install": { "$ref": "#/$defs/filesystemDiff" },
+        "load": { "$ref": "#/$defs/filesystemDiff" }
+      }
+    },
+    "result": { "enum": ["compatible", "install-failed", "load-failed", "unknown"] },
+    "reason": { "type": "string", "maxLength": 4096 },
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["isolationProviderClaim", "isolationVerifiedByRadar", "disposableEnvironmentRequired", "lifecycleScriptsEnabledForPluginInstall", "pluginCodeMayExecuteDuringLoad", "inheritedHostSecrets", "note"],
+      "properties": {
+        "isolationProviderClaim": { "enum": ["github-actions-hosted-runner", "firecracker", "other"] },
+        "isolationVerifiedByRadar": { "const": false },
+        "disposableEnvironmentRequired": { "const": true },
+        "lifecycleScriptsEnabledForPluginInstall": { "const": true },
+        "pluginCodeMayExecuteDuringLoad": { "const": true },
+        "inheritedHostSecrets": { "const": false },
+        "note": { "type": "string", "maxLength": 4096 }
+      }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["spec", "name", "version", "lifecycleScripts"],
+      "properties": {
+        "spec": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "name": { "type": "string", "minLength": 1, "maxLength": 214 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "integrity": { "type": "string", "maxLength": 1024 },
+        "bytes": { "type": "integer", "minimum": 0, "maximum": 67108864 },
+        "bundlePatch": { "type": "string", "minLength": 1, "maxLength": 4096 },
+        "lifecycleScripts": {
+          "type": "array",
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": { "enum": ["preinstall", "install", "postinstall", "prepare"] }
+        }
+      }
+    },
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["passed", "failed", "skipped"] },
+        "code": { "type": ["integer", "null"] },
+        "detail": { "type": "string", "maxLength": 8192 },
+        "timedOut": { "type": "boolean" },
+        "outputExceeded": { "type": "boolean" }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "tracer", "traceFiles", "bytes", "lines", "parsedEvents", "otherLines", "tamperResistance"],
+      "properties": {
+        "status": { "enum": ["captured", "missing", "truncated"] },
+        "tracer": { "const": "strace" },
+        "traceFiles": { "type": "integer", "minimum": 0 },
+        "bytes": { "type": "integer", "minimum": 0, "maximum": 16777216 },
+        "lines": { "type": "integer", "minimum": 0, "maximum": 100000 },
+        "parsedEvents": { "type": "integer", "minimum": 0 },
+        "otherLines": { "type": "integer", "minimum": 0 },
+        "tamperResistance": { "const": "best-effort-same-container" }
+      }
+    },
+    "process": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["executable", "arguments", "succeeded", "count"],
+      "properties": {
+        "executable": { "type": "string", "maxLength": 1024 },
+        "arguments": { "type": "array", "maxItems": 16, "items": { "type": "string", "maxLength": 512 } },
+        "succeeded": { "type": "boolean" },
+        "count": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "network": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation", "family", "address", "succeeded", "count"],
+      "properties": {
+        "operation": { "enum": ["connect", "sendto", "sendmsg"] },
+        "family": { "type": "string", "maxLength": 64 },
+        "address": { "type": "string", "maxLength": 1024 },
+        "port": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "succeeded": { "type": "boolean" },
+        "count": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "fileWrite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation", "path", "succeeded", "count"],
+      "properties": {
+        "operation": { "type": "string", "maxLength": 64 },
+        "path": { "type": "string", "maxLength": 1024 },
+        "sourcePath": { "type": "string", "maxLength": 1024 },
+        "succeeded": { "type": "boolean" },
+        "count": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["coverage", "processes", "network", "fileWrites"],
+      "properties": {
+        "coverage": { "$ref": "#/$defs/coverage" },
+        "processes": { "type": "array", "maxItems": 512, "items": { "$ref": "#/$defs/process" } },
+        "network": { "type": "array", "maxItems": 512, "items": { "$ref": "#/$defs/network" } },
+        "fileWrites": { "type": "array", "maxItems": 512, "items": { "$ref": "#/$defs/fileWrite" } }
+      }
+    },
+    "filesystemDiff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["created", "modified", "deleted", "totals", "truncated", "snapshotErrors"],
+      "properties": {
+        "created": { "type": "array", "maxItems": 512, "items": { "type": "string", "maxLength": 4096 } },
+        "modified": { "type": "array", "maxItems": 512, "items": { "type": "string", "maxLength": 4096 } },
+        "deleted": { "type": "array", "maxItems": 512, "items": { "type": "string", "maxLength": 4096 } },
+        "totals": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["created", "modified", "deleted"],
+          "properties": {
+            "created": { "type": "integer", "minimum": 0 },
+            "modified": { "type": "integer", "minimum": 0 },
+            "deleted": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "truncated": { "type": "boolean" },
+        "snapshotErrors": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -193,6 +193,7 @@ async function checkPackContents() {
     'dist/src/index.js',
     'dist/src/dsh-plugin.js',
     'schemas/analysis-result.schema.json',
+    'schemas/dsh-install-observation.schema.json',
     'schemas/dsh-load-matrix.schema.json',
     'schemas/quickstart.schema.json',
     'schemas/reverse-dependency-index.schema.json',

--- a/scripts/write-dsh-install-plan.mjs
+++ b/scripts/write-dsh-install-plan.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { appendFile, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import process from 'node:process'
+import { buildDshInstallPlan } from '../dist/src/dsh-install-plan.js'
+
+const MAX_INPUT_BYTES = 256 * 1024 * 1024
+
+async function readJson(path) {
+  const contents = await readFile(resolve(path), 'utf8')
+  if (Buffer.byteLength(contents) > MAX_INPUT_BYTES) throw new Error(`${path} exceeds ${MAX_INPUT_BYTES} bytes`)
+  return JSON.parse(contents)
+}
+
+const [corpusPath, statePath, reportPath] = process.argv.slice(2)
+if (corpusPath === undefined || statePath === undefined || reportPath === undefined) {
+  throw new Error('usage: write-dsh-install-plan.mjs <targets.json> <observations.json> <observer-report.json>')
+}
+
+const plan = buildDshInstallPlan(
+  await readJson(corpusPath),
+  await readJson(statePath),
+  await readJson(reportPath),
+)
+process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`)
+
+if (process.env.GITHUB_OUTPUT !== undefined) {
+  const outputs = [
+    `run=${plan.run}`,
+    `dsh_version=${plan.dshVersion ?? ''}`,
+    `matrix=${JSON.stringify(plan.matrix)}`,
+    `triggers=${JSON.stringify(plan.triggers)}`,
+  ]
+  await appendFile(process.env.GITHUB_OUTPUT, `${outputs.join('\n')}\n`, 'utf8')
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,11 +2,16 @@
 
 import process from 'node:process'
 import { spawnSync } from 'node:child_process'
-import { access, readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import { access, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { renderCompatibilityBenchmark, runCompatibilityBenchmark } from './compatibility-benchmark.js'
 import { assessCompatibilityChange } from './compatibility.js'
 import { probeDshLoad, probeDshLoadMatrix, renderDshLoadMatrix, renderDshLoadProbe, type DshLoadMatrixReport } from './dsh-probe.js'
+import {
+  observeDshPluginInstall,
+  renderDshInstallObservation,
+  type InstallObservationIsolationProvider,
+} from './dsh-install-observation.js'
 import { renderDshPluginReview, reviewDshPlugin } from './dsh-review.js'
 import { createAnalysisTask, renderAgentAnalysisPrompt } from './dsh-analysis.js'
 import { createDshCaseReport, renderDshCase } from './dsh-case.js'
@@ -323,9 +328,16 @@ third-party bundles is selected automatically.
 Usage:
   upstream-radar probe dsh-load <package.tgz> [--dsh-version <exact-version>] [--json]
   upstream-radar probe dsh-matrix <package.tgz> --dsh-version <v1>,<v2>,... [--json]
+  upstream-radar probe dsh-install [npm:]<package>@<exact-version>
+    --dsh-version <exact-version> --isolation-provider <provider> --execute
+    [--timeout <seconds>] [--report <report.json>] [--json]
 
-The probe is bounded and isolated. It is a compatibility/load check, not a
-semantic safety review or a substitute for dependency monitoring.
+The load probes disable lifecycle scripts and check bundle registration/load.
+The dsh-install probe deliberately executes the exact plugin's lifecycle scripts
+and loads the bundle while recording Linux process, network, and file-change
+evidence. Run it only inside a disposable, secret-free Linux environment. It
+requires both --execute and UPSTREAM_RADAR_ISOLATED_RUNNER=1.
+Radar records the caller's isolation-provider claim but cannot verify it.
 `,
     review: `Upstream Radar — review one exact published DSH plugin in one command
 
@@ -521,6 +533,7 @@ Usage:
   upstream-radar profile-check [profile-directory] [--patch <path>] [--report <path>] [--summary] [--json]
   upstream-radar probe dsh-load <package.tgz> [--dsh-version <exact-version>] [--timeout <seconds>] [--keep-profile] [--json]
   upstream-radar probe dsh-matrix <package.tgz> --dsh-version <v1>[,<v2>,...] [--timeout <seconds>] [--keep-profile] [--json]
+  upstream-radar probe dsh-install [npm:]<package>@<exact-version> --dsh-version <exact-version> --isolation-provider <github-actions-hosted-runner|firecracker|other> --execute [--timeout <seconds>] [--report <report.json>] [--json]
   upstream-radar review dsh-plugin [npm:]<package>@<exact-version> --dsh-version <v1>,<v2>,... [--json]
   upstream-radar demo [--json]
   upstream-radar case dsh-web-ui [--json]
@@ -1173,6 +1186,7 @@ async function runDshCase(args: readonly string[]): Promise<number> {
 
 async function runProbe(args: readonly string[]): Promise<number> {
   const mode = args[0]
+  if (mode === 'dsh-install') return runDshInstallObservation(args.slice(1))
   if (mode !== 'dsh-load' && mode !== 'dsh-matrix') throw new Error('probe requires dsh-load or dsh-matrix')
   const packagePath = args[1]
   if (packagePath === undefined || packagePath.startsWith('-')) throw new Error(`probe ${mode} requires a package.tgz file`)
@@ -1226,6 +1240,70 @@ async function runProbe(args: readonly string[]): Promise<number> {
   })
   process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderDshLoadMatrix(report))
   return report.result === 'compatible' ? 0 : report.result === 'incompatible' ? 2 : 1
+}
+
+async function runDshInstallObservation(args: readonly string[]): Promise<number> {
+  const packageSpec = args[0]
+  if (packageSpec === undefined || packageSpec.startsWith('-')) {
+    throw new Error('probe dsh-install requires an exact npm package')
+  }
+  let dshVersion: string | undefined
+  let isolationProvider: InstallObservationIsolationProvider | undefined
+  let timeoutSeconds = 180
+  let reportPath: string | undefined
+  let execute = false
+  let json = false
+  for (let index = 1; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--execute') {
+      execute = true
+    } else if (argument === '--json') {
+      json = true
+    } else if (argument === '--dsh-version' || argument === '--isolation-provider' || argument === '--timeout' || argument === '--report') {
+      const value = args[index + 1]
+      if (value === undefined || value.startsWith('-')) throw new Error(`${argument} requires a value`)
+      if (argument === '--dsh-version') {
+        if (dshVersion !== undefined) throw new Error('probe dsh-install accepts only one --dsh-version')
+        dshVersion = value
+      } else if (argument === '--isolation-provider') {
+        if (value !== 'github-actions-hosted-runner' && value !== 'firecracker' && value !== 'other') {
+          throw new Error('--isolation-provider must be github-actions-hosted-runner, firecracker or other')
+        }
+        isolationProvider = value
+      } else if (argument === '--timeout') {
+        const parsed = Number(value)
+        if (!Number.isSafeInteger(parsed) || parsed < 30 || parsed > 600) {
+          throw new Error('--timeout must be an integer between 30 and 600 seconds')
+        }
+        timeoutSeconds = parsed
+      } else {
+        reportPath = value
+      }
+      index += 1
+    } else {
+      throw new Error(`unknown option for probe dsh-install: ${argument}`)
+    }
+  }
+  if (dshVersion === undefined) throw new Error('probe dsh-install requires one exact --dsh-version')
+  if (isolationProvider === undefined) throw new Error('probe dsh-install requires --isolation-provider')
+  if (!execute) throw new Error('probe dsh-install requires --execute because third-party code may run')
+  if (process.env.UPSTREAM_RADAR_ISOLATED_RUNNER !== '1') {
+    throw new Error('probe dsh-install requires UPSTREAM_RADAR_ISOLATED_RUNNER=1 in the disposable environment')
+  }
+  const report = await observeDshPluginInstall({
+    packageSpec,
+    dshVersion,
+    allowExecution: true,
+    isolationProvider,
+    timeoutMs: timeoutSeconds * 1_000,
+  })
+  if (reportPath !== undefined) {
+    const absoluteReportPath = resolve(reportPath)
+    await mkdir(dirname(absoluteReportPath), { recursive: true })
+    await writeFile(absoluteReportPath, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 })
+  }
+  process.stdout.write(json ? `${JSON.stringify(report, null, 2)}\n` : renderDshInstallObservation(report))
+  return report.result === 'compatible' ? 0 : report.result === 'unknown' ? 1 : 2
 }
 
 async function runDshPluginReview(args: readonly string[]): Promise<number> {

--- a/src/dsh-install-observation.ts
+++ b/src/dsh-install-observation.ts
@@ -301,7 +301,7 @@ export function parseDshInstallTrace(
       const operation = line.match(/\b(openat2?|open|creat|renameat2?|rename|unlink(?:at)?|mkdir(?:at)?|rmdir|symlink(?:at)?|link(?:at)?|truncate|ftruncate|chmod|fchmodat|chown|fchownat)\(/)?.[1]
       if (operation !== undefined) {
         const isOpen = operation === 'open' || operation === 'openat' || operation === 'openat2'
-        const writes = !isOpen || /\b(?:O_WRONLY|O_RDWR|O_CREAT|O_TRUNC|O_APPEND|RESOLVE_CACHED)\b/.test(line)
+        const writes = !isOpen || /\b(?:O_WRONLY|O_RDWR|O_CREAT|O_TRUNC|O_APPEND)\b/.test(line)
         if (writes) {
           const values = quotedValues(line, 4)
           const first = values[0]

--- a/src/dsh-install-observation.ts
+++ b/src/dsh-install-observation.ts
@@ -1,0 +1,972 @@
+import { createHash } from 'node:crypto'
+import { spawn } from 'node:child_process'
+import { constants } from 'node:fs'
+import { lstat, mkdir, mkdtemp, open, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, relative, resolve, sep } from 'node:path'
+import { parseNpmSpec } from './npm.js'
+import { parseNpmTarball } from './tar.js'
+import { TOOL_VERSION } from './version.js'
+
+export const DSH_INSTALL_OBSERVATION_SCHEMA = 'upstream-radar.dsh-install-observation/v1alpha1' as const
+
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+const DEFAULT_TIMEOUT_MS = 180_000
+const MAX_ARTIFACT_BYTES = 64 * 1024 * 1024
+const MAX_COMMAND_OUTPUT_BYTES = 64 * 1024
+const MAX_REPORT_DETAIL_BYTES = 4 * 1024
+const MAX_TRACE_BYTES = 16 * 1024 * 1024
+const MAX_TRACE_LINES = 100_000
+const MAX_TRACE_EVENTS = 512
+const MAX_SNAPSHOT_ENTRIES = 25_000
+const MAX_DIFF_PATHS = 512
+const PROFILE = 'headless'
+const LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepare'] as const
+
+export type DshInstallObservationResult = 'compatible' | 'install-failed' | 'load-failed' | 'unknown'
+export type InstallObservationPhase = 'artifact' | 'profile' | 'install' | 'load'
+export type InstallObservationIsolationProvider = 'github-actions-hosted-runner' | 'firecracker' | 'other'
+
+export interface InstallObservationCommand {
+  phase: InstallObservationPhase
+  command: string
+  args: string[]
+  cwd: string
+  env: NodeJS.ProcessEnv
+  timeoutMs: number
+  sandboxRoot: string
+  tracePath?: string
+}
+
+export interface InstallObservationCommandResult {
+  code: number | null
+  timedOut: boolean
+  outputExceeded: boolean
+  stdout: string
+  stderr: string
+  launchError?: string
+}
+
+export type InstallObservationRunner = (command: InstallObservationCommand) => Promise<InstallObservationCommandResult>
+
+export interface InstallObservationStage {
+  status: 'passed' | 'failed' | 'skipped'
+  code?: number | null
+  detail?: string
+  timedOut?: boolean
+  outputExceeded?: boolean
+}
+
+export interface InstallTraceProcess {
+  executable: string
+  arguments: string[]
+  succeeded: boolean
+  count: number
+}
+
+export interface InstallTraceNetwork {
+  operation: 'connect' | 'sendto' | 'sendmsg'
+  family: string
+  address: string
+  port?: number
+  succeeded: boolean
+  count: number
+}
+
+export interface InstallTraceFileWrite {
+  operation: string
+  path: string
+  sourcePath?: string
+  succeeded: boolean
+  count: number
+}
+
+export interface InstallTraceObservation {
+  coverage: {
+    status: 'captured' | 'missing' | 'truncated'
+    tracer: 'strace'
+    traceFiles: number
+    bytes: number
+    lines: number
+    parsedEvents: number
+    otherLines: number
+    tamperResistance: 'best-effort-same-container'
+  }
+  processes: InstallTraceProcess[]
+  network: InstallTraceNetwork[]
+  fileWrites: InstallTraceFileWrite[]
+}
+
+export interface InstallFilesystemDiff {
+  created: string[]
+  modified: string[]
+  deleted: string[]
+  totals: {
+    created: number
+    modified: number
+    deleted: number
+  }
+  truncated: boolean
+  snapshotErrors: number
+}
+
+export interface DshInstallObservationReport {
+  schema: typeof DSH_INSTALL_OBSERVATION_SCHEMA
+  tool: { name: 'upstream-radar'; version: string }
+  probe: 'dsh-install'
+  scope: 'install-and-load-behavior'
+  startedAt: string
+  completedAt: string
+  dshVersion: string
+  artifact: {
+    spec: string
+    name: string
+    version: string
+    sha256?: string
+    integrity?: string
+    bytes?: number
+    bundlePatch?: string
+    lifecycleScripts: string[]
+  }
+  stages: {
+    artifact: InstallObservationStage
+    profile: InstallObservationStage
+    install: InstallObservationStage
+    registration: InstallObservationStage
+    load: InstallObservationStage
+  }
+  observations: {
+    install: InstallTraceObservation
+    load: InstallTraceObservation
+  }
+  filesystem: {
+    install: InstallFilesystemDiff
+    load: InstallFilesystemDiff
+  }
+  result: DshInstallObservationResult
+  reason: string
+  boundary: {
+    isolationProviderClaim: InstallObservationIsolationProvider
+    isolationVerifiedByRadar: false
+    disposableEnvironmentRequired: true
+    lifecycleScriptsEnabledForPluginInstall: true
+    pluginCodeMayExecuteDuringLoad: true
+    inheritedHostSecrets: false
+    note: string
+  }
+}
+
+export interface DshInstallObservationOptions {
+  packageSpec: string
+  dshVersion: string
+  allowExecution: boolean
+  isolationProvider: InstallObservationIsolationProvider
+  timeoutMs?: number
+  hostEnvironment?: NodeJS.ProcessEnv
+  runner?: InstallObservationRunner
+}
+
+interface SnapshotEntry {
+  type: 'directory' | 'file' | 'symlink' | 'other'
+  size: number
+  mtimeMs: number
+}
+
+interface TreeSnapshot {
+  entries: Map<string, SnapshotEntry>
+  truncated: boolean
+  errors: number
+}
+
+interface ParsedArtifact {
+  path: string
+  filename: string
+  sha256: string
+  integrity?: string
+  bytes: number
+  bundlePatch: string
+  lifecycleScripts: string[]
+}
+
+function bounded(value: string, maximum = MAX_REPORT_DETAIL_BYTES): string {
+  const normalized = value.replace(/[\u0000-\u001f\u007f-\u009f]/g, character => (
+    `\\u${character.codePointAt(0)?.toString(16).padStart(4, '0') ?? '0000'}`
+  ))
+  return normalized.length <= maximum ? normalized : `${normalized.slice(0, maximum - 1)}…`
+}
+
+function decodeStraceString(value: string): string {
+  return value
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\n/g, '\\n')
+    .replace(/\\r/g, '\\r')
+    .replace(/\\t/g, '\\t')
+}
+
+function quotedValues(value: string, maximum = 32): string[] {
+  const values: string[] = []
+  const expression = /"((?:\\.|[^"\\])*)"/g
+  for (let match = expression.exec(value); match !== null && values.length < maximum; match = expression.exec(value)) {
+    values.push(bounded(decodeStraceString(match[1] ?? ''), 512))
+  }
+  return values
+}
+
+function syscallSucceeded(line: string): boolean {
+  const result = line.match(/\)\s+=\s+([^\s]+)/)?.[1]
+  return result !== undefined && !result.startsWith('-1')
+}
+
+function sandboxPath(value: string, sandboxRoot: string): string {
+  const normalizedRoot = resolve(sandboxRoot)
+  const normalizedValue = value.startsWith('/') ? resolve(value) : value
+  if (normalizedValue === normalizedRoot) return '$SANDBOX'
+  if (normalizedValue.startsWith(`${normalizedRoot}${sep}`)) {
+    return `$SANDBOX/${normalizedValue.slice(normalizedRoot.length + 1).replaceAll(sep, '/')}`
+  }
+  return bounded(value, 1_024)
+}
+
+function incrementEvent<T extends { count: number }>(events: Map<string, T>, key: string, event: T): void {
+  const existing = events.get(key)
+  if (existing !== undefined) existing.count += 1
+  else if (events.size < MAX_TRACE_EVENTS) events.set(key, event)
+}
+
+export function parseDshInstallTrace(
+  traces: readonly string[],
+  sandboxRoot: string,
+  options: { inputTruncated?: boolean } = {},
+): InstallTraceObservation {
+  if (traces.length === 0) return emptyTraceObservation()
+  const processes = new Map<string, InstallTraceProcess>()
+  const network = new Map<string, InstallTraceNetwork>()
+  const fileWrites = new Map<string, InstallTraceFileWrite>()
+  let bytes = 0
+  let lines = 0
+  let parsedEvents = 0
+  let otherLines = 0
+  let truncated = options.inputTruncated === true
+
+  outer: for (const trace of traces) {
+    bytes += Buffer.byteLength(trace)
+    for (const line of trace.split(/\r?\n/)) {
+      if (line === '') continue
+      if (lines >= MAX_TRACE_LINES) {
+        truncated = true
+        break outer
+      }
+      lines += 1
+      const succeeded = syscallSucceeded(line)
+
+      const execMatch = line.match(/\bexecve\("((?:\\.|[^"\\])*)",\s*\[(.*?)\],/)
+        ?? line.match(/\bexecveat\([^,]+,\s*"((?:\\.|[^"\\])*)",\s*\[(.*?)\],/)
+      if (execMatch !== null) {
+        const executable = sandboxPath(decodeStraceString(execMatch[1] ?? ''), sandboxRoot)
+        const argumentsList = quotedValues(execMatch[2] ?? '', 16)
+        const key = `${executable}\u0000${argumentsList.join('\u0000')}\u0000${succeeded}`
+        incrementEvent(processes, key, { executable, arguments: argumentsList, succeeded, count: 1 })
+        parsedEvents += 1
+        continue
+      }
+
+      const networkMatch = line.match(/\b(connect|sendto|sendmsg)\(/)
+      if (networkMatch !== null) {
+        const operation = networkMatch[1] as InstallTraceNetwork['operation']
+        const family = line.match(/sa_family=(AF_[A-Z0-9_]+)/)?.[1] ?? 'unknown'
+        const address = line.match(/sin_addr=inet_addr\("([^"]+)"\)/)?.[1]
+          ?? line.match(/inet_pton\(AF_INET6,\s*"([^"]+)"/)?.[1]
+          ?? line.match(/sun_path="((?:\\.|[^"\\])*)"/)?.[1]
+        if (address !== undefined) {
+          const decodedAddress = family === 'AF_UNIX'
+            ? sandboxPath(decodeStraceString(address), sandboxRoot)
+            : bounded(decodeStraceString(address), 256)
+          const portText = line.match(/sin6?_port=htons\((\d+)\)/)?.[1]
+          const port = portText === undefined ? undefined : Number(portText)
+          const key = `${operation}\u0000${family}\u0000${decodedAddress}\u0000${port ?? ''}\u0000${succeeded}`
+          incrementEvent(network, key, {
+            operation,
+            family,
+            address: decodedAddress,
+            ...(port === undefined ? {} : { port }),
+            succeeded,
+            count: 1,
+          })
+          parsedEvents += 1
+          continue
+        }
+      }
+
+      const operation = line.match(/\b(openat2?|open|creat|renameat2?|rename|unlink(?:at)?|mkdir(?:at)?|rmdir|symlink(?:at)?|link(?:at)?|truncate|ftruncate|chmod|fchmodat|chown|fchownat)\(/)?.[1]
+      if (operation !== undefined) {
+        const isOpen = operation === 'open' || operation === 'openat' || operation === 'openat2'
+        const writes = !isOpen || /\b(?:O_WRONLY|O_RDWR|O_CREAT|O_TRUNC|O_APPEND|RESOLVE_CACHED)\b/.test(line)
+        if (writes) {
+          const values = quotedValues(line, 4)
+          const first = values[0]
+          if (first !== undefined) {
+            const hasSourceAndDestination = /^(?:rename|renameat|renameat2|symlink|symlinkat|link|linkat)$/.test(operation)
+            const destination = hasSourceAndDestination && values[1] !== undefined ? values[1] : first
+            const path = sandboxPath(destination, sandboxRoot)
+            const sourcePath = hasSourceAndDestination ? sandboxPath(first, sandboxRoot) : undefined
+            const key = `${operation}\u0000${sourcePath ?? ''}\u0000${path}\u0000${succeeded}`
+            incrementEvent(fileWrites, key, {
+              operation,
+              path,
+              ...(sourcePath === undefined ? {} : { sourcePath }),
+              succeeded,
+              count: 1,
+            })
+            parsedEvents += 1
+            continue
+          }
+        }
+      }
+      otherLines += 1
+    }
+  }
+
+  if (processes.size >= MAX_TRACE_EVENTS || network.size >= MAX_TRACE_EVENTS || fileWrites.size >= MAX_TRACE_EVENTS) {
+    truncated = true
+  }
+  return {
+    coverage: {
+      status: truncated ? 'truncated' : 'captured',
+      tracer: 'strace',
+      traceFiles: traces.length,
+      bytes,
+      lines,
+      parsedEvents,
+      otherLines,
+      tamperResistance: 'best-effort-same-container',
+    },
+    processes: [...processes.values()],
+    network: [...network.values()],
+    fileWrites: [...fileWrites.values()],
+  }
+}
+
+function emptyTraceObservation(): InstallTraceObservation {
+  return {
+    coverage: {
+      status: 'missing',
+      tracer: 'strace',
+      traceFiles: 0,
+      bytes: 0,
+      lines: 0,
+      parsedEvents: 0,
+      otherLines: 0,
+      tamperResistance: 'best-effort-same-container',
+    },
+    processes: [],
+    network: [],
+    fileWrites: [],
+  }
+}
+
+function emptyFilesystemDiff(): InstallFilesystemDiff {
+  return {
+    created: [],
+    modified: [],
+    deleted: [],
+    totals: { created: 0, modified: 0, deleted: 0 },
+    truncated: false,
+    snapshotErrors: 0,
+  }
+}
+
+function controlledEnvironment(root: string, hostEnvironment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {}
+  for (const name of ['PATH', 'Path', 'SystemRoot', 'WINDIR', 'LANG', 'LC_ALL', 'SSL_CERT_FILE', 'SSL_CERT_DIR']) {
+    const value = hostEnvironment[name]
+    if (value !== undefined) environment[name] = value
+  }
+  if (environment.PATH === undefined && environment.Path === undefined) environment.PATH = '/usr/local/bin:/usr/bin:/bin'
+  environment.HOME = join(root, 'home')
+  environment.DSH_HOME = join(root, 'dsh-home')
+  environment.XDG_CACHE_HOME = join(root, 'xdg-cache')
+  environment.XDG_CONFIG_HOME = join(root, 'xdg-config')
+  environment.XDG_DATA_HOME = join(root, 'xdg-data')
+  environment.TMPDIR = join(root, 'tmp')
+  environment.NPM_CONFIG_CACHE = join(root, 'npm-cache')
+  environment.NPM_CONFIG_USERCONFIG = join(root, 'controlled.npmrc')
+  environment.NPM_CONFIG_GLOBALCONFIG = join(root, 'controlled-global.npmrc')
+  environment.NPM_CONFIG_AUDIT = 'false'
+  environment.NPM_CONFIG_FUND = 'false'
+  environment.NPM_CONFIG_UPDATE_NOTIFIER = 'false'
+  environment.PNPM_HOME = join(root, 'pnpm-home')
+  environment.COREPACK_HOME = join(root, 'corepack-home')
+  environment.COREPACK_ENABLE_DOWNLOAD_PROMPT = '0'
+  environment.GIT_CONFIG_NOSYSTEM = '1'
+  environment.GIT_CONFIG_GLOBAL = join(root, 'controlled.gitconfig')
+  environment.GIT_TERMINAL_PROMPT = '0'
+  environment.DSH_PERMISSION_MODE = 'read-only'
+  environment.DSH_TELEMETRY_MODE = 'DISABLED'
+  environment.CI = 'true'
+  environment.NO_COLOR = '1'
+  return environment
+}
+
+function scriptPolicy(environment: NodeJS.ProcessEnv, enabled: boolean): NodeJS.ProcessEnv {
+  const value = enabled ? 'false' : 'true'
+  return {
+    ...environment,
+    NPM_CONFIG_IGNORE_SCRIPTS: value,
+    npm_config_ignore_scripts: value,
+    PNPM_CONFIG_IGNORE_SCRIPTS: value,
+  }
+}
+
+function dshArgs(dshVersion: string, args: readonly string[]): string[] {
+  return ['dlx', `--package=@deepseek-ai/dsh@${dshVersion}`, 'dsh', ...args]
+}
+
+function defaultCommandRunner(input: InstallObservationCommand): Promise<InstallObservationCommandResult> {
+  return new Promise(resolveResult => {
+    const traced = input.tracePath !== undefined
+    const command = traced ? 'strace' : input.command
+    const args = traced
+      ? ['-f', '-qq', '-s', '256', '-o', input.tracePath as string, '-e', 'trace=%process,%file,%network', '--', input.command, ...input.args]
+      : input.args
+    const child = spawn(command, args, {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+      detached: true,
+    })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    let stdoutBytes = 0
+    let stderrBytes = 0
+    let outputExceeded = false
+    let timedOut = false
+    let launchError: string | undefined
+    let settled = false
+    let timer: NodeJS.Timeout | undefined
+
+    const terminate = (): void => {
+      try {
+        if (child.pid !== undefined) process.kill(-child.pid, 'SIGKILL')
+        else child.kill('SIGKILL')
+      } catch {
+        child.kill('SIGKILL')
+      }
+    }
+    const finish = (code: number | null): void => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) clearTimeout(timer)
+      resolveResult({
+        code,
+        timedOut,
+        outputExceeded,
+        stdout: Buffer.concat(stdout, stdoutBytes).toString('utf8'),
+        stderr: Buffer.concat(stderr, stderrBytes).toString('utf8'),
+        ...(launchError === undefined ? {} : { launchError }),
+      })
+    }
+    const collect = (target: Buffer[], chunk: Buffer, stream: 'stdout' | 'stderr'): void => {
+      if (stdoutBytes + stderrBytes + chunk.length > MAX_COMMAND_OUTPUT_BYTES) {
+        outputExceeded = true
+        terminate()
+        return
+      }
+      if (stream === 'stdout') stdoutBytes += chunk.length
+      else stderrBytes += chunk.length
+      target.push(chunk)
+    }
+    child.stdout.on('data', (chunk: Buffer) => collect(stdout, chunk, 'stdout'))
+    child.stderr.on('data', (chunk: Buffer) => collect(stderr, chunk, 'stderr'))
+    child.once('error', error => {
+      launchError = bounded(error.message)
+      finish(null)
+    })
+    child.once('close', code => finish(code))
+    timer = setTimeout(() => {
+      timedOut = true
+      terminate()
+    }, input.timeoutMs)
+  })
+}
+
+function commandStage(result: InstallObservationCommandResult): InstallObservationStage {
+  if (result.code === 0 && !result.timedOut && !result.outputExceeded && result.launchError === undefined) {
+    return { status: 'passed', code: result.code }
+  }
+  const output = [result.launchError, result.stderr, result.stdout].filter(value => value !== undefined && value !== '').join('\n').trim()
+  const prefix = result.timedOut
+    ? 'command timed out'
+    : result.outputExceeded
+      ? 'command exceeded the output budget'
+      : result.launchError !== undefined
+        ? 'command could not start'
+        : `command exited with ${result.code}`
+  return {
+    status: 'failed',
+    code: result.code,
+    detail: output === '' ? prefix : `${prefix}: ${bounded(output)}`,
+    ...(result.timedOut ? { timedOut: true } : {}),
+    ...(result.outputExceeded ? { outputExceeded: true } : {}),
+  }
+}
+
+async function runSafely(runner: InstallObservationRunner, input: InstallObservationCommand): Promise<InstallObservationCommandResult> {
+  try {
+    return await runner(input)
+  } catch (error: unknown) {
+    return {
+      code: null,
+      timedOut: false,
+      outputExceeded: false,
+      stdout: '',
+      stderr: '',
+      launchError: bounded(error instanceof Error ? error.message : String(error)),
+    }
+  }
+}
+
+async function readRegularFileNoFollow(path: string, maximum: number): Promise<Buffer> {
+  const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
+  try {
+    const metadata = await handle.stat()
+    if (!metadata.isFile()) throw new Error(`${basename(path)} is not a regular file`)
+    if (metadata.size > maximum) throw new Error(`${basename(path)} exceeds ${maximum} bytes`)
+    const buffer = Buffer.alloc(metadata.size)
+    let offset = 0
+    while (offset < buffer.length) {
+      const read = await handle.read(buffer, offset, buffer.length - offset, offset)
+      if (read.bytesRead === 0) break
+      offset += read.bytesRead
+    }
+    if (offset !== buffer.length) throw new Error(`${basename(path)} changed while it was being read`)
+    return buffer
+  } finally {
+    await handle.close()
+  }
+}
+
+async function parsePackedArtifact(
+  result: InstallObservationCommandResult,
+  artifactDirectory: string,
+  expectedName: string,
+  expectedVersion: string,
+): Promise<ParsedArtifact> {
+  if (commandStage(result).status !== 'passed') throw new Error(commandStage(result).detail ?? 'npm pack failed')
+  let output: unknown
+  try {
+    output = JSON.parse(result.stdout.trim()) as unknown
+  } catch {
+    throw new Error('npm pack did not return JSON')
+  }
+  if (!Array.isArray(output) || output.length !== 1 || typeof output[0] !== 'object' || output[0] === null) {
+    throw new Error('npm pack returned an unexpected result')
+  }
+  const item = output[0] as Record<string, unknown>
+  const filename = item.filename
+  if (typeof filename !== 'string' || filename === '' || filename !== basename(filename) || !filename.endsWith('.tgz')) {
+    throw new Error('npm pack returned an unsafe artifact filename')
+  }
+  const path = resolve(artifactDirectory, filename)
+  if (!path.startsWith(`${resolve(artifactDirectory)}${sep}`)) throw new Error('npm pack artifact escaped its directory')
+  const compressed = await readRegularFileNoFollow(path, MAX_ARTIFACT_BYTES)
+  const parsed = parseNpmTarball(compressed)
+  const manifestEntry = parsed.entries.find(entry => entry.path === 'package.json' && entry.type === 'file')
+  if (manifestEntry?.contents === undefined) throw new Error('packed artifact has no package.json')
+  let manifest: Record<string, unknown>
+  try {
+    const value = JSON.parse(manifestEntry.contents.toString('utf8')) as unknown
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error('not an object')
+    manifest = value as Record<string, unknown>
+  } catch {
+    throw new Error('packed artifact package.json is not valid JSON')
+  }
+  if (manifest.name !== expectedName || manifest.version !== expectedVersion) {
+    throw new Error(`packed artifact identity does not match ${expectedName}@${expectedVersion}`)
+  }
+  const dsh = typeof manifest.dsh === 'object' && manifest.dsh !== null && !Array.isArray(manifest.dsh)
+    ? manifest.dsh as Record<string, unknown>
+    : undefined
+  const bundle = typeof dsh?.bundle === 'object' && dsh.bundle !== null && !Array.isArray(dsh.bundle)
+    ? dsh.bundle as Record<string, unknown>
+    : undefined
+  const bundlePatchValue = bundle?.patch
+  if (typeof bundlePatchValue !== 'string' || bundlePatchValue === '') throw new Error('packed artifact does not declare dsh.bundle.patch')
+  const bundlePatch = bundlePatchValue.replace(/^\.\//, '')
+  if (bundlePatch.startsWith('/') || bundlePatch.includes('\\') || bundlePatch.split('/').some(part => part === '..' || part === '')) {
+    throw new Error('packed artifact declares an unsafe dsh.bundle.patch')
+  }
+  if (!parsed.entries.some(entry => entry.path === bundlePatch && entry.type === 'file')) {
+    throw new Error(`packed artifact is missing ${bundlePatch}`)
+  }
+  const scripts = typeof manifest.scripts === 'object' && manifest.scripts !== null && !Array.isArray(manifest.scripts)
+    ? manifest.scripts as Record<string, unknown>
+    : {}
+  const lifecycleScripts = LIFECYCLE_SCRIPTS.filter(name => typeof scripts[name] === 'string')
+  const integrity = typeof item.integrity === 'string' ? bounded(item.integrity, 1_024) : undefined
+  return {
+    path,
+    filename,
+    sha256: createHash('sha256').update(compressed).digest('hex'),
+    ...(integrity === undefined ? {} : { integrity }),
+    bytes: compressed.length,
+    bundlePatch,
+    lifecycleScripts,
+  }
+}
+
+async function snapshotTree(root: string): Promise<TreeSnapshot> {
+  const snapshot: TreeSnapshot = { entries: new Map(), truncated: false, errors: 0 }
+  const queue = [root]
+  while (queue.length > 0) {
+    if (snapshot.entries.size >= MAX_SNAPSHOT_ENTRIES) {
+      snapshot.truncated = true
+      break
+    }
+    const current = queue.shift()
+    if (current === undefined) break
+    let metadata
+    try {
+      metadata = await lstat(current)
+    } catch {
+      snapshot.errors += 1
+      continue
+    }
+    const path = relative(root, current).replaceAll(sep, '/') || '.'
+    const type: SnapshotEntry['type'] = metadata.isDirectory()
+      ? 'directory'
+      : metadata.isFile()
+        ? 'file'
+        : metadata.isSymbolicLink()
+          ? 'symlink'
+          : 'other'
+    snapshot.entries.set(path, { type, size: metadata.size, mtimeMs: metadata.mtimeMs })
+    if (type !== 'directory') continue
+    try {
+      const children = await readdir(current, { withFileTypes: true })
+      children.sort((left, right) => left.name.localeCompare(right.name))
+      for (const child of children) queue.push(join(current, child.name))
+    } catch {
+      snapshot.errors += 1
+    }
+  }
+  return snapshot
+}
+
+async function snapshotSandbox(sandboxRoot: string, environment: NodeJS.ProcessEnv): Promise<TreeSnapshot> {
+  const combined: TreeSnapshot = { entries: new Map(), truncated: false, errors: 0 }
+  for (const path of [environment.DSH_HOME, environment.HOME]) {
+    if (path === undefined) continue
+    const snapshot = await snapshotTree(path)
+    combined.truncated ||= snapshot.truncated
+    combined.errors += snapshot.errors
+    const prefix = relative(sandboxRoot, path).replaceAll(sep, '/')
+    for (const [entryPath, entry] of snapshot.entries) {
+      if (combined.entries.size >= MAX_SNAPSHOT_ENTRIES) {
+        combined.truncated = true
+        break
+      }
+      combined.entries.set(`$SANDBOX/${prefix}${entryPath === '.' ? '' : `/${entryPath}`}`, entry)
+    }
+  }
+  return combined
+}
+
+function snapshotSignature(entry: SnapshotEntry): string {
+  return `${entry.type}\u0000${entry.size}\u0000${entry.type === 'directory' ? '' : entry.mtimeMs}`
+}
+
+function diffSnapshots(before: TreeSnapshot, after: TreeSnapshot): InstallFilesystemDiff {
+  const createdAll: string[] = []
+  const modifiedAll: string[] = []
+  const deletedAll: string[] = []
+  for (const [path, entry] of after.entries) {
+    const previous = before.entries.get(path)
+    if (previous === undefined) createdAll.push(path)
+    else if (snapshotSignature(previous) !== snapshotSignature(entry)) modifiedAll.push(path)
+  }
+  for (const path of before.entries.keys()) {
+    if (!after.entries.has(path)) deletedAll.push(path)
+  }
+  createdAll.sort()
+  modifiedAll.sort()
+  deletedAll.sort()
+  return {
+    created: createdAll.slice(0, MAX_DIFF_PATHS),
+    modified: modifiedAll.slice(0, MAX_DIFF_PATHS),
+    deleted: deletedAll.slice(0, MAX_DIFF_PATHS),
+    totals: { created: createdAll.length, modified: modifiedAll.length, deleted: deletedAll.length },
+    truncated: before.truncated || after.truncated
+      || createdAll.length > MAX_DIFF_PATHS || modifiedAll.length > MAX_DIFF_PATHS || deletedAll.length > MAX_DIFF_PATHS,
+    snapshotErrors: before.errors + after.errors,
+  }
+}
+
+async function readTrace(path: string, sandboxRoot: string): Promise<InstallTraceObservation> {
+  try {
+    const metadata = await lstat(path)
+    if (!metadata.isFile()) return emptyTraceObservation()
+    const truncated = metadata.size > MAX_TRACE_BYTES
+    const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
+    try {
+      const length = Math.min(metadata.size, MAX_TRACE_BYTES)
+      const buffer = Buffer.alloc(length)
+      let offset = 0
+      while (offset < length) {
+        const read = await handle.read(buffer, offset, length - offset, offset)
+        if (read.bytesRead === 0) break
+        offset += read.bytesRead
+      }
+      return parseDshInstallTrace([buffer.subarray(0, offset).toString('utf8')], sandboxRoot, { inputTruncated: truncated })
+    } finally {
+      await handle.close()
+    }
+  } catch {
+    return emptyTraceObservation()
+  }
+}
+
+async function registeredBundle(dshHome: string, packageName: string): Promise<boolean> {
+  try {
+    const contents = await readRegularFileNoFollow(join(dshHome, 'profiles', PROFILE, 'package.json'), 4 * 1024 * 1024)
+    const manifest = JSON.parse(contents.toString('utf8')) as Record<string, unknown>
+    const dsh = typeof manifest.dsh === 'object' && manifest.dsh !== null && !Array.isArray(manifest.dsh)
+      ? manifest.dsh as Record<string, unknown>
+      : undefined
+    const profile = typeof dsh?.profile === 'object' && dsh.profile !== null && !Array.isArray(dsh.profile)
+      ? dsh.profile as Record<string, unknown>
+      : undefined
+    return Array.isArray(profile?.bundles) && profile.bundles.includes(packageName)
+  } catch {
+    return false
+  }
+}
+
+function finishReport(report: DshInstallObservationReport, result: DshInstallObservationResult, reason: string): DshInstallObservationReport {
+  report.completedAt = new Date().toISOString()
+  report.result = result
+  report.reason = reason
+  return report
+}
+
+export async function observeDshPluginInstall(options: DshInstallObservationOptions): Promise<DshInstallObservationReport> {
+  const spec = parseNpmSpec(options.packageSpec)
+  if (!EXACT_VERSION.test(options.dshVersion)) throw new Error('DSH version must be an exact semantic version')
+  if (!options.allowExecution) throw new Error('DSH install observation requires explicit execution consent')
+  if (!['github-actions-hosted-runner', 'firecracker', 'other'].includes(options.isolationProvider)) {
+    throw new Error('unsupported isolation provider')
+  }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 30_000 || timeoutMs > 600_000) {
+    throw new Error('DSH install observation timeout must be between 30000 and 600000 milliseconds')
+  }
+  if (options.runner === undefined) {
+    if (process.platform !== 'linux') throw new Error('DSH install observation requires Linux strace')
+    const declaration = options.hostEnvironment?.UPSTREAM_RADAR_ISOLATED_RUNNER ?? process.env.UPSTREAM_RADAR_ISOLATED_RUNNER
+    if (declaration !== '1') throw new Error('DSH install observation requires UPSTREAM_RADAR_ISOLATED_RUNNER=1')
+  }
+
+  const startedAt = new Date().toISOString()
+  const report: DshInstallObservationReport = {
+    schema: DSH_INSTALL_OBSERVATION_SCHEMA,
+    tool: { name: 'upstream-radar', version: TOOL_VERSION },
+    probe: 'dsh-install',
+    scope: 'install-and-load-behavior',
+    startedAt,
+    completedAt: startedAt,
+    dshVersion: options.dshVersion,
+    artifact: {
+      spec: spec.canonical,
+      name: spec.name,
+      version: spec.version,
+      lifecycleScripts: [],
+    },
+    stages: {
+      artifact: { status: 'skipped' },
+      profile: { status: 'skipped' },
+      install: { status: 'skipped' },
+      registration: { status: 'skipped' },
+      load: { status: 'skipped' },
+    },
+    observations: { install: emptyTraceObservation(), load: emptyTraceObservation() },
+    filesystem: { install: emptyFilesystemDiff(), load: emptyFilesystemDiff() },
+    result: 'unknown',
+    reason: 'observation did not complete',
+    boundary: {
+      isolationProviderClaim: options.isolationProvider,
+      isolationVerifiedByRadar: false,
+      disposableEnvironmentRequired: true,
+      lifecycleScriptsEnabledForPluginInstall: true,
+      pluginCodeMayExecuteDuringLoad: true,
+      inheritedHostSecrets: false,
+      note: 'Radar scrubs the child environment and records Linux system-call evidence, but the caller provides and must verify the disposable isolation boundary. Same-container traces are best-effort evidence, not a malicious-code safety certificate.',
+    },
+  }
+
+  const sandboxRoot = await mkdtemp(join(tmpdir(), 'upstream-radar-dsh-install-'))
+  const artifactDirectory = join(sandboxRoot, 'artifact')
+  const traceDirectory = join(sandboxRoot, 'trace')
+  const hostEnvironment = options.hostEnvironment ?? process.env
+  const environment = controlledEnvironment(sandboxRoot, hostEnvironment)
+  const noScriptsEnvironment = scriptPolicy(environment, false)
+  const scriptsEnvironment = scriptPolicy(environment, true)
+  const runner = options.runner ?? defaultCommandRunner
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+
+  try {
+    await Promise.all([
+      mkdir(artifactDirectory, { recursive: true, mode: 0o700 }),
+      mkdir(traceDirectory, { recursive: true, mode: 0o700 }),
+      mkdir(environment.HOME as string, { recursive: true, mode: 0o700 }),
+      mkdir(environment.DSH_HOME as string, { recursive: true, mode: 0o700 }),
+      mkdir(environment.TMPDIR as string, { recursive: true, mode: 0o700 }),
+    ])
+    await Promise.all([
+      writeFile(join(sandboxRoot, 'controlled.npmrc'), 'registry=https://registry.npmjs.org/\naudit=false\nfund=false\nupdate-notifier=false\n', { mode: 0o600 }),
+      writeFile(join(sandboxRoot, 'controlled-global.npmrc'), '', { mode: 0o600 }),
+      writeFile(join(sandboxRoot, 'controlled.gitconfig'), '', { mode: 0o600 }),
+    ])
+
+    const artifactResult = await runSafely(runner, {
+      phase: 'artifact',
+      command: npmCommand,
+      args: ['pack', `${spec.name}@${spec.version}`, '--ignore-scripts', '--json', '--pack-destination', '.'],
+      cwd: artifactDirectory,
+      env: noScriptsEnvironment,
+      timeoutMs,
+      sandboxRoot,
+    })
+    let artifact: ParsedArtifact
+    try {
+      artifact = await parsePackedArtifact(artifactResult, artifactDirectory, spec.name, spec.version)
+    } catch (error: unknown) {
+      report.stages.artifact = {
+        ...commandStage(artifactResult),
+        status: 'failed',
+        detail: bounded(error instanceof Error ? error.message : String(error)),
+      }
+      return finishReport(report, 'unknown', 'the exact npm artifact could not be established before execution')
+    }
+    report.artifact = {
+      ...report.artifact,
+      sha256: artifact.sha256,
+      ...(artifact.integrity === undefined ? {} : { integrity: artifact.integrity }),
+      bytes: artifact.bytes,
+      bundlePatch: artifact.bundlePatch,
+      lifecycleScripts: artifact.lifecycleScripts,
+    }
+    report.stages.artifact = { status: 'passed', code: artifactResult.code }
+
+    try {
+      const profileResult = await runSafely(runner, {
+        phase: 'profile',
+        command: pnpmCommand,
+        args: dshArgs(options.dshVersion, ['--profile', PROFILE, '--help']),
+        cwd: artifactDirectory,
+        env: noScriptsEnvironment,
+        timeoutMs,
+        sandboxRoot,
+      })
+      report.stages.profile = commandStage(profileResult)
+      if (report.stages.profile.status !== 'passed') {
+        return finishReport(report, 'unknown', 'the exact DSH runtime could not initialize the disposable profile')
+      }
+
+      const beforeInstall = await snapshotSandbox(sandboxRoot, environment)
+      const installTracePath = join(traceDirectory, 'install.strace')
+      const installResult = await runSafely(runner, {
+        phase: 'install',
+        command: pnpmCommand,
+        args: dshArgs(options.dshVersion, ['plugin', '--profile', PROFILE, 'add', artifact.filename]),
+        cwd: artifactDirectory,
+        env: scriptsEnvironment,
+        timeoutMs,
+        sandboxRoot,
+        tracePath: installTracePath,
+      })
+      const afterInstall = await snapshotSandbox(sandboxRoot, environment)
+      report.observations.install = await readTrace(installTracePath, sandboxRoot)
+      report.filesystem.install = diffSnapshots(beforeInstall, afterInstall)
+      report.stages.install = commandStage(installResult)
+      if (installResult.timedOut || installResult.outputExceeded || installResult.launchError !== undefined) {
+        return finishReport(report, 'unknown', 'the plugin install did not produce a bounded command result')
+      }
+      if (report.observations.install.coverage.status === 'missing') {
+        report.stages.install = {
+          ...report.stages.install,
+          status: 'failed',
+          detail: 'install trace evidence is missing',
+        }
+        return finishReport(report, 'unknown', 'the install command ran without readable trace evidence')
+      }
+      if (installResult.code !== 0) {
+        return finishReport(report, 'install-failed', 'the traced DSH plugin install command failed')
+      }
+
+      const registered = await registeredBundle(environment.DSH_HOME as string, spec.name)
+      report.stages.registration = registered
+        ? { status: 'passed' }
+        : { status: 'failed', detail: `the DSH profile did not register ${spec.name}` }
+      if (!registered) return finishReport(report, 'install-failed', 'DSH accepted the install command but did not register the plugin bundle')
+
+      const loadTracePath = join(traceDirectory, 'load.strace')
+      const loadResult = await runSafely(runner, {
+        phase: 'load',
+        command: pnpmCommand,
+        args: dshArgs(options.dshVersion, ['--profile', PROFILE, '--dump-config']),
+        cwd: artifactDirectory,
+        env: scriptsEnvironment,
+        timeoutMs,
+        sandboxRoot,
+        tracePath: loadTracePath,
+      })
+      const afterLoad = await snapshotSandbox(sandboxRoot, environment)
+      report.observations.load = await readTrace(loadTracePath, sandboxRoot)
+      report.filesystem.load = diffSnapshots(afterInstall, afterLoad)
+      report.stages.load = commandStage(loadResult)
+      if (loadResult.timedOut || loadResult.outputExceeded || loadResult.launchError !== undefined) {
+        return finishReport(report, 'unknown', 'the plugin load did not produce a bounded command result')
+      }
+      if (report.observations.load.coverage.status === 'missing') {
+        report.stages.load = { ...report.stages.load, status: 'failed', detail: 'load trace evidence is missing' }
+        return finishReport(report, 'unknown', 'the load command ran without readable trace evidence')
+      }
+      if (loadResult.code !== 0) return finishReport(report, 'load-failed', 'the traced DSH profile load command failed')
+      return finishReport(report, 'compatible', 'the exact artifact installed, registered and loaded under the requested DSH version')
+    } catch (error: unknown) {
+      const detail = bounded(error instanceof Error ? error.message : String(error))
+      const currentStage = (['profile', 'install', 'registration', 'load'] as const)
+        .find(name => report.stages[name].status === 'skipped')
+      if (currentStage !== undefined) report.stages[currentStage] = { status: 'failed', detail }
+      return finishReport(report, 'unknown', `the bounded observer failed while collecting ${currentStage ?? 'runtime'} evidence`)
+    }
+  } finally {
+    await rm(sandboxRoot, { recursive: true, force: true, maxRetries: 2 }).catch(() => undefined)
+  }
+}
+
+export function renderDshInstallObservation(report: DshInstallObservationReport): string {
+  const install = report.observations.install
+  const load = report.observations.load
+  const lifecycle = report.artifact.lifecycleScripts.length === 0 ? 'none' : report.artifact.lifecycleScripts.join(', ')
+  const lines = [
+    'DSH isolated install observation',
+    `Artifact: ${report.artifact.name}@${report.artifact.version}${report.artifact.sha256 === undefined ? '' : ` (sha256:${report.artifact.sha256.slice(0, 12)}…)`}`,
+    `DSH: ${report.dshVersion}`,
+    `Isolation claim: ${report.boundary.isolationProviderClaim} (provided externally; not verified by Radar)`,
+    '',
+    `Result: ${report.result.toUpperCase()} — ${report.reason}`,
+    `Lifecycle scripts declared: ${lifecycle}`,
+    `Install evidence: ${install.processes.length} process, ${install.network.length} network, ${install.fileWrites.length} file-write event(s); trace ${install.coverage.status}`,
+    `Load evidence: ${load.processes.length} process, ${load.network.length} network, ${load.fileWrites.length} file-write event(s); trace ${load.coverage.status}`,
+    `Final filesystem delta: install +${report.filesystem.install.totals.created} ~${report.filesystem.install.totals.modified} -${report.filesystem.install.totals.deleted}; load +${report.filesystem.load.totals.created} ~${report.filesystem.load.totals.modified} -${report.filesystem.load.totals.deleted}`,
+    '',
+  ]
+  for (const [name, stage] of Object.entries(report.stages)) {
+    lines.push(`  ${name}: ${stage.status}${stage.detail === undefined ? '' : ` (${stage.detail})`}`)
+  }
+  lines.push('', report.boundary.note)
+  return `${lines.join('\n')}\n`
+}

--- a/src/dsh-install-plan.ts
+++ b/src/dsh-install-plan.ts
@@ -1,0 +1,175 @@
+import { parseNpmSpec } from './npm.js'
+
+export const DSH_INSTALL_TARGETS_SCHEMA = 'upstream-radar.dsh-install-targets/v1alpha1' as const
+
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+const DSH_TARGET_ID = 'deepseek-harness'
+const DSH_PACKAGE = '@deepseek-ai/dsh'
+const MAX_TARGETS = 50
+
+export interface DshInstallTarget {
+  id: string
+  spec: string
+  reason: string
+  observerTargetId?: string
+}
+
+export interface DshInstallTargets {
+  schema: typeof DSH_INSTALL_TARGETS_SCHEMA
+  plugins: DshInstallTarget[]
+}
+
+export interface DshInstallPlan {
+  run: boolean
+  dshVersion?: string
+  matrix: {
+    include: Array<{ id: string; plugin: string }>
+  }
+  triggers: string[]
+  reason: string
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${label} must be an object`)
+  return value as Record<string, unknown>
+}
+
+function boundedString(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== 'string' || value.trim() === '' || value.length > maximum) {
+    throw new Error(`${label} must be a non-empty string no longer than ${maximum} characters`)
+  }
+  return value
+}
+
+export function parseDshInstallTargets(input: unknown): DshInstallTargets {
+  const root = record(input, 'DSH install targets')
+  if (root.schema !== DSH_INSTALL_TARGETS_SCHEMA) throw new Error(`DSH install targets schema must be ${DSH_INSTALL_TARGETS_SCHEMA}`)
+  if (!Array.isArray(root.plugins) || root.plugins.length === 0 || root.plugins.length > MAX_TARGETS) {
+    throw new Error(`DSH install targets must contain between 1 and ${MAX_TARGETS} plugins`)
+  }
+  const ids = new Set<string>()
+  const observerIds = new Set<string>()
+  const plugins = root.plugins.map((value, index): DshInstallTarget => {
+    const item = record(value, `plugins[${index}]`)
+    const id = boundedString(item.id, `plugins[${index}].id`, 64)
+    if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(id)) throw new Error(`plugins[${index}].id must be a short lowercase label`)
+    if (ids.has(id)) throw new Error(`duplicate DSH install target id: ${id}`)
+    ids.add(id)
+    const parsedSpec = parseNpmSpec(boundedString(item.spec, `plugins[${index}].spec`, 512))
+    const spec = `${parsedSpec.name}@${parsedSpec.version}`
+    const reason = boundedString(item.reason, `plugins[${index}].reason`, 2_048)
+    const observerTargetId = item.observerTargetId === undefined
+      ? undefined
+      : boundedString(item.observerTargetId, `plugins[${index}].observerTargetId`, 128)
+    if (observerTargetId !== undefined) {
+      if (observerIds.has(observerTargetId)) throw new Error(`duplicate observerTargetId in DSH install targets: ${observerTargetId}`)
+      observerIds.add(observerTargetId)
+    }
+    return { id, spec, reason, ...(observerTargetId === undefined ? {} : { observerTargetId }) }
+  })
+  plugins.sort((left, right) => left.id.localeCompare(right.id))
+  return { schema: DSH_INSTALL_TARGETS_SCHEMA, plugins }
+}
+
+interface PackageCoordinate {
+  name: string
+  version: string
+  integrity?: string
+}
+
+function packageCoordinate(value: unknown): PackageCoordinate | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+  const item = value as Record<string, unknown>
+  if (typeof item.name !== 'string' || typeof item.version !== 'string' || !EXACT_VERSION.test(item.version)) return undefined
+  return {
+    name: item.name,
+    version: item.version,
+    ...(typeof item.integrity === 'string' ? { integrity: item.integrity } : {}),
+  }
+}
+
+function snapshotPackage(value: unknown): PackageCoordinate | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+  return packageCoordinate((value as Record<string, unknown>).package)
+}
+
+function coordinateChanged(before: PackageCoordinate | undefined, after: PackageCoordinate | undefined): boolean {
+  return after !== undefined && (
+    before === undefined
+    || before.name !== after.name
+    || before.version !== after.version
+    || before.integrity !== after.integrity
+  )
+}
+
+function observedDshVersion(stateInput: unknown): string | undefined {
+  if (typeof stateInput !== 'object' || stateInput === null || Array.isArray(stateInput)) return undefined
+  const targets = (stateInput as Record<string, unknown>).targets
+  if (typeof targets !== 'object' || targets === null || Array.isArray(targets)) return undefined
+  const target = (targets as Record<string, unknown>)[DSH_TARGET_ID]
+  const coordinate = snapshotPackage(target)
+  return coordinate?.name === DSH_PACKAGE ? coordinate.version : undefined
+}
+
+export function buildDshInstallPlan(corpusInput: unknown, stateInput: unknown, reportInput: unknown): DshInstallPlan {
+  const corpus = parseDshInstallTargets(corpusInput)
+  const report = record(reportInput, 'observer report')
+  if (!Array.isArray(report.changes)) throw new Error('observer report changes must be an array')
+  const changes = report.changes
+    .map((value, index) => ({ value: record(value, `changes[${index}]`), index }))
+    .filter(({ value }) => value.meaningful === true && typeof value.targetId === 'string')
+
+  const dshChange = changes.find(({ value }) => value.targetId === DSH_TARGET_ID)
+  const dshBefore = dshChange === undefined ? undefined : snapshotPackage(dshChange.value.previous)
+  const dshAfter = dshChange === undefined ? undefined : snapshotPackage(dshChange.value.current)
+  const dshPackageChanged = dshAfter?.name === DSH_PACKAGE && coordinateChanged(dshBefore, dshAfter)
+  const dshVersion = dshPackageChanged ? dshAfter.version : observedDshVersion(stateInput)
+  const selected = new Map<string, { id: string; plugin: string }>()
+  const triggers = new Set<string>()
+
+  if (dshPackageChanged) {
+    triggers.add(DSH_TARGET_ID)
+    for (const target of corpus.plugins) selected.set(target.id, { id: target.id, plugin: target.spec })
+  }
+
+  for (const target of corpus.plugins) {
+    if (target.observerTargetId === undefined) continue
+    const change = changes.find(({ value }) => value.targetId === target.observerTargetId)
+    if (change === undefined) continue
+    const before = snapshotPackage(change.value.previous)
+    const after = snapshotPackage(change.value.current)
+    if (!coordinateChanged(before, after) || after === undefined) continue
+    const expected = parseNpmSpec(target.spec)
+    if (after.name !== expected.name) continue
+    triggers.add(target.observerTargetId)
+    selected.set(target.id, { id: target.id, plugin: `${after.name}@${after.version}` })
+  }
+
+  const include = [...selected.values()].sort((left, right) => left.id.localeCompare(right.id))
+  if (include.length === 0) {
+    return {
+      run: false,
+      ...(dshVersion === undefined ? {} : { dshVersion }),
+      matrix: { include: [] },
+      triggers: [],
+      reason: 'no maintained install target changed its exact published coordinate',
+    }
+  }
+  if (dshVersion === undefined) {
+    return {
+      run: false,
+      matrix: { include: [] },
+      triggers: [...triggers].sort(),
+      reason: 'a maintained plugin changed, but no exact observed DSH release is available',
+    }
+  }
+  return {
+    run: true,
+    dshVersion,
+    matrix: { include },
+    triggers: [...triggers].sort(),
+    reason: dshPackageChanged
+      ? `the official DSH package changed to ${DSH_PACKAGE}@${dshVersion}`
+      : 'a maintained plugin changed its exact published coordinate',
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,34 @@ export {
   type DshProbeStage,
 } from './dsh-probe.js'
 export {
+  DSH_INSTALL_OBSERVATION_SCHEMA,
+  observeDshPluginInstall,
+  parseDshInstallTrace,
+  renderDshInstallObservation,
+  type DshInstallObservationOptions,
+  type DshInstallObservationReport,
+  type DshInstallObservationResult,
+  type InstallFilesystemDiff,
+  type InstallObservationCommand,
+  type InstallObservationCommandResult,
+  type InstallObservationIsolationProvider,
+  type InstallObservationPhase,
+  type InstallObservationRunner,
+  type InstallObservationStage,
+  type InstallTraceFileWrite,
+  type InstallTraceNetwork,
+  type InstallTraceObservation,
+  type InstallTraceProcess,
+} from './dsh-install-observation.js'
+export {
+  DSH_INSTALL_TARGETS_SCHEMA,
+  buildDshInstallPlan,
+  parseDshInstallTargets,
+  type DshInstallPlan,
+  type DshInstallTarget,
+  type DshInstallTargets,
+} from './dsh-install-plan.js'
+export {
   DSH_PLUGIN_REVIEW_SCHEMA,
   renderDshPluginReview,
   reviewDshPlugin,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.38.0'
+export const TOOL_VERSION = '0.39.0'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -46,6 +46,7 @@ describe('CLI option parsing', () => {
     assert.match(help.stdout, /--no-dsh-patch\s+setup: keep the legacy UPSTREAM_RADAR_\* environment-variable wiring/)
     assert.match(help.stdout, /probe dsh-load <package\.tgz>/)
     assert.match(help.stdout, /probe dsh-matrix <package\.tgz>/)
+    assert.match(help.stdout, /probe dsh-install \[npm:\]<package>@<exact-version>/)
     assert.match(help.stdout, /review dsh-plugin .*--dsh-version/)
     assert.match(help.stdout, /demo \[--json\]/)
     assert.match(help.stdout, /case dsh-web-ui \[--json\]/)
@@ -118,6 +119,14 @@ describe('CLI option parsing', () => {
     const incompleteProbeMatrix = spawnSync(process.execPath, [cli, 'probe', 'dsh-matrix', 'missing.tgz', '--dsh-version', '0.1.0-rc.6'], { encoding: 'utf8' })
     assert.equal(incompleteProbeMatrix.status, 1)
     assert.match(incompleteProbeMatrix.stderr, /at least two exact DSH versions/)
+
+    const installWithoutConsent = spawnSync(process.execPath, [cli, 'probe', 'dsh-install', 'demo-plugin@1.0.0', '--dsh-version', '0.1.0-rc.8', '--isolation-provider', 'other'], { encoding: 'utf8' })
+    assert.equal(installWithoutConsent.status, 1)
+    assert.match(installWithoutConsent.stderr, /requires --execute/)
+
+    const installWithoutIsolation = spawnSync(process.execPath, [cli, 'probe', 'dsh-install', 'demo-plugin@1.0.0', '--dsh-version', '0.1.0-rc.8', '--isolation-provider', 'other', '--execute'], { encoding: 'utf8' })
+    assert.equal(installWithoutIsolation.status, 1)
+    assert.match(installWithoutIsolation.stderr, /UPSTREAM_RADAR_ISOLATED_RUNNER=1/)
 
     const incompleteReview = spawnSync(process.execPath, [cli, 'review', 'dsh-plugin', 'demo-plugin@1.0.0'], { encoding: 'utf8' })
     assert.equal(incompleteReview.status, 1)
@@ -225,6 +234,11 @@ describe('CLI option parsing', () => {
     assert.match(observeHelp.stdout, /--reverse-index <index\.json>/)
     assert.match(observeHelp.stdout, /issue-locator\/\.env-style file/)
     assert.match(observeHelp.stdout, /MODEL\/CODEX_MODEL/)
+
+    const probeHelp = spawnSync(process.execPath, [cli, 'probe', '--help'], { encoding: 'utf8' })
+    assert.equal(probeHelp.status, 0)
+    assert.match(probeHelp.stdout, /executes the exact plugin's lifecycle scripts/)
+    assert.match(probeHelp.stdout, /disposable, secret-free Linux environment/)
 
     const statusHelp = spawnSync(process.execPath, [cli, 'radar', 'status', '--help'], { encoding: 'utf8' })
     assert.equal(statusHelp.status, 0)

--- a/test/dsh-install-observation.test.ts
+++ b/test/dsh-install-observation.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import {
+  observeDshPluginInstall,
+  parseDshInstallTrace,
+  renderDshInstallObservation,
+  type InstallObservationCommand,
+  type InstallObservationCommandResult,
+} from '../src/dsh-install-observation.js'
+import { makeTarball } from './helpers/tar.js'
+
+const TRACE = `420 execve("/usr/bin/node", ["node", "scripts/postinstall.js"], 0x7ffe) = 0
+420 connect(18, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("203.0.113.10")}, 16) = 0
+420 openat(AT_FDCWD, "/sandbox/dsh-home/profiles/headless/install.log", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 18
+420 mkdir("/sandbox/dsh-home/profiles/headless/generated", 0777) = 0
+420 unlink("/sandbox/dsh-home/profiles/headless/temporary", 0) = -1 ENOENT (No such file or directory)
+`
+
+function passed(overrides: Partial<InstallObservationCommandResult> = {}): InstallObservationCommandResult {
+  return {
+    code: 0,
+    timedOut: false,
+    outputExceeded: false,
+    stdout: '',
+    stderr: '',
+    ...overrides,
+  }
+}
+
+describe('DSH install observation', () => {
+  it('turns bounded strace evidence into process, network and file-write events', () => {
+    const observation = parseDshInstallTrace([TRACE], '/sandbox')
+
+    assert.equal(observation.coverage.status, 'captured')
+    assert.equal(observation.processes[0]?.executable, '/usr/bin/node')
+    assert.deepEqual(observation.processes[0]?.arguments, ['node', 'scripts/postinstall.js'])
+    assert.equal(observation.network[0]?.address, '203.0.113.10')
+    assert.equal(observation.network[0]?.port, 443)
+    assert.equal(observation.fileWrites[0]?.path, '$SANDBOX/dsh-home/profiles/headless/install.log')
+    assert.equal(observation.fileWrites[0]?.operation, 'openat')
+    assert.equal(observation.fileWrites.some(event => event.operation === 'unlink' && event.succeeded === false), true)
+  })
+
+  it('refuses execution unless the caller explicitly accepts third-party code', async () => {
+    let calls = 0
+    await assert.rejects(
+      observeDshPluginInstall({
+        packageSpec: 'example-plugin@1.0.0',
+        dshVersion: '0.1.0-rc.8',
+        allowExecution: false,
+        isolationProvider: 'github-actions-hosted-runner',
+        runner: async () => {
+          calls += 1
+          return passed()
+        },
+      }),
+      /explicit execution consent/,
+    )
+    assert.equal(calls, 0)
+  })
+
+  it('observes one exact artifact through DSH install and load without inheriting host secrets', async () => {
+    const calls: InstallObservationCommand[] = []
+    const runner = async (command: InstallObservationCommand): Promise<InstallObservationCommandResult> => {
+      calls.push(command)
+      assert.equal(command.env.GITHUB_TOKEN, undefined)
+      assert.equal(command.env.ISSUE_LOCATOR_LLM_API_KEY, undefined)
+
+      if (command.phase === 'artifact') {
+        const artifactPath = join(command.cwd, 'example-plugin-1.0.0.tgz')
+        await writeFile(artifactPath, makeTarball([
+          { path: 'package/package.json', contents: JSON.stringify({
+            name: 'example-plugin',
+            version: '1.0.0',
+            scripts: { postinstall: 'node scripts/postinstall.js' },
+            dsh: { bundle: { patch: './cordis.patch.yml' } },
+          }) },
+          { path: 'package/cordis.patch.yml', contents: '[]\n' },
+        ]))
+        return passed({ stdout: JSON.stringify([{ filename: 'example-plugin-1.0.0.tgz', integrity: 'sha512-demo' }]) })
+      }
+
+      if (command.phase === 'install') {
+        assert.equal(command.env.NPM_CONFIG_IGNORE_SCRIPTS, 'false')
+        assert.equal(command.args.includes('example-plugin-1.0.0.tgz'), true)
+        const dshHome = command.env.DSH_HOME
+        assert.equal(typeof dshHome, 'string')
+        const profileDirectory = join(dshHome as string, 'profiles', 'headless')
+        await mkdir(join(profileDirectory, 'generated'), { recursive: true })
+        await writeFile(join(profileDirectory, 'generated', 'install.txt'), 'created during install\n')
+        await writeFile(join(profileDirectory, 'package.json'), JSON.stringify({
+          dsh: { profile: { bundles: ['example-plugin'] } },
+        }))
+      }
+
+      if (command.tracePath !== undefined) {
+        await writeFile(command.tracePath, TRACE.replaceAll('/sandbox', command.sandboxRoot))
+      }
+      return passed()
+    }
+
+    const report = await observeDshPluginInstall({
+      packageSpec: 'example-plugin@1.0.0',
+      dshVersion: '0.1.0-rc.8',
+      allowExecution: true,
+      isolationProvider: 'github-actions-hosted-runner',
+      hostEnvironment: {
+        PATH: '/usr/bin:/bin',
+        GITHUB_TOKEN: 'must-not-cross-boundary',
+        ISSUE_LOCATOR_LLM_API_KEY: 'must-not-cross-boundary',
+      },
+      runner,
+    })
+
+    assert.equal(report.result, 'compatible')
+    assert.equal(report.artifact.name, 'example-plugin')
+    assert.equal(report.artifact.version, '1.0.0')
+    assert.match(report.artifact.sha256 ?? '', /^[0-9a-f]{64}$/)
+    assert.deepEqual(report.artifact.lifecycleScripts, ['postinstall'])
+    assert.equal(report.stages.registration.status, 'passed')
+    assert.equal(report.observations.install.processes.length, 1)
+    assert.equal(report.observations.install.fileWrites.length >= 1, true)
+    assert.equal(report.filesystem.install.created.some(path => path.endsWith('/generated/install.txt')), true)
+    assert.equal(calls.map(call => call.phase).join(','), 'artifact,profile,install,load')
+    assert.match(renderDshInstallObservation(report), /COMPATIBLE/)
+    assert.match(renderDshInstallObservation(report), /Lifecycle scripts declared: postinstall/)
+  })
+
+  it('keeps an observed install failure distinct from missing trace evidence', async () => {
+    const artifact = makeTarball([
+      { path: 'package/package.json', contents: JSON.stringify({
+        name: 'broken-plugin',
+        version: '1.2.3',
+        dsh: { bundle: { patch: 'cordis.patch.yml' } },
+      }) },
+      { path: 'package/cordis.patch.yml', contents: '[]\n' },
+    ])
+    const runner = async (command: InstallObservationCommand): Promise<InstallObservationCommandResult> => {
+      if (command.phase === 'artifact') {
+        await writeFile(join(command.cwd, 'broken-plugin-1.2.3.tgz'), artifact)
+        return passed({ stdout: JSON.stringify([{ filename: 'broken-plugin-1.2.3.tgz' }]) })
+      }
+      if (command.phase === 'install') {
+        if (command.tracePath !== undefined) await writeFile(command.tracePath, TRACE)
+        return passed({ code: 1, stderr: 'dependency build failed' })
+      }
+      return passed()
+    }
+
+    const report = await observeDshPluginInstall({
+      packageSpec: 'broken-plugin@1.2.3',
+      dshVersion: '0.1.0-rc.8',
+      allowExecution: true,
+      isolationProvider: 'other',
+      runner,
+    })
+
+    assert.equal(report.result, 'install-failed')
+    assert.equal(report.stages.install.status, 'failed')
+    assert.match(report.reason, /install command failed/)
+  })
+})

--- a/test/dsh-install-observation.test.ts
+++ b/test/dsh-install-observation.test.ts
@@ -14,6 +14,7 @@ import { makeTarball } from './helpers/tar.js'
 const TRACE = `420 execve("/usr/bin/node", ["node", "scripts/postinstall.js"], 0x7ffe) = 0
 420 connect(18, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("203.0.113.10")}, 16) = 0
 420 openat(AT_FDCWD, "/sandbox/dsh-home/profiles/headless/install.log", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 18
+420 openat2(AT_FDCWD, "/sandbox/dsh-home/profiles/headless/read-only.json", {flags=O_RDONLY, resolve=RESOLVE_CACHED}, 24) = 19
 420 mkdir("/sandbox/dsh-home/profiles/headless/generated", 0777) = 0
 420 unlink("/sandbox/dsh-home/profiles/headless/temporary", 0) = -1 ENOENT (No such file or directory)
 `
@@ -40,6 +41,7 @@ describe('DSH install observation', () => {
     assert.equal(observation.network[0]?.port, 443)
     assert.equal(observation.fileWrites[0]?.path, '$SANDBOX/dsh-home/profiles/headless/install.log')
     assert.equal(observation.fileWrites[0]?.operation, 'openat')
+    assert.equal(observation.fileWrites.some(event => event.path.endsWith('/read-only.json')), false)
     assert.equal(observation.fileWrites.some(event => event.operation === 'unlink' && event.succeeded === false), true)
   })
 

--- a/test/dsh-install-plan.test.ts
+++ b/test/dsh-install-plan.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { buildDshInstallPlan, parseDshInstallTargets } from '../src/dsh-install-plan.js'
+
+const corpus = {
+  schema: 'upstream-radar.dsh-install-targets/v1alpha1',
+  plugins: [
+    { id: 'feishu', spec: 'dsh-feishu-bot@0.16.0', observerTargetId: 'dsh-feishu-bot', reason: 'messaging plugin' },
+    { id: 'browser', spec: 'dsh-browser@1.2.3', reason: 'browser plugin' },
+  ],
+}
+
+function state(dshVersion = '0.1.0-rc.8'): unknown {
+  return {
+    targets: {
+      'deepseek-harness': { package: { name: '@deepseek-ai/dsh', version: dshVersion } },
+    },
+  }
+}
+
+describe('DSH install observation plan', () => {
+  it('tests the whole maintained corpus when the official DSH coordinate changes', () => {
+    const plan = buildDshInstallPlan(corpus, state(), {
+      changes: [{
+        targetId: 'deepseek-harness',
+        meaningful: true,
+        previous: { package: { name: '@deepseek-ai/dsh', version: '0.1.0-rc.8' } },
+        current: { package: { name: '@deepseek-ai/dsh', version: '0.1.0-rc.9' } },
+      }],
+    })
+
+    assert.equal(plan.run, true)
+    assert.equal(plan.dshVersion, '0.1.0-rc.9')
+    assert.deepEqual(plan.matrix.include.map(item => item.plugin), ['dsh-browser@1.2.3', 'dsh-feishu-bot@0.16.0'])
+    assert.deepEqual(plan.triggers, ['deepseek-harness'])
+  })
+
+  it('tests only the changed mapped plugin against the last observed DSH release', () => {
+    const plan = buildDshInstallPlan(corpus, state(), {
+      changes: [{
+        targetId: 'dsh-feishu-bot',
+        meaningful: true,
+        previous: { package: { name: 'dsh-feishu-bot', version: '0.16.0' } },
+        current: { package: { name: 'dsh-feishu-bot', version: '0.17.0' } },
+      }],
+    })
+
+    assert.equal(plan.run, true)
+    assert.equal(plan.dshVersion, '0.1.0-rc.8')
+    assert.deepEqual(plan.matrix.include, [{ id: 'feishu', plugin: 'dsh-feishu-bot@0.17.0' }])
+    assert.deepEqual(plan.triggers, ['dsh-feishu-bot'])
+  })
+
+  it('stays quiet when no meaningful DSH or maintained-plugin coordinate changed', () => {
+    const plan = buildDshInstallPlan(corpus, state(), { changes: [] })
+    assert.equal(plan.run, false)
+    assert.equal(plan.dshVersion, '0.1.0-rc.8')
+    assert.deepEqual(plan.matrix.include, [])
+    assert.match(plan.reason, /no maintained install target changed/)
+  })
+
+  it('refuses ranges and duplicate ids in the maintained corpus', () => {
+    assert.throws(() => parseDshInstallTargets({
+      schema: 'upstream-radar.dsh-install-targets/v1alpha1',
+      plugins: [
+        { id: 'duplicate', spec: 'one@^1.0.0', reason: 'bad range' },
+        { id: 'duplicate', spec: 'two@1.0.0', reason: 'duplicate id' },
+      ],
+    }), /exact|duplicate/)
+  })
+})

--- a/test/release-preflight.test.ts
+++ b/test/release-preflight.test.ts
@@ -23,7 +23,7 @@ describe('release preflight', () => {
       checks: Array<{ status: string }>
     }
     assert.equal(report.schema, 'upstream-radar.release-preflight/v1alpha1')
-    assert.equal(report.version, '0.38.0')
+    assert.equal(report.version, '0.39.0')
     assert.equal(report.passed, true)
     assert.equal(report.publishedCheck, false)
     assert.ok(report.checks.length >= 4)


### PR DESCRIPTION
## Summary

- add an explicit `probe dsh-install` command that binds one exact npm tarball to one exact DSH release
- record bounded install/load process, network, file-write, registration, and filesystem evidence
- run each target in a fresh GitHub-hosted VM plus restricted container with no Agent/model secret
- watch the official DSH package and a maintained three-plugin matrix, executing only after exact published coordinates change
- prepare the `0.39.0` release and document the Docker/Firecracker trust boundary

## Security boundary

Static graph and artifact collection still never executes target code. The new lane requires `--execute` plus `UPSTREAM_RADAR_ISOLATED_RUNNER=1`. Its workflow passes no repository write token, model key, host workspace, or Docker socket into the target container. Same-container traces remain best-effort and are not presented as a malware safety certificate.

## Verification

- `pnpm test` — 291 tests passed
- `actionlint v1.7.12` — all workflows passed
- `git diff --check` — passed
- release preflight and packed CLI smoke — passed