### PR TITLE
Release Upstream Radar 0.40.0

### DIFF
--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.39.0
+      - uses: MicroMilo/upstream-radar@v0.40.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/.github/workflows/review-dsh-plugin.yml
+++ b/.github/workflows/review-dsh-plugin.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.39.0
+        uses: MicroMilo/upstream-radar@v0.40.0
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to Upstream Radar are documented here.
 
-## Unreleased
+## [0.40.0] - 2026-08-21
+
+### Awesome DSH cohort
+
+- Import a commit-pinned, eight-repository cohort from `awesome-dsh-plugin`,
+  monitor all eight source/lockfile streams, and add the six independently
+  matched npm artifacts to the isolated DSH compatibility matrix.
+- Support explicit GitHub-only observer targets so repository-installed plugins
+  are never silently mapped to an unrelated same-name npm package.
+
+### Isolated compatibility contracts
 
 - Stop isolated DSH plugin observations before code execution when the exact npm
   artifact's declared Node range excludes the runner, and report the pair as
@@ -14,6 +24,15 @@ All notable changes to Upstream Radar are documented here.
 - Include the standard Node-gyp Python/C++ toolchain in the disposable observer
   image so an explicitly approved native build is not confused with a plugin
   compatibility failure.
+
+### Live validation
+
+- Test nine exact public plugin artifacts against DSH `0.1.1-rc.1` in separate
+  disposable GitHub-hosted VMs: eight satisfy their recorded install contracts,
+  while OpenPencil is correctly stopped before execution because its Node
+  `>=24.11.0` contract excludes the Node 22 runner.
+- Prove the steady-state always-on path across 13 targets: no upstream changes,
+  no Agent invocation, no install matrix, and no timestamp-only state commit.
 
 ## [0.39.0] - 2026-08-21
 
@@ -163,8 +182,6 @@ All notable changes to Upstream Radar are documented here.
 
 ### Added
 
-- Import a commit-pinned, eight-repository cohort from `awesome-dsh-plugin`, monitor all eight source/lockfile streams, and add the six independently matched npm artifacts to the isolated DSH compatibility matrix.
-- Support explicit GitHub-only observer targets so repository-installed plugins are never silently mapped to an unrelated same-name npm package.
 - Add `observe --llm-env-file` as an explicit OpenAI-compatible issue-locator model entry point for installations that do not yet have a DSH Agent wrapper; model failures leave deterministic upstream tasks pending for retry.
 - Make the scheduled upstream-observer workflow optionally forward issue-locator model secrets without making static observation depend on an LLM configuration.
 - Show the concrete unresolved dependency edges behind an incomplete npm artifact review, and accept common `MODEL`/`CODEX_MODEL` env names for observer model calls.

--- a/README.md
+++ b/README.md
@@ -63,15 +63,15 @@ baseline report, and defined in [`schemas/upstream-downstream-ir.schema.json`](s
 
 ```bash
 # No DSH profile, API key, or network state required
-npx --yes upstream-radar@0.39.0 demo
+npx --yes upstream-radar@0.40.0 demo
 
 # Scan a public DSH plugin repository without installing it
-npx --yes upstream-radar@0.39.0 scan \
+npx --yes upstream-radar@0.40.0 scan \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --fail-on never
 
 # Review a real browser plugin users would install, then check two DSH releases
-npx --yes upstream-radar@0.39.0 review dsh-plugin dsh-cloudflare-browser-run@0.1.1 \
+npx --yes upstream-radar@0.40.0 review dsh-plugin dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
 
@@ -176,11 +176,11 @@ Two copies of `parser` are different nodes. An alert names the exact version and
 For a collection of saved reports, build the reverse index that turns an upstream package update into affected plugins:
 
 ```bash
-npx --yes upstream-radar@0.39.0 graph reverse ./reports \
+npx --yes upstream-radar@0.40.0 graph reverse ./reports \
   --output reverse-dependency-index.json
 
 # Ask: which plugins currently depend on this exact package?
-npx --yes upstream-radar@0.39.0 graph reverse ./reports \
+npx --yes upstream-radar@0.40.0 graph reverse ./reports \
   --package parser@2.9.0
 
 # Rebuild the checked-in index from the real first 50 DSH plugin reports
@@ -199,7 +199,7 @@ To route an upstream old → new change to that index, pass it to the always-on
 observer:
 
 ```bash
-npx --yes upstream-radar@0.39.0 observe ./targets.yml \
+npx --yes upstream-radar@0.40.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json \
   --report ./upstream-radar-observer.md
@@ -225,7 +225,7 @@ replay baseline → one Agent task → quiet run without network access.
 The repository already contains a reusable, composite Action in [`action.yml`](action.yml). It runs the same frozen Radar check in CI and writes a short Job Summary.
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.39.0
+- uses: MicroMilo/upstream-radar@v0.40.0
   with:
     config: upstream-radar.config.json
     fail-on: high
@@ -250,7 +250,7 @@ See the [consumer workflow](examples/github-actions/consumer/README.md) for conf
 pnpm add upstream-radar
 
 # Generate a reviewable DSH profile inventory from the installed profile
-npx --yes upstream-radar@0.39.0 setup
+npx --yes upstream-radar@0.40.0 setup
 ```
 
 For Feishu/webhook routing, DSH Agent handoff, observer state, report schemas, and troubleshooting, use the [full Chinese guide](docs/README.zh-CN.md). The [architecture notes](docs/architecture.md) explain the boundaries and evidence model.

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.39.0
+    default: 0.40.0
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -58,7 +58,7 @@ npx --yes upstream-radar@latest quickstart
 | 从 GitHub Actions 立即扫描 | [一次性扫描 workflow](../examples/github-actions/upstream-scan-minimal.yml) | 输入公开仓库 URL，马上看到结果并下载 JSON，不需要本地安装。 |
 | 审查一个精确的发布物 | `upstream-radar inspect <包名>@<精确版本> --deep` | 查看单个版本的包、依赖、漏洞和 provenance 证据。 |
 | 用两个 DSH 版本检查一个插件 | [可复制的 review workflow](../examples/github-actions/dsh-plugin-review-minimal.yml) | 输入 `package@version` 和两个 DSH 版本，同时得到发布物审计与真实 bundle-load 矩阵，不需要本地 DSH profile 或 LLM。 |
-| 在隔离环境真实安装/加载插件 | [隔离安装 workflow](../.github/workflows/observe-dsh-plugin-install.yml) | 每个插件使用一台新的 GitHub 托管虚拟机和受限容器，开启安装脚本并记录进程、联网、文件写入、登记和加载结果；模型密钥不会进入执行环境。 |
+| 在隔离环境真实安装/加载插件 | [隔离安装 workflow](../.github/workflows/observe-dsh-plugin-install.yml) | 每个插件使用一台新的 GitHub 托管虚拟机和受限容器；先核对发布包声明的 Node 版本，再按精确许可运行依赖构建，并记录进程、联网、文件写入、登记和加载结果；模型密钥不会进入执行环境。 |
 | 发布和维护 DSH 插件 | [插件作者路径](#dsh-插件作者) | 从真实 DSH 脚手架开始，先审查锁定的依赖图，再在用户安装前接入两步 CI 门禁。 |
 | 把变化通知到飞书 | [飞书与 HTTPS 通知](#飞书与-https-通知) | 原生飞书 V2 文本、只从环境读取密钥、持久确认和失败重试。 |
 
@@ -98,7 +98,7 @@ FIRST EPSS estimated exploitation probability: 97.2% (percentile 100.0%)
 想立即检查一个真实发布的 DSH 插件，可以在空目录直接运行：
 
 ```bash
-npx --yes upstream-radar@0.39.0 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.40.0 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 它会直接输出简短的准入结论、覆盖情况、依赖数量、漏洞数量和下一步，不需要先
@@ -111,7 +111,7 @@ npx --yes upstream-radar@0.39.0 inspect dsh-feishu-bot@0.15.8 --deep
 npm 解析环境中目前无法建立完整依赖图：
 
 ```bash
-npx --yes upstream-radar@0.39.0 inspect \
+npx --yes upstream-radar@0.40.0 inspect \
   @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
   --deep --fail-on never
 ```
@@ -336,9 +336,9 @@ npm：     dsh-feishu-bot@0.15.8
 会继续显示为 `incomplete`，不会被当成已经确认的故障。
 
 ```bash
-npx --yes upstream-radar@0.39.0 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.40.0 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.39.0 observe ./targets.yml \
+npx --yes upstream-radar@0.40.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -376,7 +376,7 @@ Radar 会在三层目录内自动找到它；npm 名称和源码 manifest 不一
 想明确选择锁文件时再加 `--lockfile`：
 
 ```bash
-npx --yes upstream-radar@0.39.0 observe \
+npx --yes upstream-radar@0.40.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -399,7 +399,7 @@ workspace 边保留为未解析证据；不会安装或启动 DSH。
 会额外指定 `--package`：
 
 ```bash
-npx --yes upstream-radar@0.39.0 observe \
+npx --yes upstream-radar@0.40.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -677,7 +677,7 @@ cd my-dsh-plugin
 pnpm install --ignore-scripts
 
 # 把插件放进 DSH profile 前，先读取精确依赖图。
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
 ```
 
 这棵图会保留精确的 DSH 包版本，也会把未解析的可选 peer 明确显示出来；它不会加载生成的插件，也不会运行 lifecycle script。审查后，把下面这个完整 workflow 复制到 `.github/workflows/upstream-radar.yml`：
@@ -699,7 +699,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.39.0
+      - uses: MicroMilo/upstream-radar@v0.40.0
         with:
           fail-on: high
           fail-on-compatibility: breaking
@@ -710,7 +710,7 @@ Action 会自动识别唯一的 `pnpm-lock.yaml`，检查同一棵精确依赖�
 也可以直接检查一个真实发布的 DSH 包：
 
 ```bash
-npx --yes upstream-radar@0.39.0 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.40.0 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 这次检查的结论是 `REVIEW`：registry 完整性、签名、provenance 和 89 个已解析包都
@@ -723,7 +723,7 @@ npx --yes upstream-radar@0.39.0 inspect dsh-feishu-bot@0.15.8 --deep
 如果不想分别执行 `inspect`、打包和 `probe`，可以用一个命令完成一次 DSH 插件审查：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar review dsh-plugin \
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar review dsh-plugin \
   dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
@@ -889,7 +889,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -902,7 +902,7 @@ pnpm dlx --package=upstream-radar@0.39.0 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -928,7 +928,7 @@ pnpm run showcase:dsh-probe
 如果要比较多个 DSH 版本，可以使用矩阵入口：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -946,7 +946,7 @@ JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.39.0
+  - uses: MicroMilo/upstream-radar@v0.40.0
     with:
       fail-on: high
       # 可选：把确定性的 DSH/插件兼容性破坏也作为 CI 失败条件
@@ -955,12 +955,12 @@ steps:
       threat-intel: true
 ```
 
-这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。`threat-intel` 默认是 `false`，这样普通 CI 门禁不会因为额外查询变重；设置为 `true` 后，Job Summary 和原始 JSON 会包含 CISA KEV 与 FIRST EPSS 的优先级证据。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。除了原始 JSON 日志，Action 还会把经过转义的简短摘要写入 GitHub Job Summary，定时任务失败时可以直接看到受影响的包、准确依赖路径、已经发布的修复版本（如果有）、一行优先级证据和建议的下一步。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.39.0` 的发布标签，并根据团队策略固定 checkout Action。
+这个 Action 只是 `radar check --frozen --state :memory: --fail-on high --fail-on-compatibility breaking --json` 的薄封装。`--frozen` 是有意的：它只使用配置文件里的依赖图，不会尝试读取 runner 上不存在的本地 DSH profile。`threat-intel` 默认是 `false`，这样普通 CI 门禁不会因为额外查询变重；设置为 `true` 后，Job Summary 和原始 JSON 会包含 CISA KEV 与 FIRST EPSS 的优先级证据。每次运行彼此独立；发现达到阈值的漏洞或选择的兼容性变化时返回 `2`，运行或漏洞源出错时返回 `1`。`breaking` 只拦截有 confirmed/strong 信号的兼容性事件，`any` 会拦截所有活动兼容性事件，默认值是 `never`。除了原始 JSON 日志，Action 还会把经过转义的简短摘要写入 GitHub Job Summary，定时任务失败时可以直接看到受影响的包、准确依赖路径、已经发布的修复版本（如果有）、一行优先级证据和建议的下一步。这个入口不会投递 DSH Agent 任务，也不会修改分支；需要持续监控和项目级分析时，仍使用原生 DSH bundle。建议把 Action 固定到类似 `v0.40.0` 的发布标签，并根据团队策略固定 checkout Action。
 
 如果仓库还没有提交 Radar 配置，最短接入方式是省略 `config`、`pnpm-lock` 和 `npm-lock`。checkout 之后，Action 会自动使用唯一存在的 `pnpm-lock.yaml` 或 `package-lock.json`，生成临时的审查清单，再执行同一个 frozen 检查：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.39.0
+- uses: MicroMilo/upstream-radar@v0.40.0
   with:
     fail-on: high
 ```
@@ -970,7 +970,7 @@ steps:
 如果要在插件进入 DSH 前审查精确发布物，可以增加 `inspect-package`：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.39.0
+- uses: MicroMilo/upstream-radar@v0.40.0
   with:
     inspect-package: dsh-cloudflare-browser-run@0.1.1
     # review 是安全默认值；只有允许覆盖不完整时才使用 block
@@ -982,7 +982,7 @@ steps:
 如果仓库只有 pnpm 锁文件，还没有提交 Radar 配置，可以让 Action 在同一个 job 中生成配置；可直接复制[pnpm workflow 示例](../examples/github-actions/upstream-radar-pnpm.yml)：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.39.0
+- uses: MicroMilo/upstream-radar@v0.40.0
   with:
     pnpm-lock: pnpm-lock.yaml
     fail-on: high
@@ -996,7 +996,7 @@ npm 项目可以改用 `npm-lock: package-lock.json`；`pnpm-lock` 和 `npm-lock
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -1004,7 +1004,7 @@ pnpm dlx --package=upstream-radar@0.39.0 upstream-radar radar check \
 如果还要检查一个已发布插件能否跨多个 DSH 版本加载，可以增加三个 input：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.39.0
+- uses: MicroMilo/upstream-radar@v0.40.0
   id: radar
   with:
     config: upstream-radar.config.json

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -210,7 +210,7 @@ When the native DSH adapter is running, it additionally verifies the exact `@dee
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -224,7 +224,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.39.0
+  - uses: MicroMilo/upstream-radar@v0.40.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -257,7 +257,7 @@ It packs without lifecycle scripts, runs one temporary DSH profile per version, 
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -271,7 +271,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```

--- a/examples/dsh/install-observer/reports/2026-08-21-dsh-0.1.1-rc.1.md
+++ b/examples/dsh/install-observer/reports/2026-08-21-dsh-0.1.1-rc.1.md
@@ -14,11 +14,11 @@ Runtime for these checks: Node `22.23.2`, pnpm `11.7.0`, Linux x64. DSH
 | `dsh-wsl-workspace@0.2.3` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install/load traces captured | [Actions run 32462817936](https://github.com/MicroMilo/upstream-radar/actions/runs/32462817936) |
 | `dsh-feishu-bot@0.16.0` + DSH `0.1.1-rc.1`, `allowBuilds: [protobufjs]` | Installed, registered, and loaded under the plugin's documented build policy; install trace truncated, load trace captured | [Actions run 32463552879](https://github.com/MicroMilo/upstream-radar/actions/runs/32463552879) |
 | `@nanmicoder/dsh-agent-teams@0.1.10` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install/load traces captured | [Actions run 32467123465](https://github.com/MicroMilo/upstream-radar/actions/runs/32467123465) |
-| `dsh-better-sidebar@0.14.0` + DSH `0.1.1-rc.1`, `allowBuilds: [node-pty]` | Native dependency built; plugin installed, registered, and loaded; install trace truncated, load trace captured | [Actions run 32467779335](https://github.com/MicroMilo/upstream-radar/actions/runs/32467779335) |
+| `dsh-better-sidebar@0.14.0` + DSH `0.1.1-rc.1`, `allowBuilds: [node-pty]` | Native dependency built; plugin installed, registered, and loaded; install trace truncated, load trace captured | [main Actions run 32468315353](https://github.com/MicroMilo/upstream-radar/actions/runs/32468315353) |
 | `dsh-context@0.20.0` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install trace truncated, load trace captured | [Actions run 32467128011](https://github.com/MicroMilo/upstream-radar/actions/runs/32467128011) |
 | `dsh-cost-meter@1.5.31` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install trace truncated, load trace captured | [Actions run 32467130872](https://github.com/MicroMilo/upstream-radar/actions/runs/32467130872) |
 | `dshmarket@1.17.1` + DSH `0.1.1-rc.1` | Installed, registered, and loaded; install trace truncated, load trace captured | [Actions run 32467133279](https://github.com/MicroMilo/upstream-radar/actions/runs/32467133279) |
-| `@zseven-w/dsh-openpencil@0.1.0-rc.1` + DSH `0.1.1-rc.1` | `runtime-incompatible`: package requires Node `>=24.11.0`, runner provides Node `22.23.2`; no plugin/dependency code executed | [Actions run 32467600598](https://github.com/MicroMilo/upstream-radar/actions/runs/32467600598) |
+| `@zseven-w/dsh-openpencil@0.1.0-rc.1` + DSH `0.1.1-rc.1` | `runtime-incompatible`: package requires Node `>=24.11.0`, runner provides Node `22.23.2`; no plugin/dependency code executed | [main Actions run 32468313387](https://github.com/MicroMilo/upstream-radar/actions/runs/32468313387) |
 | `dsh-feishu-bot@0.16.0` raw `dsh plugin add` control | Install stopped before registration because no dependency build was approved | [Actions run 32462812288](https://github.com/MicroMilo/upstream-radar/actions/runs/32462812288) |
 
 ## Feishu install-contract control
@@ -80,7 +80,7 @@ three observations remain available as separate evidence:
 
 - [no build approved](https://github.com/MicroMilo/upstream-radar/actions/runs/32467125435);
 - [`node-pty` approved but observer toolchain absent](https://github.com/MicroMilo/upstream-radar/actions/runs/32467603173); and
-- [`node-pty` approved with the declared build baseline](https://github.com/MicroMilo/upstream-radar/actions/runs/32467779335).
+- [`node-pty` approved with the declared build baseline on `main`](https://github.com/MicroMilo/upstream-radar/actions/runs/32468315353).
 
 ### OpenPencil: successful loading did not satisfy the package contract
 
@@ -97,6 +97,15 @@ before DSH initialization, dependency scripts, installation, or plugin loading.
 The corrected run reports `runtime-incompatible` and leaves all execution stages
 skipped. It does not claim the plugin is broken on Node 24; it says this exact
 Node 22 pair is outside the package's declared contract.
+
+## Always-on steady-state control
+
+After the cohort baseline was persisted, the
+[next scheduled-path run](https://github.com/MicroMilo/upstream-radar/actions/runs/32468490401)
+checked all 13 upstream targets and the 37-plugin reverse index. It produced
+`changes: []`, no pending tasks, zero Agent attempts, an empty install matrix,
+no errors, and no state commit. This proves the expensive and code-executing
+lanes stay asleep when exact observed coordinates have not changed.
 
 ## Evidence boundary
 

--- a/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
+++ b/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
@@ -19,7 +19,7 @@ From a clean checkout, the finding is reproducible without installing or
 executing the plugin:
 
 ```bash
-npx --yes upstream-radar@0.39.0 scan . --json
+npx --yes upstream-radar@0.40.0 scan . --json
 ```
 
 The current static scan reports:

--- a/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
+++ b/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
@@ -43,5 +43,5 @@ graph, the unresolved peer boundary, the vulnerability result, and the two
 remaining review actions in one report.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.39.0`. Review the Draft PR before relying on the fallback
+`upstream-radar@0.40.0`. Review the Draft PR before relying on the fallback
 resolver from npm.

--- a/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
+++ b/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
@@ -21,7 +21,7 @@ Reproduce it with:
 
 ```bash
 npm pack --ignore-scripts --pack-destination /tmp dsh-feishu-bot@0.15.4
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar probe dsh-matrix \
   /tmp/dsh-feishu-bot-0.15.4.tgz \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```

--- a/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
+++ b/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
@@ -8,7 +8,7 @@ graph without installing anything.
 ## Reproduction
 
 ```bash
-npx --yes upstream-radar@0.39.0 scan \
+npx --yes upstream-radar@0.40.0 scan \
   https://github.com/2008924/dsh-progress-viz \
   --fail-on never
 ```
@@ -22,7 +22,7 @@ query an advisory service, or call an LLM.
 
 ```text
 Reading 2008924/dsh-progress-viz (plugin directory: plugin) without installing dependencies or running code...
-Upstream Radar 0.39.0
+Upstream Radar 0.40.0
 Target: dsh-progress-viz-plugin@0.1.0
 Artifact: sha256:c9b6b2dc31a458b480587f6200772fe72d4af5451b1e71d41594c5017be929c5
 DSH bundle: yes (./cordis.patch.yml)

--- a/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
+++ b/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
@@ -13,11 +13,11 @@ No DSH profile, plugin code, lifecycle script, or LLM was started.
 ## Commands
 
 ```bash
-npx --yes upstream-radar@0.39.0 scan \
+npx --yes upstream-radar@0.40.0 scan \
   https://github.com/ccch1mneyyy/dsh-TUI \
   --fail-on never
 
-npx --yes upstream-radar@0.39.0 inspect \
+npx --yes upstream-radar@0.40.0 inspect \
   npm:@deepseek-harness-tui/dsh-tui@0.8.0 \
   --deep --fail-on never
 ```

--- a/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
+++ b/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
@@ -8,7 +8,7 @@ release.
 ## Rechecked with the public CLI
 
 Each repository was cloned at its current public `main` commit and scanned with
-`upstream-radar@0.39.0`. No package was installed, loaded, or executed.
+`upstream-radar@0.40.0`. No package was installed, loaded, or executed.
 
 | Repository | Commit | `package.json` | `package-lock.json` root | Result |
 | --- | --- | ---: | ---: | --- |

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -40,7 +40,7 @@ The optional probe is load-only. It packs with `--ignore-scripts`, uses a tempor
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.39.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.40.0 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.39.0
+      - uses: MicroMilo/upstream-radar@v0.40.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/dsh-plugin-review-minimal.yml
+++ b/examples/github-actions/dsh-plugin-review-minimal.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.39.0
+        uses: MicroMilo/upstream-radar@v0.40.0
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/examples/github-actions/upstream-observer-minimal.yml
+++ b/examples/github-actions/upstream-observer-minimal.yml
@@ -53,7 +53,7 @@ jobs:
           llm_env_file="$RUNNER_TEMP/issue-locator.env"
           trap 'rm -f "$llm_env_file"' EXIT
           observe_args=(
-            npx --yes upstream-radar@0.39.0 observe "$repository"
+            npx --yes upstream-radar@0.40.0 observe "$repository"
             --ref "$ref"
             --state observations.json
             --report "$report"

--- a/examples/github-actions/upstream-radar-npm.yml
+++ b/examples/github-actions/upstream-radar-npm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.39.0
+      - uses: MicroMilo/upstream-radar@v0.40.0
         with:
           npm-lock: package-lock.json
           fail-on: high

--- a/examples/github-actions/upstream-radar-pnpm.yml
+++ b/examples/github-actions/upstream-radar-pnpm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.39.0
+      - uses: MicroMilo/upstream-radar@v0.40.0
         with:
           pnpm-lock: pnpm-lock.yaml
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.39.0
+      - uses: MicroMilo/upstream-radar@v0.40.0
         with:
           # The Action auto-detects one pnpm-lock.yaml or package-lock.json.
           fail-on: high

--- a/examples/github-actions/upstream-scan-minimal.yml
+++ b/examples/github-actions/upstream-scan-minimal.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           report="$RUNNER_TEMP/upstream-radar-scan.json"
-          npx --yes upstream-radar@0.39.0 scan \
+          npx --yes upstream-radar@0.40.0 scan \
             "$OBSERVER_REPOSITORY_INPUT" \
             --json --fail-on never > "$report"
           if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/examples/upstream-observer/README.md
+++ b/examples/upstream-observer/README.md
@@ -24,7 +24,7 @@ Replace it with the repositories your team depends on.
 For one repository, the shortest path skips YAML and lockfile configuration entirely:
 
 ```bash
-npx --yes upstream-radar@0.39.0 observe \
+npx --yes upstream-radar@0.40.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -35,7 +35,7 @@ Radar automatically chooses the committed `pnpm-lock.yaml` or
 the explicit form below adds `--package`:
 
 ```bash
-npx --yes upstream-radar@0.39.0 observe \
+npx --yes upstream-radar@0.40.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -75,9 +75,9 @@ Build one index from saved DSH plugin scan/review/config JSON, then give it to
 the observer:
 
 ```bash
-npx --yes upstream-radar@0.39.0 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.40.0 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.39.0 observe ./targets.yml \
+npx --yes upstream-radar@0.40.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -99,7 +99,7 @@ and run `pnpm run showcase:observer` to replay a real
 The scheduled workflow uses the checked-in index directly:
 
 ```bash
-npx --yes upstream-radar@0.39.0 observe ./targets.yml \
+npx --yes upstream-radar@0.40.0 observe ./targets.yml \
   --reverse-index ../dsh/first-batch/reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -126,7 +126,7 @@ Run it from any directory with the published CLI:
 
 ```bash
 export GITHUB_TOKEN='a read-only token with repository metadata access'
-npx --yes upstream-radar@0.39.0 observe \
+npx --yes upstream-radar@0.40.0 observe \
   /path/to/targets.yml \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md

--- a/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
+++ b/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
@@ -30,5 +30,5 @@ than silently monitoring the repository root. Local `workspace:` links remain
 explicitly unresolved; Radar does not guess their published versions.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.39.0`. Review the Draft PR before using the auto-discovery
+`upstream-radar@0.40.0`. Review the Draft PR before using the auto-discovery
 path from npm.

--- a/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
+++ b/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
@@ -10,12 +10,12 @@ The baseline was taken at the commit that produced the published `0.5.4`
 artifact, then the same state was checked against the current `master`:
 
 ```bash
-npx --yes upstream-radar@0.39.0 observe \
+npx --yes upstream-radar@0.40.0 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref aa5f4efc7827176cce27c73f73a2f42514da1ebf \
   --state observations.json --report baseline.md --json
 
-npx --yes upstream-radar@0.39.0 observe \
+npx --yes upstream-radar@0.40.0 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref master \
   --state observations.json --report repair.md --json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Always-on dependency and compatibility monitoring for DeepSeek Harness plugins, including exact paths, upstream changes, and isolated install/load evidence.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.39.0'
+export const TOOL_VERSION = '0.40.0'

--- a/test/release-preflight.test.ts
+++ b/test/release-preflight.test.ts
@@ -23,7 +23,7 @@ describe('release preflight', () => {
       checks: Array<{ status: string }>
     }
     assert.equal(report.schema, 'upstream-radar.release-preflight/v1alpha1')
-    assert.equal(report.version, '0.39.0')
+    assert.equal(report.version, '0.40.0')
     assert.equal(report.passed, true)
     assert.equal(report.publishedCheck, false)
     assert.ok(report.checks.length >= 4)


### PR DESCRIPTION
## 0.40.0

- publish the commit-pinned awesome-dsh-plugin monitoring cohort
- publish exact plugin Node runtime-contract enforcement before code execution
- publish Better Sidebar native-build baseline and exact node-pty approval
- link the main-branch nine-plugin evidence and always-on quiet control
- advance copyable npm and GitHub Action pins to 0.40.0

## Verified

- 299/299 tests
- release preflight passed
- OpenPencil main proof: https://github.com/MicroMilo/upstream-radar/actions/runs/32468313387
- Better Sidebar main proof: https://github.com/MicroMilo/upstream-radar/actions/runs/32468315353
- quiet always-on proof: https://github.com/MicroMilo/upstream-radar/actions/runs/32468490401