### PR TITLE
Enforce plugin runtime contracts in isolated DSH observations

### DIFF
--- a/.github/workflows/observe-dsh-plugin-install.yml
+++ b/.github/workflows/observe-dsh-plugin-install.yml
@@ -206,6 +206,7 @@ jobs:
                 `- Result: \`${inline(report.result)}\` — ${inline(report.reason)}`,
                 `- Exact artifact: \`sha256:${inline(report.artifact?.sha256)}\``,
                 `- Runtime: Node \`${inline(report.runtime?.nodeVersion)}\` on \`${inline(`${report.runtime?.platform}/${report.runtime?.architecture}`)}\`; pnpm \`${inline(report.runtime?.packageManager?.version)}\``,
+                `- Plugin Node requirement: \`${inline(report.artifact?.nodeEngine ?? 'not declared')}\``,
                 `- Approved dependency builds: \`${inline(report.boundary?.approvedDependencyBuilds?.join(', ') || 'none')}\``,
                 `- Declared lifecycle scripts: \`${inline(report.artifact?.lifecycleScripts?.join(', ') || 'none')}\``,
                 `- Install behavior: ${count(report.observations?.install?.processes)} process exec(s), ${count(report.observations?.install?.network)} network attempt(s), ${count(report.observations?.install?.fileWrites)} file-write syscall(s)`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to Upstream Radar are documented here.
   Summaries.
 - Approve only `node-pty` for the maintained Better Sidebar install case, matching
   the plugin's documented native dependency instead of allowing all builds.
+- Include the standard Node-gyp Python/C++ toolchain in the disposable observer
+  image so an explicitly approved native build is not confused with a plugin
+  compatibility failure.
 
 ## [0.39.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Upstream Radar are documented here.
 
+## Unreleased
+
+- Stop isolated DSH plugin observations before code execution when the exact npm
+  artifact's declared Node range excludes the runner, and report the pair as
+  `runtime-incompatible` instead of a false compatibility success.
+- Record each artifact's Node requirement in JSON, text output, and GitHub Job
+  Summaries.
+- Approve only `node-pty` for the maintained Better Sidebar install case, matching
+  the plugin's documented native dependency instead of allowing all builds.
+
 ## [0.39.0] - 2026-08-21
 
 ### Isolated DSH install and load observation

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ therefore uses a separate, deliberately untrusted lane:
 fresh GitHub-hosted VM (no secrets, read-only repository token)
   → restricted container (no host workspace or Docker socket)
   → npm pack exact package@version with scripts disabled
+  → enforce the artifact's declared Node range before plugin code can run
   → record the exact Node and pnpm runtime used by the check
   → DSH installs that same tarball with only the declared dependency-build approvals
   → strace records child processes, network destinations and file writes
@@ -126,7 +127,7 @@ These are real, reproducible cases in this repository—not synthetic “vulnera
 
 | Case | Finding | Why it matters |
 | --- | --- | --- |
-| [Live DSH `0.1.1-rc.1` isolated matrix](examples/dsh/install-observer/reports/2026-08-21-dsh-0.1.1-rc.1.md) | All three maintained plugins install/register/load under their recorded contracts; Feishu's raw control fails until its documented `protobufjs` approval is supplied | This is the first always-on behavior result: Radar preserves a red negative control without mislabeling a documented install policy as a new author defect. |
+| [Live DSH `0.1.1-rc.1` isolated matrix](examples/dsh/install-observer/reports/2026-08-21-dsh-0.1.1-rc.1.md) | Eight exact artifacts install/register/load under their recorded contracts; OpenPencil is stopped before execution because it requires Node ≥24.11 while the isolated runner is Node 22.23; Better Sidebar passes only with its documented `node-pty` build approval and a real native toolchain | The imported awesome cohort found both a genuine runtime-pair incompatibility and a test-environment defect, while preserving the evidence that distinguishes them. |
 | [`dsh-cloudflare-browser-run@0.1.1`](examples/reports/dsh-cloudflare-browser-run-0.1.1.txt) | 18 resolved packages, 2 unresolved optional Cordis edges, 0 known vulnerabilities, and DSH rc.6/rc.7 both loaded the bundle | A real browser plugin demonstrates the DSH admission boundary and why incomplete edges stay visible. |
 | [50-plugin batch](examples/dsh/reports/dsh-batch-50-2026-08-17.md) / [real graph corpus](examples/dsh/first-batch/README.md) | 50 source scans, 30 exact npm reviews, 37 real plugin graphs indexed; 13 targets kept as missing evidence | The reverse index is now built from real DSH plugins, and missing graphs are not treated as clean. |
 | [`dsh-feishu-bot@0.15.8`](examples/dsh/reports/dsh-feishu-bot-0.15.8-review-2026-08-18.md) | 89-package graph, 12 unresolved optional edges, reachable `protobufjs` `postinstall`, DSH rc.6/rc.7 compatible | “No known CVE” is not the same as “no installation trust boundary.” |

--- a/docker/dsh-install-observer.Dockerfile
+++ b/docker/dsh-install-observer.Dockerfile
@@ -16,7 +16,7 @@ FROM node:22-bookworm-slim AS runtime
 
 # DSH rc.7 and rc.8 declare pnpm@11.7.0 in the official source tree.
 RUN apt-get update \
-  && apt-get install --yes --no-install-recommends ca-certificates git strace \
+  && apt-get install --yes --no-install-recommends ca-certificates git strace python3 make g++ \
   && rm -rf /var/lib/apt/lists/* \
   && npm install --global --ignore-scripts pnpm@11.7.0 \
   && useradd --create-home --uid 10001 --shell /usr/sbin/nologin observer

--- a/examples/dsh/install-observer/README.md
+++ b/examples/dsh/install-observer/README.md
@@ -19,15 +19,17 @@ Inside the restricted container, Radar:
 1. downloads one exact npm artifact with lifecycle scripts disabled;
 2. verifies the tarball's package identity and DSH bundle declaration;
 3. binds the report to the tarball SHA-256;
-4. records the exact Node and pnpm runtime used by the observation;
-5. initializes one exact DSH release with scripts disabled;
-6. installs the local tarball through DSH with lifecycle scripts enabled and
+4. checks the package's declared Node requirement against the exact isolated
+   runtime before any plugin or dependency code may run;
+5. records the exact Node and pnpm runtime used by the observation;
+6. initializes one exact DSH release with scripts disabled;
+7. installs the local tarball through DSH with lifecycle scripts enabled and
    only the dependency-build approvals explicitly declared for that target;
-7. verifies that DSH registered the bundle;
-8. loads the profile with `--dump-config`;
-9. records install and load process execution, network destinations, write-like
+8. verifies that DSH registered the bundle;
+9. loads the profile with `--dump-config`;
+10. records install and load process execution, network destinations, write-like
    file syscalls, and final filesystem changes; and
-10. destroys the container and hosted VM after preserving bounded JSON.
+11. destroys the container and hosted VM after preserving bounded JSON.
 
 The container is read-only except for a memory-backed sandbox and one output
 directory. It runs without the host workspace, without a Docker socket, with a
@@ -60,6 +62,7 @@ blocked script into a global “allow all” policy.
 | Result | Meaning |
 | --- | --- |
 | `compatible` | The exact tarball installed, registered, and loaded under the exact DSH release and recorded build-approval set, with readable bounded traces. |
+| `runtime-incompatible` | The exact tarball requires a Node version that excludes the isolated runtime. No plugin or dependency code is executed. |
 | `install-failed` | The traced install failed or DSH did not register the plugin. |
 | `load-failed` | Installation and registration passed, but the traced profile load failed. |
 | `unknown` | The artifact, DSH bootstrap, timeout/output bound, tracer, or collector could not establish a reliable result. |

--- a/examples/dsh/install-observer/README.md
+++ b/examples/dsh/install-observer/README.md
@@ -35,6 +35,10 @@ The container is read-only except for a memory-backed sandbox and one output
 directory. It runs without the host workspace, without a Docker socket, with a
 PID limit, memory/CPU limits, `no-new-privileges`, all capabilities dropped
 except the `SYS_PTRACE` capability needed by `strace`, and a hard outer timeout.
+Its declared Linux baseline includes Python 3, `make`, and `g++`, so an approved
+native dependency is tested against a usable build environment instead of being
+misclassified merely because the observer image omitted the standard Node-gyp
+toolchain.
 
 ## When the matrix runs
 

--- a/examples/dsh/install-observer/reports/2026-08-21-dsh-0.1.1-rc.1.md
+++ b/examples/dsh/install-observer/reports/2026-08-21-dsh-0.1.1-rc.1.md
@@ -1,11 +1,11 @@
 # Live isolated matrix: DSH `0.1.1-rc.1`
 
-On 2026-08-21, Upstream Radar installed three exact public npm artifacts through
+On 2026-08-21, Upstream Radar tested nine exact public npm artifacts through
 `@deepseek-ai/dsh@0.1.1-rc.1` in separate disposable GitHub-hosted Linux VMs.
 Each target ran in the restricted, secret-free container documented in the
 [install observer](../README.md).
 
-Runtime for all three checks: Node `22.23.2`, pnpm `11.7.0`, Linux x64. DSH
+Runtime for these checks: Node `22.23.2`, pnpm `11.7.0`, Linux x64. DSH
 `0.1.1-rc.1` declares pnpm `11.7.0` in its official source tree.
 
 | Exact pair | Result | Evidence |
@@ -13,6 +13,12 @@ Runtime for all three checks: Node `22.23.2`, pnpm `11.7.0`, Linux x64. DSH
 | `dsh-cloudflare-browser-run@0.1.3` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install/load traces captured | [Actions run 32462814986](https://github.com/MicroMilo/upstream-radar/actions/runs/32462814986) |
 | `dsh-wsl-workspace@0.2.3` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install/load traces captured | [Actions run 32462817936](https://github.com/MicroMilo/upstream-radar/actions/runs/32462817936) |
 | `dsh-feishu-bot@0.16.0` + DSH `0.1.1-rc.1`, `allowBuilds: [protobufjs]` | Installed, registered, and loaded under the plugin's documented build policy; install trace truncated, load trace captured | [Actions run 32463552879](https://github.com/MicroMilo/upstream-radar/actions/runs/32463552879) |
+| `@nanmicoder/dsh-agent-teams@0.1.10` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install/load traces captured | [Actions run 32467123465](https://github.com/MicroMilo/upstream-radar/actions/runs/32467123465) |
+| `dsh-better-sidebar@0.14.0` + DSH `0.1.1-rc.1`, `allowBuilds: [node-pty]` | Native dependency built; plugin installed, registered, and loaded; install trace truncated, load trace captured | [Actions run 32467779335](https://github.com/MicroMilo/upstream-radar/actions/runs/32467779335) |
+| `dsh-context@0.20.0` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install trace truncated, load trace captured | [Actions run 32467128011](https://github.com/MicroMilo/upstream-radar/actions/runs/32467128011) |
+| `dsh-cost-meter@1.5.31` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install trace truncated, load trace captured | [Actions run 32467130872](https://github.com/MicroMilo/upstream-radar/actions/runs/32467130872) |
+| `dshmarket@1.17.1` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install trace truncated, load trace captured | [Actions run 32467133279](https://github.com/MicroMilo/upstream-radar/actions/runs/32467133279) |
+| `@zseven-w/dsh-openpencil@0.1.0-rc.1` + DSH `0.1.1-rc.1` | `runtime-incompatible`: package requires Node `>=24.11.0`, runner provides Node `22.23.2`; no plugin/dependency code executed | [Actions run 32467600598](https://github.com/MicroMilo/upstream-radar/actions/runs/32467600598) |
 | `dsh-feishu-bot@0.16.0` raw `dsh plugin add` control | Install stopped before registration because no dependency build was approved | [Actions run 32462812288](https://github.com/MicroMilo/upstream-radar/actions/runs/32462812288) |
 
 ## Feishu install-contract control
@@ -52,10 +58,50 @@ the pair compatible. Radar intentionally does not infer or auto-approve a
 package from an error message because approval is the supply-chain trust
 decision being measured.
 
+## Awesome cohort findings
+
+The six added npm targets came from the commit-pinned
+[`awesome-dsh-plugin` cohort](../../awesome-observer/README.md). Four installed
+and loaded without a dependency-build approval. Two exposed distinct contracts
+that a plain source comparison would not establish.
+
+### Better Sidebar: approval and build environment are separate facts
+
+The exact Better Sidebar artifact is
+`sha256:ef430c13135495ba62f552a5b45704cfda6cc70a35ef4caf6f818a7a33c732e8`.
+Its first run stopped because pnpm refused to execute `node-pty@1.1.0`; the
+plugin README documents that native build requirement. A second run approved
+only `node-pty` and proved that the observer image itself lacked Python, `make`,
+and a C++ compiler. That was a test-environment defect, not a plugin defect.
+
+After adding the standard Node-gyp toolchain, the same artifact and the same
+single-package approval installed, registered, and loaded successfully. The
+three observations remain available as separate evidence:
+
+- [no build approved](https://github.com/MicroMilo/upstream-radar/actions/runs/32467125435);
+- [`node-pty` approved but observer toolchain absent](https://github.com/MicroMilo/upstream-radar/actions/runs/32467603173); and
+- [`node-pty` approved with the declared build baseline](https://github.com/MicroMilo/upstream-radar/actions/runs/32467779335).
+
+### OpenPencil: successful loading did not satisfy the package contract
+
+The exact OpenPencil artifact is
+`sha256:a4563e560e91bcd3a2a9302ee7dbee046b146c1bd0de6b27b7c7524fd52e77ca`
+and declares `engines.node: ">=24.11.0"`. pnpm initially allowed that artifact
+to install and DSH loaded it on Node `22.23.2`, producing a misleading green
+[control run](https://github.com/MicroMilo/upstream-radar/actions/runs/32467135800).
+That proved a successful narrow load is insufficient when the runtime violates
+the author's declared support contract.
+
+Radar now reads the requirement from the authenticated tarball and checks it
+before DSH initialization, dependency scripts, installation, or plugin loading.
+The corrected run reports `runtime-incompatible` and leaves all execution stages
+skipped. It does not claim the plugin is broken on Node 24; it says this exact
+Node 22 pair is outside the package's declared contract.
+
 ## Evidence boundary
 
 The compatible results prove these exact install/register/load paths under the
-recorded environment and approval sets. The raw Feishu control proves the
-default command failure and its dependency-build cause. Same-container syscall
-traces remain best-effort and the run does not exercise plugin business actions
-or external credentials.
+recorded environment and approval sets. The negative controls prove the named
+failure boundaries without generalizing them into malware or universal plugin
+incompatibility. Same-container syscall traces remain best-effort and the run
+does not exercise plugin business actions or external credentials.

--- a/examples/dsh/install-observer/targets.json
+++ b/examples/dsh/install-observer/targets.json
@@ -30,6 +30,7 @@
       "id": "better-sidebar",
       "spec": "dsh-better-sidebar@0.14.0",
       "observerTargetId": "dsh-better-sidebar",
+      "allowedBuilds": ["node-pty"],
       "reason": "A high-adoption UI workbench with a broad DSH peer surface and a native terminal dependency."
     },
     {

--- a/schemas/dsh-install-observation.schema.json
+++ b/schemas/dsh-install-observation.schema.json
@@ -73,7 +73,7 @@
         "load": { "$ref": "#/$defs/filesystemDiff" }
       }
     },
-    "result": { "enum": ["compatible", "install-failed", "load-failed", "unknown"] },
+    "result": { "enum": ["compatible", "runtime-incompatible", "install-failed", "load-failed", "unknown"] },
     "reason": { "type": "string", "maxLength": 4096 },
     "boundary": {
       "type": "object",
@@ -109,6 +109,7 @@
         "integrity": { "type": "string", "maxLength": 1024 },
         "bytes": { "type": "integer", "minimum": 0, "maximum": 67108864 },
         "bundlePatch": { "type": "string", "minLength": 1, "maxLength": 4096 },
+        "nodeEngine": { "type": "string", "minLength": 1, "maxLength": 512 },
         "lifecycleScripts": {
           "type": "array",
           "maxItems": 4,

--- a/src/dsh-install-observation.ts
+++ b/src/dsh-install-observation.ts
@@ -5,6 +5,7 @@ import { lstat, mkdir, mkdtemp, open, readdir, rm, writeFile } from 'node:fs/pro
 import { tmpdir } from 'node:os'
 import { basename, join, relative, resolve, sep } from 'node:path'
 import { parseNpmSpec } from './npm.js'
+import { satisfiesSemverRange } from './semver.js'
 import { parseNpmTarball } from './tar.js'
 import { TOOL_VERSION } from './version.js'
 
@@ -24,7 +25,7 @@ const MAX_ALLOWED_BUILDS = 16
 const PROFILE = 'headless'
 const LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepare'] as const
 
-export type DshInstallObservationResult = 'compatible' | 'install-failed' | 'load-failed' | 'unknown'
+export type DshInstallObservationResult = 'compatible' | 'runtime-incompatible' | 'install-failed' | 'load-failed' | 'unknown'
 export type InstallObservationPhase = 'runtime' | 'artifact' | 'profile' | 'install' | 'load'
 export type InstallObservationIsolationProvider = 'github-actions-hosted-runner' | 'firecracker' | 'other'
 
@@ -136,6 +137,7 @@ export interface DshInstallObservationReport {
     integrity?: string
     bytes?: number
     bundlePatch?: string
+    nodeEngine?: string
     lifecycleScripts: string[]
   }
   stages: {
@@ -213,6 +215,7 @@ interface ParsedArtifact {
   integrity?: string
   bytes: number
   bundlePatch: string
+  nodeEngine?: string
   lifecycleScripts: string[]
 }
 
@@ -632,6 +635,14 @@ async function parsePackedArtifact(
     ? manifest.scripts as Record<string, unknown>
     : {}
   const lifecycleScripts = LIFECYCLE_SCRIPTS.filter(name => typeof scripts[name] === 'string')
+  const engines = typeof manifest.engines === 'object' && manifest.engines !== null && !Array.isArray(manifest.engines)
+    ? manifest.engines as Record<string, unknown>
+    : undefined
+  const rawNodeEngine = typeof engines?.node === 'string' ? engines.node.trim() : undefined
+  if (rawNodeEngine !== undefined && rawNodeEngine.length > 512) {
+    throw new Error('packed artifact Node engine requirement exceeds 512 characters')
+  }
+  const nodeEngine = rawNodeEngine === undefined || rawNodeEngine === '' ? undefined : bounded(rawNodeEngine, 512)
   const integrity = typeof item.integrity === 'string' ? bounded(item.integrity, 1_024) : undefined
   return {
     path,
@@ -640,6 +651,7 @@ async function parsePackedArtifact(
     ...(integrity === undefined ? {} : { integrity }),
     bytes: compressed.length,
     bundlePatch,
+    ...(nodeEngine === undefined ? {} : { nodeEngine }),
     lifecycleScripts,
   }
 }
@@ -913,9 +925,28 @@ export async function observeDshPluginInstall(options: DshInstallObservationOpti
       ...(artifact.integrity === undefined ? {} : { integrity: artifact.integrity }),
       bytes: artifact.bytes,
       bundlePatch: artifact.bundlePatch,
+      ...(artifact.nodeEngine === undefined ? {} : { nodeEngine: artifact.nodeEngine }),
       lifecycleScripts: artifact.lifecycleScripts,
     }
     report.stages.artifact = { status: 'passed', code: artifactResult.code }
+
+    if (artifact.nodeEngine !== undefined) {
+      const runtimeMatches = satisfiesSemverRange(report.runtime.nodeVersion, artifact.nodeEngine)
+      if (runtimeMatches === false) {
+        return finishReport(
+          report,
+          'runtime-incompatible',
+          `the plugin declares Node ${artifact.nodeEngine}, but the isolated runtime is Node ${report.runtime.nodeVersion}`,
+        )
+      }
+      if (runtimeMatches === undefined) {
+        return finishReport(
+          report,
+          'unknown',
+          `the observer could not safely evaluate the plugin Node requirement ${artifact.nodeEngine}`,
+        )
+      }
+    }
 
     try {
       const profileResult = await runSafely(runner, {
@@ -1017,6 +1048,7 @@ export function renderDshInstallObservation(report: DshInstallObservationReport)
     `Artifact: ${report.artifact.name}@${report.artifact.version}${report.artifact.sha256 === undefined ? '' : ` (sha256:${report.artifact.sha256.slice(0, 12)}…)`}`,
     `DSH: ${report.dshVersion}`,
     `Runtime: Node ${report.runtime.nodeVersion} (${report.runtime.platform}/${report.runtime.architecture}), pnpm ${report.runtime.packageManager.version ?? 'unknown'}`,
+    `Plugin Node requirement: ${report.artifact.nodeEngine ?? 'not declared'}`,
     `Isolation claim: ${report.boundary.isolationProviderClaim} (provided externally; not verified by Radar)`,
     `Approved dependency builds: ${report.boundary.approvedDependencyBuilds.length === 0 ? 'none' : report.boundary.approvedDependencyBuilds.join(', ')}`,
     '',

--- a/test/dsh-install-observation.test.ts
+++ b/test/dsh-install-observation.test.ts
@@ -81,6 +81,43 @@ describe('DSH install observation', () => {
     assert.deepEqual(phases, ['runtime'])
   })
 
+  it('stops before DSH or plugin execution when the exact artifact excludes the isolated Node runtime', async () => {
+    const phases: InstallObservationCommand['phase'][] = []
+    const report = await observeDshPluginInstall({
+      packageSpec: 'future-plugin@1.0.0',
+      dshVersion: '0.1.1-rc.1',
+      allowExecution: true,
+      isolationProvider: 'github-actions-hosted-runner',
+      runner: async command => {
+        phases.push(command.phase)
+        if (command.phase === 'runtime') return passed({ stdout: '11.7.0\n' })
+        if (command.phase === 'artifact') {
+          await writeFile(join(command.cwd, 'future-plugin-1.0.0.tgz'), makeTarball([
+            { path: 'package/package.json', contents: JSON.stringify({
+              name: 'future-plugin',
+              version: '1.0.0',
+              engines: { node: '>=999.0.0' },
+              dsh: { bundle: { patch: 'cordis.patch.yml' } },
+            }) },
+            { path: 'package/cordis.patch.yml', contents: '[]\n' },
+          ]))
+          return passed({ stdout: JSON.stringify([{ filename: 'future-plugin-1.0.0.tgz' }]) })
+        }
+        throw new Error(`unexpected execution phase: ${command.phase}`)
+      },
+    })
+
+    assert.equal(report.result, 'runtime-incompatible')
+    assert.equal(report.artifact.nodeEngine, '>=999.0.0')
+    assert.equal(report.stages.artifact.status, 'passed')
+    assert.equal(report.stages.profile.status, 'skipped')
+    assert.equal(report.stages.install.status, 'skipped')
+    assert.equal(report.stages.load.status, 'skipped')
+    assert.deepEqual(phases, ['runtime', 'artifact'])
+    assert.match(report.reason, /declares Node >=999\.0\.0/)
+    assert.match(renderDshInstallObservation(report), /RUNTIME-INCOMPATIBLE/)
+  })
+
   it('observes one exact artifact through DSH install and load without inheriting host secrets', async () => {
     const calls: InstallObservationCommand[] = []
     const runner = async (command: InstallObservationCommand): Promise<InstallObservationCommandResult> => {
@@ -96,6 +133,7 @@ describe('DSH install observation', () => {
           { path: 'package/package.json', contents: JSON.stringify({
             name: 'example-plugin',
             version: '1.0.0',
+            engines: { node: '>=18.0.0' },
             scripts: { postinstall: 'node scripts/postinstall.js' },
             dsh: { bundle: { patch: './cordis.patch.yml' } },
           }) },
@@ -139,6 +177,7 @@ describe('DSH install observation', () => {
     assert.equal(report.result, 'compatible')
     assert.equal(report.artifact.name, 'example-plugin')
     assert.equal(report.artifact.version, '1.0.0')
+    assert.equal(report.artifact.nodeEngine, '>=18.0.0')
     assert.match(report.artifact.sha256 ?? '', /^[0-9a-f]{64}$/)
     assert.deepEqual(report.artifact.lifecycleScripts, ['postinstall'])
     assert.equal(report.runtime.packageManager.version, '11.7.0')
@@ -150,6 +189,7 @@ describe('DSH install observation', () => {
     assert.equal(calls.map(call => call.phase).join(','), 'runtime,artifact,profile,install,load')
     assert.match(renderDshInstallObservation(report), /COMPATIBLE/)
     assert.match(renderDshInstallObservation(report), /pnpm 11\.7\.0/)
+    assert.match(renderDshInstallObservation(report), /Plugin Node requirement: >=18\.0\.0/)
     assert.match(renderDshInstallObservation(report), /Approved dependency builds: none/)
     assert.match(renderDshInstallObservation(report), /Lifecycle scripts declared: postinstall/)
   })


### PR DESCRIPTION
## Outcome

- enforce each exact npm artifact Node engine contract before any plugin or dependency code executes
- classify excluded pairs as runtime-incompatible and retain the requirement in JSON/text/Job Summary evidence
- give Better Sidebar only its documented node-pty build approval
- add the standard Node-gyp toolchain to the disposable observer image
- publish the nine-plugin DSH 0.1.1-rc.1 cohort report

## Real isolated proof

- OpenPencil is stopped before execution on Node 22 because its artifact requires Node >=24.11: https://github.com/MicroMilo/upstream-radar/actions/runs/32467600598
- Better Sidebar installs, registers, and loads after the exact node-pty approval in a usable native build baseline: https://github.com/MicroMilo/upstream-radar/actions/runs/32467779335

## Verification

- pnpm test (299 tests)
- one fresh GitHub-hosted VM and restricted container per real plugin run
- no repository secrets passed into plugin execution