### PR TITLE
Monitor the first awesome-dsh-plugin cohort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,8 @@ All notable changes to Upstream Radar are documented here.
 
 ### Added
 
+- Import a commit-pinned, eight-repository cohort from `awesome-dsh-plugin`, monitor all eight source/lockfile streams, and add the six independently matched npm artifacts to the isolated DSH compatibility matrix.
+- Support explicit GitHub-only observer targets so repository-installed plugins are never silently mapped to an unrelated same-name npm package.
 - Add `observe --llm-env-file` as an explicit OpenAI-compatible issue-locator model entry point for installations that do not yet have a DSH Agent wrapper; model failures leave deterministic upstream tasks pending for retry.
 - Make the scheduled upstream-observer workflow optionally forward issue-locator model secrets without making static observation depend on an LLM configuration.
 - Show the concrete unresolved dependency edges behind an incomplete npm artifact review, and accept common `MODEL`/`CODEX_MODEL` env names for observer model calls.

--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ it is not intended as a normal laptop command.
 
 This lane is wired into the always-on observer. Radar now watches the official
 `@deepseek-ai/dsh` `next` release channel (current DSH releases are prereleases
-rather than npm `latest`). A new exact DSH publication fans out the small
-[maintained plugin corpus](examples/dsh/install-observer/targets.json), one fresh
-VM per plugin. A mapped plugin publication retests only that plugin. Unchanged
+rather than npm `latest`). A new exact DSH publication fans out the
+[nine-plugin maintained corpus](examples/dsh/install-observer/targets.json), one
+fresh VM per plugin. Six of those targets come from an identity-checked,
+[commit-pinned `awesome-dsh-plugin` cohort](examples/dsh/awesome-observer/README.md);
+two additional catalog targets are source-only because their real distribution
+is GitHub rather than npm. A mapped plugin publication retests only that plugin. Unchanged
 evidence keeps `observations.json` byte-stable, persistent source/publish drift
 does not wake the Agent again, and the DSH Agent/API key never enters the execution job.
 Build-script approvals are exact package names stored in the maintained target

--- a/examples/dsh/awesome-observer/README.md
+++ b/examples/dsh/awesome-observer/README.md
@@ -1,0 +1,44 @@
+# awesome-dsh-plugin monitored cohort
+
+This directory binds a small operational cohort to one immutable snapshot of
+the public [`awesome-dsh-plugin`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
+catalog. The catalog is a discovery source, not a security review or an install
+instruction.
+
+## What was imported
+
+[`cohort.json`](cohort.json) records the exact catalog commit and eight selected
+repositories across seven DSH integration surfaces. Selection is intentionally
+small enough that every identity can be checked before execution:
+
+| Monitoring lane | Count | Targets |
+| --- | ---: | --- |
+| Source + npm coordinate + dependency graph + isolated install/load | 6 | Agent Teams, Better Sidebar, Context, Cost Meter, DSH Market, OpenPencil |
+| Source + dependency graph only | 2 | dsh-browser, Aegis |
+
+The two source-only targets are not evidence gaps accidentally presented as npm
+packages. `dsh-browser` uses a repository-specific installer and its bridge
+package is private. Aegis documents a GitHub install while the same unscoped npm
+name belongs to another project. Radar therefore records their commits and
+graphs but never executes an unrelated npm artifact.
+
+## How the loop closes
+
+```text
+pinned catalog entry
+  -> examples/upstream-observer/targets.yml
+  -> daily source, npm and lockfile observation
+  -> persisted old -> new coordinate
+  -> exact affected target selection
+  -> one secret-free hosted VM per npm plugin
+  -> install/register/load report against the changed DSH release
+```
+
+The first observation of a repository is a baseline and does not execute code.
+After that, a new exact DSH release tests all six npm targets; a new exact plugin
+publication tests only its mapped target. Source-only commits remain static
+analysis tasks. An unchanged run updates nothing and schedules no VM.
+
+The initial compatibility baseline is dispatched explicitly once, using the
+same isolated workflow that later scheduled changes use. Results are checked in
+only after their exact DSH/plugin pairs and trace coverage have been reviewed.

--- a/examples/dsh/awesome-observer/cohort.json
+++ b/examples/dsh/awesome-observer/cohort.json
@@ -1,0 +1,189 @@
+{
+  "schema": "upstream-radar.awesome-dsh-cohort/v1alpha1",
+  "selectedAt": "2026-08-21T09:04:58Z",
+  "source": {
+    "repository": "awesome-dsh-plugin/awesome-dsh-plugin",
+    "commit": "7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82",
+    "commitUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82",
+    "entryDirectory": "data/plugins",
+    "entryCount": 1837,
+    "license": "CC0-1.0"
+  },
+  "selection": {
+    "strategy": "small-diverse-maintained-cohort",
+    "reason": "Exercise browser, UI, market, context, multi-agent, cost and skill integration surfaces before expanding execution.",
+    "trustBoundary": "The catalog discovers repositories only. Repository identity, source package identity and npm distribution identity are observed independently."
+  },
+  "plugins": [
+    {
+      "id": "dsh-browser",
+      "catalogEntry": "data/plugins/Lum1104__dsh-browser--packages-browser-bridge-browser.yml",
+      "repository": "Lum1104/dsh-browser",
+      "ref": "main",
+      "category": "browser",
+      "packagePath": "packages/browser/bridge-browser/package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@yuxianglin/dsh-bridge-browser",
+        "version": "0.0.3",
+        "private": true
+      },
+      "distribution": {
+        "kind": "repository-installer",
+        "reason": "The bridge package is private and its README uses the repository installer; the unrelated dsh-browser npm name must not be substituted."
+      }
+    },
+    {
+      "id": "dsh-better-sidebar",
+      "catalogEntry": "data/plugins/omdsh-dev__DSH-better-sidebar.yml",
+      "repository": "omdsh-dev/DSH-better-sidebar",
+      "ref": "main",
+      "category": "ui",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-better-sidebar",
+        "version": "0.14.1"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-better-sidebar",
+        "selectedVersion": "0.14.0",
+        "distTag": "latest"
+      }
+    },
+    {
+      "id": "dsh-market",
+      "catalogEntry": "data/plugins/dsh-market__dsh-market.yml",
+      "repository": "dsh-market/dsh-market",
+      "ref": "main",
+      "category": "market",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dshmarket",
+        "version": "1.17.1"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dshmarket",
+        "selectedVersion": "1.17.1",
+        "distTag": "latest"
+      }
+    },
+    {
+      "id": "dsh-openpencil",
+      "catalogEntry": "data/plugins/ZSeven-W__dsh-openpencil.yml",
+      "repository": "ZSeven-W/dsh-openpencil",
+      "ref": "main",
+      "category": "ui",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@zseven-w/dsh-openpencil",
+        "version": "0.1.0-rc.1"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@zseven-w/dsh-openpencil",
+        "selectedVersion": "0.1.0-rc.1",
+        "distTag": "latest"
+      }
+    },
+    {
+      "id": "dsh-context",
+      "catalogEntry": "data/plugins/bowenliang123__dsh-context.yml",
+      "repository": "bowenliang123/dsh-context",
+      "ref": "main",
+      "category": "usage",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-context",
+        "version": "0.19.2"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-context",
+        "selectedVersion": "0.19.2",
+        "distTag": "latest"
+      }
+    },
+    {
+      "id": "dsh-agent-teams",
+      "catalogEntry": "data/plugins/NanmiCoder__dsh-agent-teams.yml",
+      "repository": "NanmiCoder/dsh-agent-teams",
+      "ref": "main",
+      "category": "workflow",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@nanmicoder/dsh-agent-teams",
+        "version": "0.1.10"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@nanmicoder/dsh-agent-teams",
+        "selectedVersion": "0.1.10",
+        "distTag": "latest"
+      }
+    },
+    {
+      "id": "dsh-cost-meter",
+      "catalogEntry": "data/plugins/Han-1413141__dsh-cost-meter.yml",
+      "repository": "Han-1413141/dsh-cost-meter",
+      "ref": "master",
+      "category": "usage",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-cost-meter",
+        "version": "1.5.31"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-cost-meter",
+        "selectedVersion": "1.5.31",
+        "distTag": "latest"
+      }
+    },
+    {
+      "id": "aegis",
+      "catalogEntry": "data/plugins/GanyuanRan__Aegis.yml",
+      "repository": "GanyuanRan/Aegis",
+      "ref": "main",
+      "category": "skill",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "aegis",
+        "version": "2.8.4"
+      },
+      "distribution": {
+        "kind": "github",
+        "installSpec": "github:GanyuanRan/Aegis",
+        "reason": "The matching DSH install path is GitHub; the aegis npm coordinate belongs to a different project."
+      }
+    }
+  ]
+}

--- a/examples/dsh/awesome-observer/cohort.json
+++ b/examples/dsh/awesome-observer/cohort.json
@@ -115,12 +115,12 @@
       },
       "sourceCoordinateAtSelection": {
         "name": "dsh-context",
-        "version": "0.19.2"
+        "version": "0.20.0"
       },
       "distribution": {
         "kind": "npm",
         "name": "dsh-context",
-        "selectedVersion": "0.19.2",
+        "selectedVersion": "0.20.0",
         "distTag": "latest"
       }
     },

--- a/examples/dsh/install-observer/README.md
+++ b/examples/dsh/install-observer/README.md
@@ -3,7 +3,9 @@
 This directory is the maintained dynamic-test corpus for Upstream Radar. It is
 small on purpose: static checks can cover the wider plugin inventory every day;
 code execution happens only after an exact DSH or mapped plugin publication
-changes.
+changes. The corpus currently contains nine published plugins: the original
+three behavior cases plus six identity-checked targets imported from the
+[`awesome-dsh-plugin` cohort](../awesome-observer/README.md).
 
 ## What runs where
 

--- a/examples/dsh/install-observer/targets.json
+++ b/examples/dsh/install-observer/targets.json
@@ -19,6 +19,42 @@
       "spec": "dsh-wsl-workspace@0.2.3",
       "observerTargetId": "dsh-wsl-workspace",
       "reason": "A plugin whose native dependency makes install behavior materially different from manifest-only review."
+    },
+    {
+      "id": "agent-teams",
+      "spec": "@nanmicoder/dsh-agent-teams@0.1.10",
+      "observerTargetId": "dsh-agent-teams",
+      "reason": "A popular multi-agent workflow plugin imported from the awesome-dsh-plugin maintained cohort."
+    },
+    {
+      "id": "better-sidebar",
+      "spec": "dsh-better-sidebar@0.14.0",
+      "observerTargetId": "dsh-better-sidebar",
+      "reason": "A high-adoption UI workbench with a broad DSH peer surface and a native terminal dependency."
+    },
+    {
+      "id": "context",
+      "spec": "dsh-context@0.19.2",
+      "observerTargetId": "dsh-context",
+      "reason": "A context lifecycle plugin that exercises host, session and client integration boundaries."
+    },
+    {
+      "id": "cost-meter",
+      "spec": "dsh-cost-meter@1.5.31",
+      "observerTargetId": "dsh-cost-meter",
+      "reason": "A cost and budget plugin that reads DSH credential and home-path services."
+    },
+    {
+      "id": "dsh-market",
+      "spec": "dshmarket@1.17.1",
+      "observerTargetId": "dsh-market",
+      "reason": "The in-product plugin market is a high-leverage downstream consumer of DSH compatibility changes."
+    },
+    {
+      "id": "openpencil",
+      "spec": "@zseven-w/dsh-openpencil@0.1.0-rc.1",
+      "observerTargetId": "dsh-openpencil",
+      "reason": "A Node 24-targeted design plugin that exercises host tools and a broad web-client peer surface."
     }
   ]
 }

--- a/examples/dsh/install-observer/targets.json
+++ b/examples/dsh/install-observer/targets.json
@@ -34,7 +34,7 @@
     },
     {
       "id": "context",
-      "spec": "dsh-context@0.19.2",
+      "spec": "dsh-context@0.20.0",
       "observerTargetId": "dsh-context",
       "reason": "A context lifecycle plugin that exercises host, session and client integration boundaries."
     },

--- a/examples/upstream-observer/targets.yml
+++ b/examples/upstream-observer/targets.yml
@@ -48,3 +48,75 @@ targets:
     ref: master
     package: '@sanqi-normal/dsh-webui-market-plugin'
     packagePath: package.json
+
+  # First maintained cohort imported from awesome-dsh-plugin at the immutable
+  # commit recorded in examples/dsh/awesome-observer/cohort.json.
+  - id: dsh-browser
+    ecosystem: dsh
+    repository: Lum1104/dsh-browser
+    ref: main
+    npm: false
+    packagePath: packages/browser/bridge-browser/package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+
+  - id: dsh-better-sidebar
+    ecosystem: dsh
+    repository: omdsh-dev/DSH-better-sidebar
+    ref: main
+    package: dsh-better-sidebar
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+
+  - id: dsh-market
+    ecosystem: dsh
+    repository: dsh-market/dsh-market
+    ref: main
+    package: dshmarket
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+
+  - id: dsh-openpencil
+    ecosystem: dsh
+    repository: ZSeven-W/dsh-openpencil
+    ref: main
+    package: '@zseven-w/dsh-openpencil'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+
+  - id: dsh-context
+    ecosystem: dsh
+    repository: bowenliang123/dsh-context
+    ref: main
+    package: dsh-context
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+
+  - id: dsh-agent-teams
+    ecosystem: dsh
+    repository: NanmiCoder/dsh-agent-teams
+    ref: main
+    package: '@nanmicoder/dsh-agent-teams'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+
+  - id: dsh-cost-meter
+    ecosystem: dsh
+    repository: Han-1413141/dsh-cost-meter
+    ref: master
+    package: dsh-cost-meter
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+
+  - id: aegis
+    ecosystem: dsh
+    repository: GanyuanRan/Aegis
+    ref: main
+    npm: false
+    packagePath: package.json

--- a/src/upstream-alignment.ts
+++ b/src/upstream-alignment.ts
@@ -40,6 +40,8 @@ export interface UpstreamDownstreamIR {
     coordinate: AlignmentCoordinate
   }
   downstream: {
+    /** False when the repository itself is the declared distribution. Defaults to true. */
+    npmExpected?: boolean
     published?: AlignmentCoordinate
     graph: {
       status: AlignmentGraphStatus
@@ -67,6 +69,8 @@ export interface UpstreamDownstreamAlignmentInput {
     name: string
     version: string
   }
+  /** Whether an npm publication is part of this target's distribution contract. Defaults to true. */
+  npmExpected?: boolean
   graph?: DependencyGraph
   graphError?: string
 }
@@ -96,6 +100,8 @@ function overallStatus(checks: readonly AlignmentCheck[]): AlignmentStatus {
 /** Build the IR without fetching, installing, or executing anything. */
 export function buildUpstreamDownstreamIR(input: UpstreamDownstreamAlignmentInput): UpstreamDownstreamIR {
   const upstream = coordinateFromManifest(input.manifest)
+  const npmExpected = input.npmExpected ?? true
+  if (!npmExpected && input.package !== undefined) throw new Error('a source-only alignment cannot contain an npm package observation')
   const published = input.package === undefined
     ? undefined
     : { name: input.package.name, version: input.package.version }
@@ -110,7 +116,15 @@ export function buildUpstreamDownstreamIR(input: UpstreamDownstreamAlignmentInpu
       : 'complete'
   const checks: AlignmentCheck[] = []
 
-  if (published === undefined) {
+  if (!npmExpected) {
+    checks.push({
+      code: 'source-published-identity',
+      status: 'aligned',
+      summary: 'This target is explicitly source-only; no npm publication is part of its distribution contract.',
+      upstream: coordinateText(upstream),
+      downstream: 'source repository',
+    })
+  } else if (published === undefined) {
     checks.push({
       code: 'source-published-identity',
       status: 'unknown',
@@ -166,7 +180,15 @@ export function buildUpstreamDownstreamIR(input: UpstreamDownstreamAlignmentInpu
     })
   }
 
-  if (published === undefined || graphRoot === undefined) {
+  if (!npmExpected) {
+    checks.push({
+      code: 'published-graph-root',
+      status: 'aligned',
+      summary: 'No npm-to-graph comparison is required for an explicitly source-only target.',
+      upstream: 'source repository',
+      downstream: coordinateText(graphRoot),
+    })
+  } else if (published === undefined || graphRoot === undefined) {
     checks.push({
       code: 'published-graph-root',
       status: 'unknown',
@@ -219,6 +241,7 @@ export function buildUpstreamDownstreamIR(input: UpstreamDownstreamAlignmentInpu
       coordinate: upstream,
     },
     downstream: {
+      ...(npmExpected ? {} : { npmExpected: false }),
       ...(published === undefined ? {} : { published }),
       graph: {
         status: graphStatus,
@@ -270,7 +293,10 @@ export function parseUpstreamDownstreamIR(value: unknown, label = 'alignment'): 
     coordinate: parseCoordinate(upstreamValue.coordinate, `${label}.upstream.coordinate`),
   }
   const downstreamValue = record(source.downstream, `${label}.downstream`)
+  const npmExpected = downstreamValue.npmExpected === undefined ? true : downstreamValue.npmExpected
+  if (typeof npmExpected !== 'boolean') throw new Error(`${label}.downstream.npmExpected must be true or false`)
   const published = downstreamValue.published === undefined ? undefined : parseCoordinate(downstreamValue.published, `${label}.downstream.published`)
+  if (!npmExpected && published !== undefined) throw new Error(`${label}.downstream cannot contain a published package when npmExpected is false`)
   const graphValue = record(downstreamValue.graph, `${label}.downstream.graph`)
   const graphStatus = boundedString(graphValue.status, `${label}.downstream.graph.status`, 16) as AlignmentGraphStatus
   if (graphStatus !== 'complete' && graphStatus !== 'incomplete' && graphStatus !== 'unavailable') throw new Error(`${label}.downstream.graph.status is invalid`)
@@ -310,6 +336,7 @@ export function parseUpstreamDownstreamIR(value: unknown, label = 'alignment'): 
     ecosystem,
     upstream: upstreamSource,
     downstream: {
+      ...(npmExpected ? {} : { npmExpected: false }),
       ...(published === undefined ? {} : { published }),
       graph: {
         status: graphStatus,

--- a/src/upstream-observer.ts
+++ b/src/upstream-observer.ts
@@ -58,6 +58,8 @@ export interface ObserverTarget {
   ref?: string
   /** npm package name. When omitted, the source package.json name is used. */
   packageName?: string
+  /** Whether this target has an npm release stream. Defaults to true. */
+  observeNpm?: boolean
   /** npm dist-tag to observe. Defaults to latest. */
   packageTag?: string
   packagePath?: string
@@ -481,6 +483,7 @@ function yamlMapping(line: YamlLine): { key: string; value: unknown } | undefine
 
 function normalizeTargetKey(key: string): string {
   if (key === 'package') return 'packageName'
+  if (key === 'npm') return 'observeNpm'
   if (key === 'package-tag') return 'packageTag'
   if (key === 'package-path') return 'packagePath'
   if (key === 'lockfile-type') return 'lockfileType'
@@ -593,10 +596,14 @@ function target(value: unknown, index: number): ObserverTarget {
   if (packageName !== undefined && !EXACT_NPM_PACKAGE_NAME.test(packageName)) {
     throw new Error(`targets[${index}].package must be an npm package name`)
   }
+  const observeNpm = source.observeNpm === undefined ? true : source.observeNpm
+  if (typeof observeNpm !== 'boolean') throw new Error(`targets[${index}].npm must be true or false`)
   const packageTag = optionalBoundedString(source.packageTag, `targets[${index}].packageTag`, 128)
   if (packageTag !== undefined && !SAFE_NPM_DIST_TAG.test(packageTag)) {
     throw new Error(`targets[${index}].packageTag must be a lowercase npm dist-tag`)
   }
+  if (!observeNpm && packageName !== undefined) throw new Error(`targets[${index}].package cannot be set when npm is false`)
+  if (!observeNpm && packageTag !== undefined) throw new Error(`targets[${index}].packageTag cannot be set when npm is false`)
   const lockfile = source.lockfile === undefined ? undefined : validateRelativePath(source.lockfile, `targets[${index}].lockfile`)
   const rawLockfileType = optionalBoundedString(source.lockfileType, `targets[${index}].lockfileType`, 16)
   const lockfileType = rawLockfileType === undefined
@@ -621,6 +628,7 @@ function target(value: unknown, index: number): ObserverTarget {
     repository: validateRepository(source.repository, `targets[${index}].repository`),
     ref,
     ...(packageName === undefined ? {} : { packageName }),
+    ...(observeNpm ? {} : { observeNpm: false }),
     ...(packageTag === undefined ? {} : { packageTag }),
     ...(packagePath === undefined ? {} : { packagePath }),
     ...(lockfile === undefined ? {} : { lockfile }),
@@ -1141,8 +1149,12 @@ export class UpstreamObserverClient implements ObserverSource {
     if (targetValue.packageName !== undefined && targetValue.packageName !== manifest.name) {
       warnings.push(`target package ${targetValue.packageName} does not match source manifest ${manifest.name}`)
     }
-    const packageObservation = await this.fetchNpmObservation(packageName, targetValue.packageTag)
-    if (packageObservation === undefined) warnings.push(`${packageName} was not found on the configured npm registry`)
+    const packageObservation = targetValue.observeNpm === false
+      ? undefined
+      : await this.fetchNpmObservation(packageName, targetValue.packageTag)
+    if (targetValue.observeNpm !== false && packageObservation === undefined) {
+      warnings.push(`${packageName} was not found on the configured npm registry`)
+    }
     let graph: DependencyGraph | undefined
     let graphError: string | undefined
     let lockfileUrl: string | undefined

--- a/src/upstream-observer.ts
+++ b/src/upstream-observer.ts
@@ -1215,6 +1215,7 @@ export class UpstreamObserverClient implements ObserverSource {
         packagePath,
       },
       manifest,
+      npmExpected: targetValue.observeNpm !== false,
       ...(packageObservation === undefined ? {} : {
         package: {
           name: packageObservation.name,

--- a/test/awesome-dsh-cohort.test.ts
+++ b/test/awesome-dsh-cohort.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import { parseDshInstallTargets } from '../src/dsh-install-plan.js'
+import { parseObserverConfigText } from '../src/upstream-observer.js'
+
+interface CohortPlugin {
+  id: string
+  repository: string
+  ref: string
+  packagePath: string
+  distribution: {
+    kind: 'npm' | 'github' | 'repository-installer'
+    name?: string
+    selectedVersion?: string
+  }
+}
+
+interface Cohort {
+  schema: string
+  source: { commit: string; entryCount: number }
+  plugins: CohortPlugin[]
+}
+
+describe('awesome-dsh-plugin monitored cohort', () => {
+  it('keeps catalog provenance, static targets and executable npm targets aligned', async () => {
+    const cohort = JSON.parse(await readFile('examples/dsh/awesome-observer/cohort.json', 'utf8')) as Cohort
+    const observer = parseObserverConfigText(await readFile('examples/upstream-observer/targets.yml', 'utf8'))
+    const installTargets = parseDshInstallTargets(JSON.parse(
+      await readFile('examples/dsh/install-observer/targets.json', 'utf8'),
+    ) as unknown)
+
+    assert.equal(cohort.schema, 'upstream-radar.awesome-dsh-cohort/v1alpha1')
+    assert.match(cohort.source.commit, /^[0-9a-f]{40}$/)
+    assert.ok(cohort.source.entryCount >= cohort.plugins.length)
+    assert.equal(cohort.plugins.length, 8)
+    assert.equal(new Set(cohort.plugins.map(plugin => plugin.id)).size, cohort.plugins.length)
+
+    const importedIds = new Set(cohort.plugins.map(plugin => plugin.id))
+    const importedObserverTargets = observer.targets.filter(target => importedIds.has(target.id))
+    assert.equal(importedObserverTargets.length, cohort.plugins.length)
+
+    for (const plugin of cohort.plugins) {
+      const observed = importedObserverTargets.find(target => target.id === plugin.id)
+      assert.ok(observed, `missing observer target for ${plugin.id}`)
+      assert.equal(observed.repository, plugin.repository)
+      assert.equal(observed.ref, plugin.ref)
+      assert.equal(observed.packagePath, plugin.packagePath)
+    }
+
+    const npmPlugins = cohort.plugins.filter(plugin => plugin.distribution.kind === 'npm')
+    const sourceOnlyPlugins = cohort.plugins.filter(plugin => plugin.distribution.kind !== 'npm')
+    assert.equal(npmPlugins.length, 6)
+    assert.deepEqual(sourceOnlyPlugins.map(plugin => plugin.id).sort(), ['aegis', 'dsh-browser'])
+
+    for (const plugin of npmPlugins) {
+      assert.ok(plugin.distribution.name)
+      assert.ok(plugin.distribution.selectedVersion)
+      const executable = installTargets.plugins.find(target => target.observerTargetId === plugin.id)
+      assert.ok(executable, `missing isolated install target for ${plugin.id}`)
+      assert.equal(executable.spec, `${plugin.distribution.name}@${plugin.distribution.selectedVersion}`)
+    }
+
+    for (const plugin of sourceOnlyPlugins) {
+      const observed = importedObserverTargets.find(target => target.id === plugin.id)
+      assert.equal(observed?.observeNpm, false)
+      assert.equal(installTargets.plugins.some(target => target.observerTargetId === plugin.id), false)
+    }
+  })
+})

--- a/test/upstream-alignment.test.ts
+++ b/test/upstream-alignment.test.ts
@@ -81,6 +81,19 @@ describe('upstream/downstream alignment IR', () => {
     assert.match(report.checks.find(check => check.code === 'dependency-graph-coverage')?.remediation ?? '', /empty vulnerability result is not complete coverage/)
   })
 
+  it('treats an explicitly source-only distribution as intentional instead of demanding npm', () => {
+    const report = buildUpstreamDownstreamIR(input({
+      npmExpected: false,
+      package: undefined,
+    }))
+    assert.equal(report.status, 'aligned')
+    assert.equal(report.downstream.npmExpected, false)
+    assert.equal(report.checks.find(check => check.code === 'source-published-identity')?.status, 'aligned')
+    assert.equal(report.checks.some(check => check.remediation?.includes('npm package')), false)
+    assert.deepEqual(parseUpstreamDownstreamIR(report), report)
+    assert.throws(() => buildUpstreamDownstreamIR(input({ npmExpected: false })), /source-only alignment/)
+  })
+
   it('validates persisted IR before it is reused', () => {
     const report = buildUpstreamDownstreamIR(input())
     assert.deepEqual(parseUpstreamDownstreamIR(report), report)

--- a/test/upstream-observer.test.ts
+++ b/test/upstream-observer.test.ts
@@ -371,6 +371,10 @@ targets:
     assert.equal(result.package, undefined)
     assert.equal(result.graph?.rootNodeId, 'pnpm:workspace-root:source-only-plugin@1.0.0')
     assert.deepEqual(result.warnings, undefined)
+    assert.ok(result.alignment)
+    assert.equal(result.alignment.downstream.npmExpected, false)
+    assert.equal(result.alignment.checks.find(check => check.code === 'source-published-identity')?.status, 'aligned')
+    assert.equal(result.alignment.checks.some(check => check.remediation?.includes('npm package')), false)
   })
 
   it('creates a baseline, calls the Agent on a meaningful change, and stays quiet without a new change', async () => {

--- a/test/upstream-observer.test.ts
+++ b/test/upstream-observer.test.ts
@@ -262,6 +262,34 @@ targets:
     assert.deepEqual(config.targets[0], { ...target, packageTag: 'next', dshVersions: ['0.1.0-rc.6', '0.1.0-rc.7'] })
   })
 
+  it('keeps a GitHub-only target out of the npm namespace', () => {
+    const config = parseObserverConfigText(`
+schema: ${OBSERVER_TARGETS_SCHEMA}
+targets:
+  - id: source-only
+    ecosystem: dsh
+    repository: acme/source-only
+    npm: false
+    package-path: packages/plugin/package.json
+`)
+    assert.deepEqual(config.targets[0], {
+      id: 'source-only',
+      ecosystem: 'dsh',
+      repository: 'acme/source-only',
+      ref: 'main',
+      observeNpm: false,
+      packagePath: 'packages/plugin/package.json',
+    })
+    assert.throws(() => parseObserverConfigText(`
+targets:
+  - id: contradictory
+    ecosystem: dsh
+    repository: acme/source-only
+    npm: false
+    package: unrelated-name
+`), /package cannot be set when npm is false/)
+  })
+
   it('observes the configured npm release channel instead of assuming latest', async () => {
     const source = new UpstreamObserverClient({
       fetch: async input => {
@@ -299,6 +327,50 @@ targets:
     assert.equal(result.package?.version, '2.0.0-rc.1')
     assert.equal(result.package?.distTag, 'next')
     assert.equal(result.package?.integrity, 'sha512-next')
+  })
+
+  it('observes GitHub-only source and lockfile evidence without querying npm', async () => {
+    const source = new UpstreamObserverClient({
+      fetch: async input => {
+        const url = String(input)
+        if (url.includes('/commits/main')) return new Response(JSON.stringify({ sha: 'commit-1' }), { status: 200 })
+        if (url.endsWith('/commit-1/plugin/package.json')) {
+          return new Response(JSON.stringify({
+            name: 'source-only-plugin',
+            version: '1.0.0',
+            dsh: { bundle: { patch: './cordis.patch.yml' } },
+          }), { status: 200 })
+        }
+        if (url.endsWith('/commit-1/pnpm-lock.yaml')) {
+          return new Response([
+            "lockfileVersion: '9.0'",
+            '',
+            'importers:',
+            '  plugin: {}',
+            '',
+            'packages: {}',
+            '',
+            'snapshots: {}',
+            '',
+          ].join('\n'), { status: 200 })
+        }
+        if (url.startsWith('https://registry.npmjs.org/')) throw new Error('npm must not be queried')
+        throw new Error(`unexpected request: ${url}`)
+      },
+    })
+    const result = await source.observe({
+      id: 'source-only',
+      ecosystem: 'dsh',
+      repository: 'acme/source-only',
+      ref: 'main',
+      observeNpm: false,
+      packagePath: 'plugin/package.json',
+      lockfile: 'pnpm-lock.yaml',
+      lockfileType: 'pnpm',
+    }, '2026-08-21T00:00:00.000Z')
+    assert.equal(result.package, undefined)
+    assert.equal(result.graph?.rootNodeId, 'pnpm:workspace-root:source-only-plugin@1.0.0')
+    assert.deepEqual(result.warnings, undefined)
   })
 
   it('creates a baseline, calls the Agent on a meaningful change, and stays quiet without a new change', async () => {


### PR DESCRIPTION
## Why

Prove the always-on DSH compatibility loop against a real ecosystem cohort instead of hand-picked demos.

## What changed

- pin one immutable awesome-dsh-plugin catalog commit and record an eight-repository cohort
- monitor all eight repositories, package manifests and available lockfile graphs
- add six independently matched npm artifacts to the isolated install/load matrix
- model dsh-browser and Aegis as GitHub-only distributions so Radar never substitutes unrelated same-name npm packages
- enforce catalog → observer → execution-corpus alignment in tests

## Execution boundary

This PR does not execute third-party plugin code locally. Baselines are static. Dynamic compatibility runs use the existing secret-free GitHub-hosted VM plus restricted Docker workflow, one exact plugin/DSH pair per VM.

## Validation

- [x] pnpm test
- [x] 297 tests passed
- [x] git diff --check
- [x] Config alignment verifies 8 static targets, 6 executable npm targets and 2 source-only targets