### PR TITLE
fix: install the exact local DSH artifact

### DIFF
--- a/docker/dsh-install-observer.Dockerfile
+++ b/docker/dsh-install-observer.Dockerfile
@@ -14,10 +14,11 @@ RUN pnpm run build
 
 FROM node:22-bookworm-slim AS runtime
 
+# DSH rc.7 and rc.8 declare pnpm@11.7.0 in the official source tree.
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends ca-certificates git strace \
   && rm -rf /var/lib/apt/lists/* \
-  && npm install --global --ignore-scripts pnpm@11.3.0 \
+  && npm install --global --ignore-scripts pnpm@11.7.0 \
   && useradd --create-home --uid 10001 --shell /usr/sbin/nologin observer
 
 WORKDIR /radar

--- a/src/dsh-install-observation.ts
+++ b/src/dsh-install-observation.ts
@@ -879,7 +879,7 @@ export async function observeDshPluginInstall(options: DshInstallObservationOpti
       const installResult = await runSafely(runner, {
         phase: 'install',
         command: pnpmCommand,
-        args: dshArgs(options.dshVersion, ['plugin', '--profile', PROFILE, 'add', artifact.filename]),
+        args: dshArgs(options.dshVersion, ['plugin', '--profile', PROFILE, 'add', join(artifactDirectory, artifact.filename)]),
         cwd: artifactDirectory,
         env: scriptsEnvironment,
         timeoutMs,

--- a/test/dsh-install-observation.test.ts
+++ b/test/dsh-install-observation.test.ts
@@ -86,7 +86,7 @@ describe('DSH install observation', () => {
 
       if (command.phase === 'install') {
         assert.equal(command.env.NPM_CONFIG_IGNORE_SCRIPTS, 'false')
-        assert.equal(command.args.includes('example-plugin-1.0.0.tgz'), true)
+        assert.equal(command.args.at(-1), join(command.cwd, 'example-plugin-1.0.0.tgz'))
         const dshHome = command.env.DSH_HOME
         assert.equal(typeof dshHome, 'string')
         const profileDirectory = join(dshHome as string, 'profiles', 'headless')


### PR DESCRIPTION
The first three isolated rc.8 observations all exposed the same observer defect: Radar downloaded an exact npm tarball, then passed only its filename to DSH. Because DSH runs pnpm from the profile directory, pnpm treated that filename as a registry package and returned 404.

This change passes the absolute path of the authenticated tarball and adds a regression assertion for the install command.

Validation:
- pnpm test (291/291)
- red/green focused install-observation test
- affected evidence runs: #32461508167, #32461511157, #32461530349

After CI, the same three exact artifacts will be rerun in disposable hosted runners before any compatibility claim or npm release.