### PR TITLE
fix: follow the active DSH release channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Upstream Radar are documented here.
 - Add a secret-free reusable GitHub Actions workflow using a fresh hosted VM and restricted container for each plugin, with bounded JSON evidence and honest trace-coverage states.
 - Record the exact Node/pnpm runtime and explicit dependency-build allowlist, preserve the report before failing a non-compatible check, and install the authenticated local tarball rather than resolving its filename from the registry.
 - Observe the official `@deepseek-ai/dsh` coordinate and fan out a maintained three-plugin matrix only when DSH or a mapped plugin's exact published coordinate changes, using each mapped plugin's latest observed exact package.
+- Follow DSH's explicit npm `next` channel, persist the selected dist-tag, and keep no-change observation state byte-stable so persistent source/publish drift cannot wake the Agent or create timestamp-only cron commits.
 - Add the dynamic result schema, tested plan builder, public execution-boundary documentation, and a Firecracker migration boundary for future adversarial tamper resistance.
 
 ## [0.38.0] - 2026-08-21

--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ to run unless both `--execute` and `UPSTREAM_RADAR_ISOLATED_RUNNER=1` are presen
 it is not intended as a normal laptop command.
 
 This lane is wired into the always-on observer. Radar now watches the official
-`@deepseek-ai/dsh` coordinate. A new exact DSH publication fans out the small
+`@deepseek-ai/dsh` `next` release channel (current DSH releases are prereleases
+rather than npm `latest`). A new exact DSH publication fans out the small
 [maintained plugin corpus](examples/dsh/install-observer/targets.json), one fresh
 VM per plugin. A mapped plugin publication retests only that plugin. Unchanged
-commits stay quiet, and the DSH Agent/API key never enters the execution job.
+evidence keeps `observations.json` byte-stable, persistent source/publish drift
+does not wake the Agent again, and the DSH Agent/API key never enters the execution job.
 Build-script approvals are exact package names stored in the maintained target
 and copied into every report; an absent list approves nothing.
 

--- a/examples/upstream-observer/README.md
+++ b/examples/upstream-observer/README.md
@@ -150,6 +150,15 @@ scheduled workflow also uses
 `--retry-pending`, so a task left behind by a temporarily unavailable Agent is
 retried on the next run without needing a new upstream commit.
 
+Targets observe npm's `latest` dist-tag by default. Set `package-tag: next` (or
+another explicit lowercase dist-tag) when the upstream publishes the channel
+you maintain outside `latest`. The checked-in DSH runtime target uses `next` so
+`0.1.1-rc.1` is not silently replaced by the older `latest` value
+`0.1.0-rc.7`. The selected tag is persisted with the exact package coordinate.
+If all evidence is unchanged, the durable snapshot keeps its prior timestamp;
+the run report still has a fresh check time, but cron does not create a noise
+commit or re-report an unchanged drift condition.
+
 At the time this example was recorded, the target resolved to 242 dependency
 nodes and 380 edges. Radar also reported that the source manifest is named
 `dsh-lark-bot` while the published package is `dsh-feishu-bot`; it keeps that

--- a/examples/upstream-observer/targets.yml
+++ b/examples/upstream-observer/targets.yml
@@ -7,6 +7,7 @@ targets:
     repository: deepseek-ai/deepseek-harness
     ref: master
     package: '@deepseek-ai/dsh'
+    package-tag: next
     packagePath: apps/cli/package.json
     lockfile: pnpm-lock.yaml
     lockfileType: pnpm

--- a/src/upstream-observer.ts
+++ b/src/upstream-observer.ts
@@ -43,6 +43,7 @@ const OBSERVER_RETRY_DELAY_MS = 150
 const EXACT_NPM_PACKAGE_NAME = /^(?:@[^/\s]+\/[^/\s]+|[^/@\s]+)$/
 const EXACT_DSH_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 const SAFE_TARGET_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
+const SAFE_NPM_DIST_TAG = /^[a-z][a-z0-9._-]{0,127}$/
 
 type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>
 
@@ -57,6 +58,8 @@ export interface ObserverTarget {
   ref?: string
   /** npm package name. When omitted, the source package.json name is used. */
   packageName?: string
+  /** npm dist-tag to observe. Defaults to latest. */
+  packageTag?: string
   packagePath?: string
   lockfile?: string
   lockfileType?: ObserverLockfileType
@@ -72,6 +75,7 @@ export interface ObserverConfig {
 export interface ObserverPackageObservation {
   name: string
   version: string
+  distTag?: string
   integrity?: string
   tarball?: string
   repository?: string
@@ -477,6 +481,7 @@ function yamlMapping(line: YamlLine): { key: string; value: unknown } | undefine
 
 function normalizeTargetKey(key: string): string {
   if (key === 'package') return 'packageName'
+  if (key === 'package-tag') return 'packageTag'
   if (key === 'package-path') return 'packagePath'
   if (key === 'lockfile-type') return 'lockfileType'
   if (key === 'dsh-versions') return 'dshVersions'
@@ -588,6 +593,10 @@ function target(value: unknown, index: number): ObserverTarget {
   if (packageName !== undefined && !EXACT_NPM_PACKAGE_NAME.test(packageName)) {
     throw new Error(`targets[${index}].package must be an npm package name`)
   }
+  const packageTag = optionalBoundedString(source.packageTag, `targets[${index}].packageTag`, 128)
+  if (packageTag !== undefined && !SAFE_NPM_DIST_TAG.test(packageTag)) {
+    throw new Error(`targets[${index}].packageTag must be a lowercase npm dist-tag`)
+  }
   const lockfile = source.lockfile === undefined ? undefined : validateRelativePath(source.lockfile, `targets[${index}].lockfile`)
   const rawLockfileType = optionalBoundedString(source.lockfileType, `targets[${index}].lockfileType`, 16)
   const lockfileType = rawLockfileType === undefined
@@ -612,6 +621,7 @@ function target(value: unknown, index: number): ObserverTarget {
     repository: validateRepository(source.repository, `targets[${index}].repository`),
     ref,
     ...(packageName === undefined ? {} : { packageName }),
+    ...(packageTag === undefined ? {} : { packageTag }),
     ...(packagePath === undefined ? {} : { packagePath }),
     ...(lockfile === undefined ? {} : { lockfile }),
     ...(lockfileType === undefined ? {} : { lockfileType }),
@@ -662,9 +672,12 @@ function parsePackageObservation(value: unknown, label: string): ObserverPackage
   if (source === undefined) throw new Error(`${label} must be an object`)
   const name = boundedString(source.name, `${label}.name`, 512)
   const version = boundedString(source.version, `${label}.version`, 512)
+  const distTag = optionalBoundedString(source.distTag, `${label}.distTag`, 128)
+  if (distTag !== undefined && !SAFE_NPM_DIST_TAG.test(distTag)) throw new Error(`${label}.distTag is invalid`)
   return {
     name,
     version,
+    ...(distTag === undefined ? {} : { distTag }),
     ...(optionalBoundedString(source.integrity, `${label}.integrity`, 512) === undefined ? {} : { integrity: source.integrity as string }),
     ...(optionalBoundedString(source.tarball, `${label}.tarball`, 4_096) === undefined ? {} : { tarball: source.tarball as string }),
     ...(optionalBoundedString(source.repository, `${label}.repository`, 4_096) === undefined ? {} : { repository: source.repository as string }),
@@ -1078,7 +1091,7 @@ export class UpstreamObserverClient implements ObserverSource {
     return undefined
   }
 
-  private async fetchNpmObservation(name: string): Promise<ObserverPackageObservation | undefined> {
+  private async fetchNpmObservation(name: string, distTag = 'latest'): Promise<ObserverPackageObservation | undefined> {
     const url = new URL(encodeURIComponent(name), this.registry)
     const response = await this.fetchWithRetry(url, {
       headers: { accept: 'application/vnd.npm.install-v1+json, application/json', 'user-agent': 'upstream-radar/upstream-observer' },
@@ -1089,21 +1102,22 @@ export class UpstreamObserverClient implements ObserverSource {
     const tags = asRecord(root?.['dist-tags'])
     const versions = asRecord(root?.versions)
     const times = asRecord(root?.time)
-    const latest = typeof tags?.latest === 'string' ? tags.latest : undefined
-    const rawManifest = latest === undefined ? undefined : versions?.[latest]
+    const selectedVersion = typeof tags?.[distTag] === 'string' ? tags[distTag] as string : undefined
+    const rawManifest = selectedVersion === undefined ? undefined : versions?.[selectedVersion]
     const manifest = asRecord(rawManifest)
-    if (latest === undefined || manifest === undefined) throw new Error(`npm registry has no latest manifest for ${name}`)
+    if (selectedVersion === undefined || manifest === undefined) throw new Error(`npm registry has no ${distTag} manifest for ${name}`)
     const dist = asRecord(manifest.dist)
     const repository = typeof manifest.repository === 'string'
       ? manifest.repository
       : typeof asRecord(manifest.repository)?.url === 'string' ? asRecord(manifest.repository)?.url as string : undefined
     return {
       name,
-      version: latest,
+      version: selectedVersion,
+      distTag,
       ...(typeof dist?.integrity === 'string' ? { integrity: dist.integrity } : {}),
       ...(typeof dist?.tarball === 'string' ? { tarball: dist.tarball } : {}),
       ...(repository === undefined ? {} : { repository: repository.slice(0, 4_096) }),
-      ...(typeof times?.[latest] === 'string' ? { publishedAt: times[latest] as string } : {}),
+      ...(typeof times?.[selectedVersion] === 'string' ? { publishedAt: times[selectedVersion] as string } : {}),
     }
   }
 
@@ -1127,7 +1141,7 @@ export class UpstreamObserverClient implements ObserverSource {
     if (targetValue.packageName !== undefined && targetValue.packageName !== manifest.name) {
       warnings.push(`target package ${targetValue.packageName} does not match source manifest ${manifest.name}`)
     }
-    const packageObservation = await this.fetchNpmObservation(packageName)
+    const packageObservation = await this.fetchNpmObservation(packageName, targetValue.packageTag)
     if (packageObservation === undefined) warnings.push(`${packageName} was not found on the configured npm registry`)
     let graph: DependencyGraph | undefined
     let graphError: string | undefined
@@ -1309,6 +1323,11 @@ function summary(snapshot: ObserverSnapshot): ObserverSnapshotSummary {
   }
 }
 
+function snapshotEvidenceSignature(snapshot: ObserverSnapshot): string {
+  const { observedAt: _observedAt, ...evidence } = snapshot
+  return JSON.stringify(evidence)
+}
+
 function alignmentSignature(value: UpstreamDownstreamIR | undefined): string {
   if (value === undefined) return ''
   return JSON.stringify({
@@ -1417,6 +1436,11 @@ function packageChanged(before: ObserverSnapshot, after: ObserverSnapshot): bool
   return before.package?.integrity !== after.package?.integrity
 }
 
+function sourcePublishedVersionDrift(snapshot: ObserverSnapshot): string | undefined {
+  if (snapshot.package === undefined || snapshot.manifest.version === snapshot.package.version) return undefined
+  return `${snapshot.manifest.name}@${snapshot.manifest.version}|${snapshot.package.name}@${snapshot.package.version}`
+}
+
 function graphChanged(before: ObserverSnapshot, after: ObserverSnapshot): boolean {
   if (before.graphError !== after.graphError) return true
   if (before.graph === undefined || after.graph === undefined) return before.graph !== after.graph
@@ -1440,7 +1464,9 @@ function meaningfulChange(sourceChange: ObserverSourceChange, before: ObserverSn
   if (before.manifest.name !== after.manifest.name || before.manifest.version !== after.manifest.version) {
     reasons.push(`source manifest identity changed: ${before.manifest.name}@${before.manifest.version} → ${after.manifest.name}@${after.manifest.version}`)
   }
-  if (after.package !== undefined && after.manifest.version !== after.package.version) {
+  const beforeDrift = sourcePublishedVersionDrift(before)
+  const afterDrift = sourcePublishedVersionDrift(after)
+  if (afterDrift !== undefined && beforeDrift !== afterDrift && after.package !== undefined) {
     reasons.push(`source/published version drift: source ${after.manifest.name}@${after.manifest.version}, npm ${after.package.name}@${after.package.version}`)
   }
   // Legacy observation files predate the IR. Populate the new field on the
@@ -1876,12 +1902,18 @@ export async function runObserver(
     try {
       const current = await source.observe(configuredTarget, checkedAt)
       const before = previousState.targets[configuredTarget.id]
-      nextTargets[configuredTarget.id] = current
       if (before === undefined) {
+        nextTargets[configuredTarget.id] = current
         baselineTargets.push(configuredTarget.id)
         if (current.alignment !== undefined) alignmentFindings.push({ targetId: configuredTarget.id, alignment: structuredClone(current.alignment) })
         continue
       }
+      // checkedAt belongs in the run report. Keep the durable observation point
+      // byte-stable when its evidence did not change, so a no-op cron run does
+      // not manufacture a commit from a fresh timestamp alone.
+      nextTargets[configuredTarget.id] = snapshotEvidenceSignature(before) === snapshotEvidenceSignature(current)
+        ? before
+        : current
       if (before.alignment === undefined && current.alignment !== undefined) {
         // Upgrade legacy state into the IR and show its first finding once.
         // This is evidence for the author, not a fake upstream change and not
@@ -2002,7 +2034,9 @@ export function observerExitCode(report: ObserverReport): 0 | 1 {
 }
 
 function displayPackage(value: ObserverPackageObservation | undefined): string {
-  return value === undefined ? 'not observed' : `${value.name}@${value.version}`
+  return value === undefined
+    ? 'not observed'
+    : `${value.name}@${value.version}${value.distTag === undefined ? '' : ` via npm tag ${value.distTag}`}`
 }
 
 function displayGraph(value: ObserverSnapshotSummary['graph'] | undefined): string {

--- a/test/upstream-observer.test.ts
+++ b/test/upstream-observer.test.ts
@@ -252,13 +252,53 @@ targets:
     repository: acme/dsh-demo
     ref: main
     package: dsh-demo
+    package-tag: next
     package-path: plugin/package.json
     lockfile: plugin/pnpm-lock.yaml
     lockfile-type: pnpm
     dsh-versions: ["0.1.0-rc.6", "0.1.0-rc.7"]
 `)
     assert.equal(config.schema, OBSERVER_TARGETS_SCHEMA)
-    assert.deepEqual(config.targets[0], { ...target, dshVersions: ['0.1.0-rc.6', '0.1.0-rc.7'] })
+    assert.deepEqual(config.targets[0], { ...target, packageTag: 'next', dshVersions: ['0.1.0-rc.6', '0.1.0-rc.7'] })
+  })
+
+  it('observes the configured npm release channel instead of assuming latest', async () => {
+    const source = new UpstreamObserverClient({
+      fetch: async input => {
+        const url = String(input)
+        if (url.includes('/commits/main')) return new Response(JSON.stringify({ sha: 'commit-1' }), { status: 200 })
+        if (url.endsWith('/commit-1/plugin/package.json')) {
+          return new Response(JSON.stringify({ name: 'dsh-demo', version: '2.0.0-rc.1' }), { status: 200 })
+        }
+        if (url.startsWith('https://registry.npmjs.org/')) {
+          return new Response(JSON.stringify({
+            'dist-tags': { latest: '1.0.0', next: '2.0.0-rc.1' },
+            versions: {
+              '1.0.0': { dist: { integrity: 'sha512-latest' } },
+              '2.0.0-rc.1': { dist: { integrity: 'sha512-next' } },
+            },
+          }), { status: 200 })
+        }
+        if (url.endsWith('/commit-1/plugin/pnpm-lock.yaml')) {
+          return new Response([
+            "lockfileVersion: '9.0'",
+            '',
+            'importers:',
+            '  plugin: {}',
+            '',
+            'packages: {}',
+            '',
+            'snapshots: {}',
+            '',
+          ].join('\n'), { status: 200 })
+        }
+        throw new Error(`unexpected request: ${url}`)
+      },
+    })
+    const result = await source.observe({ ...target, packageTag: 'next' }, '2026-08-21T00:00:00.000Z')
+    assert.equal(result.package?.version, '2.0.0-rc.1')
+    assert.equal(result.package?.distTag, 'next')
+    assert.equal(result.package?.integrity, 'sha512-next')
   })
 
   it('creates a baseline, calls the Agent on a meaningful change, and stays quiet without a new change', async () => {
@@ -305,7 +345,7 @@ targets:
     assert.match(rendered, /Exact artifact check: npx --yes upstream-radar@latest inspect npm:dsh-demo@1\.1\.0 --deep/)
 
     const thirdRun = await runObserver({ schema: OBSERVER_TARGETS_SCHEMA, targets: [target] }, secondRun.state, {
-      source,
+      source: { ...source, observe: async () => ({ ...second, observedAt: '2026-08-17T02:00:00.000Z' }) },
       now: new Date('2026-08-17T02:00:00.000Z'),
       agent: async () => {
         throw new Error('Agent must not be called without a change')
@@ -313,6 +353,7 @@ targets:
     })
     assert.equal(thirdRun.report.changes.length, 0)
     assert.equal(thirdRun.report.agent.attempted, 0)
+    assert.equal(thirdRun.state.targets[target.id]?.observedAt, secondRun.state.targets[target.id]?.observedAt)
   })
 
   it('routes an upstream dependency version change to downstream plugins from the reverse index', async () => {
@@ -660,6 +701,18 @@ targets:
     assert.match(result.report.changes[0]?.reasons.join('\n') ?? '', /source\/published version drift/)
     assert.equal(result.report.pendingTaskDetails[0]?.sourceManifestAfter, 'dsh-demo@1.0.0')
     assert.equal(result.report.pendingTaskDetails[0]?.publishedPackageAfter, 'dsh-demo@2.0.0')
+
+    const repeated = await runObserver({ schema: OBSERVER_TARGETS_SCHEMA, targets: [target] }, result.state, {
+      source: {
+        observe: async () => ({ ...after, observedAt: '2026-08-17T05:00:00.000Z' }),
+        compare: async () => { throw new Error('compare must not run for unchanged drift') },
+      },
+      now: new Date('2026-08-17T05:00:00.000Z'),
+      agent: async () => { throw new Error('persistent drift must not wake the Agent again') },
+    })
+    assert.equal(repeated.report.changes.length, 0)
+    assert.equal(repeated.report.agent.attempted, 0)
+    assert.equal(repeated.state.targets[target.id]?.observedAt, result.state.targets[target.id]?.observedAt)
   })
 
   it('renders an explicit read-only contract for the DSH Agent', () => {


### PR DESCRIPTION
The first two live main-branch observer runs exposed two always-on failures:

- DSH prereleases are published on npm `next`, while `latest` still points to `0.1.0-rc.7`; the observer therefore missed `0.1.1-rc.1`.
- A persistent source/published drift was treated as a fresh meaningful change on every run, waking the Agent and creating timestamp-only state commits.

This change:
- adds an explicit, validated `package-tag` target field and persists the selected tag with the exact package coordinate;
- points the official DSH target at `next`;
- triggers drift only when the drift identity changes;
- keeps the durable observation snapshot byte-stable when only the check timestamp changed.

After merge, the first run should observe DSH `rc.7 → rc.1` and fan out the three-plugin isolated matrix. A second run should produce no matrix, no Agent call, and no state commit.

Validation: `pnpm test` (294/294), `pnpm run release:check`, diff checks.