### PR TITLE
fix: accept npm wildcard peer ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Upstream Radar are documented here.
 
 ### Closed-loop compatibility incidents
 
+- Evaluate npm's bare `*` peer range as an explicit match instead of an
+  indeterminate contract, preventing resolved wildcard peers from creating a
+  daily observer failure.
 - Reconcile actionable isolated DSH incompatibilities into one managed GitHub
   issue per stable target/runtime cell. Persistent failures update the same
   issue, regressions reopen it, and a compatible retest comments and closes it.

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -112,7 +112,12 @@ export function satisfiesSemverRange(versionValue: string, rangeValue: string): 
   const version = parseSemver(versionValue)
   if (version === undefined) return undefined
   const normalized = rangeValue.trim().replace(/^workspace:/, '')
-  if (normalized === '^' || normalized === '~' || normalized === '*') return undefined
+  // npm's bare wildcard is an explicit unconstrained range. Treating it as
+  // indeterminate made every resolved `peerDependencies: { name: "*" }`
+  // contract look like missing evidence even though any semantic version is
+  // a mathematical match.
+  if (normalized === '*') return true
+  if (normalized === '^' || normalized === '~') return undefined
   let sawUnknown = false
   for (const branch of normalized.split('||')) {
     const result = branchMatches(version, branch)

--- a/test/semver.test.ts
+++ b/test/semver.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { satisfiesSemverRange } from '../src/semver.js'
+
+describe('semantic version ranges', () => {
+  it('treats the npm bare wildcard as an explicit match', () => {
+    assert.equal(satisfiesSemverRange('4.0.1', '*'), true)
+    assert.equal(satisfiesSemverRange('0.1.1-rc.2', '*'), true)
+    assert.equal(satisfiesSemverRange('not-a-version', '*'), undefined)
+  })
+})


### PR DESCRIPTION
## What changed

- Treat the npm bare wildcard peer range as an explicit semantic-version match.
- Add regression coverage for stable and prerelease versions.
- Prevent resolved wildcard peers from becoming daily unknown DSH observations.

## Evidence

The first live compatibility run resolved all six dsh-wsl-workspace 0.2.3 peers to concrete DSH versions, but Radar marked every wildcard range indeterminate. All 329 tests pass with this fix.