### PR TITLE
docs: finalize the 0.41.0 release evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Upstream Radar are documented here.
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-08-23
+
 ### Closed-loop compatibility incidents
 
 - Evaluate npm's bare `*` peer range as an explicit match instead of an
@@ -35,8 +37,6 @@ All notable changes to Upstream Radar are documented here.
   reproduced runtime crash.
 - Maintain the OpenPencil cell on Node 24, matching its published Node engine,
   and add a reproducible current-DSH contract-drift case.
-
-## [0.41.0] - 2026-08-21
 
 ### Continuously reconciled DSH compatibility
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -122,7 +122,8 @@ profile、插件执行或 LLM。完整证据见[作者修复报告](../examples/
 这条案例已经闭环：维护者确认了宿主依赖约定，并提交了[修复
 `8b32828`](https://github.com/Sanqi-normal/dsh-webui-market-plugin/commit/8b328289ce5268451bd4414fa3ae41ee2f515649)；
 我在该源码提交上用禁用脚本的干净解析重新验证，已经不再拉取 `dsh-compact`。
-npm 发布物还没有更新，所以报告仍明确区分“源码已修复”和“发布版本待跟进”。
+后续发布的 `0.5.5` 也已用精确 npm tarball 复核：严格依赖解析建立了 69 个包的
+完整必需依赖图，原 issue 已作为“发布物修复验证通过”关闭。
 
 如果你手里的是公开 DSH 插件仓库，不需要先手动 clone：
 
@@ -408,8 +409,9 @@ npx --yes upstream-radar@0.41.0 observe \
 
 提交的 targets 示例还包含一个没有锁文件的真实案例
 [`Sanqi-normal/dsh-webui-market-plugin`](../examples/upstream-observer/targets.yml)。
-它的 peer 修复先进入源码，npm 仍是 `0.5.4` 时 observer 不会冒充“发布物已修复”，
-而是留下待处理任务；完整结果见[observer 重放报告](../examples/upstream-observer/reports/sanqi-maintainer-repair-live.md)。
+它的 peer 修复先进入源码、npm 仍是 `0.5.4` 时，observer 没有冒充“发布物已修复”，
+而是留下待处理任务；`0.5.5` 发布后又进入 maintained isolated matrix。完整时间线见
+[observer 重放报告](../examples/upstream-observer/reports/sanqi-maintainer-repair-live.md)。
 
 执行一次检查：
 

--- a/examples/dsh/reports/sanqi-market-plugin-dependency-resolution.md
+++ b/examples/dsh/reports/sanqi-market-plugin-dependency-resolution.md
@@ -108,8 +108,9 @@ The clean resolver completed successfully and selected:
 @deepseek-ai/dsh-compact           absent
 ```
 
-The npm `latest` tag is still `0.5.4`, so the exact published artifact analysed
-above remains the pre-fix release until the maintainer publishes the source
-fix. This is now a complete feedback loop with a clear release follow-up:
-Radar found the unresolvable path, the author confirmed and fixed it, and the
-repair is independently re-checkable before release.
+The analysis above records the pre-fix `0.5.4` artifact. The maintainer later
+published `0.5.5`; Radar verified its exact tarball in a fresh scripts-disabled
+strict resolution. The required graph now resolves 69 packages and no longer
+reaches `@deepseek-ai/dsh-compact`, so the original author issue was closed as
+verified resolved. Web-client versus headless host-contract coverage is tracked
+separately and does not rewrite this publication result.

--- a/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
+++ b/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
@@ -1,5 +1,9 @@
 # Live observer replay: maintainer repair before npm release
 
+> Follow-up, 2026-08-23: version `0.5.5` is now published. Its exact tarball
+> completes strict dependency resolution without `@deepseek-ai/dsh-compact`
+> and has joined the maintained isolated matrix. The original issue is closed.
+
 This is a real old → new observer run for
 `@sanqi-normal/dsh-webui-market-plugin`. It demonstrates the useful case where
 the source repository is fixed before the npm artifact is republished.
@@ -57,8 +61,8 @@ The model endpoint returned HTTP 404 on every supported OpenAI-compatible path,
 so Radar kept the task pending and wrote no model conclusion. The static result
 remains usable without a model; a later scheduled run can retry the same task.
 
-The npm `latest` tag remains `0.5.4`, so the next scheduled observer run will
-detect the release separately. This is the intended always-on loop:
+At the time of this replay, npm `latest` remained `0.5.4`. The later `0.5.5`
+publication was detected and checked separately, completing the intended loop:
 
 ```text
 maintainer source fix


### PR DESCRIPTION
## Summary

- Move the compatibility ledger, IR, and managed incident loop into the 0.41.0 release section.
- Update the Sanqi case from source-fix pending to exact 0.5.5 artifact verified.
- Preserve the historical observer replay while adding its completed follow-up.

## Verification

Release preflight passes, including package contents and a fresh offline consumer smoke.