### PR TITLE
docs: sharpen the bilingual compatibility story

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,164 +1,92 @@
-# Upstream Radar
+<h1 align="center">Upstream Radar</h1>
 
-[![CI](https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml/badge.svg)](https://github.com/MicroMilo/upstream-radar/actions)
-[![npm](https://img.shields.io/npm/v/upstream-radar)](https://www.npmjs.com/package/upstream-radar)
-[![GitHub stars](https://img.shields.io/github/stars/MicroMilo/upstream-radar)](https://github.com/MicroMilo/upstream-radar/stargazers)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+<p align="center"><strong>Know which DeepSeek Harness plugins break after every release—before users do.</strong></p>
 
-**Compatibility evidence for the [DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness) plugin ecosystem.**
+<p align="center">
+  English · <a href="README.zh-CN.md">简体中文</a>
+</p>
 
-A plugin repository can look healthy while its published artifact has drifted
-from the DSH host it actually runs in. Upstream Radar joins what a plugin
-declares with what an isolated DSH profile really resolves, then keeps that
-relationship current as DSH and plugins change.
+<p align="center">
+  <a href="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://www.npmjs.com/package/upstream-radar"><img alt="npm" src="https://img.shields.io/npm/v/upstream-radar"></a>
+  <a href="https://github.com/MicroMilo/upstream-radar/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/MicroMilo/upstream-radar"></a>
+  <a href="LICENSE"><img alt="Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
+</p>
 
-The core object is an exact environment, not a package name or a diff:
+Upstream Radar continuously retests a maintained fleet of exact published
+plugins against changing
+[DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness)
+releases in disposable runners. When a pair breaks, it produces a reproducible
+issue; when the author ships a fix, it retests and closes the loop.
 
-```text
-plugin tarball SHA-256 × DSH version × Node/pnpm baseline × approved dependency builds
-```
+**10 maintained plugin artifacts · 37 real dependency graphs · 1,025 dependency coordinates · 4 upstream reports closed**
 
-## How the system fits together
+## Why it exists
+
+A healthy repository does not prove that its published plugin still works.
+The artifact users install must resolve against a specific DSH host, Node
+runtime, profile, and dependency set—and any of them can change overnight.
+
+Upstream Radar checks the relationship, not just the two repositories. A local
+pre-publish check asks, “does this plugin pass today?” Radar asks, “which
+maintained plugins stopped passing after the ecosystem changed?”
+
+## The loop
 
 ```mermaid
 flowchart TB
-  Artifact["Exact plugin tarball"] --> Static["Static: peer declaration + literal import evidence"]
-  DSH["Exact DSH + Node runtime"] --> Runtime["Fresh VM + restricted container"]
-  Static --> Runtime
-  Runtime --> Resolve["Dynamic: install → register → profile resolver → import → headless boot"]
-  Resolve --> IR["Compatibility IR: declared range ↔ resolved host version"]
-  IR --> Ledger["Current-cell ledger"]
-  IR --> Impact["Reverse impact index + author-facing repair"]
-  Ledger --> Incident["Managed compatibility incident"]
-  Incident --> Repair["Plugin or DSH repair"]
-  Repair --> Artifact
+  Schedule["Scheduled GitHub Action"] --> Watch["Watch DSH + plugin releases"]
+  Watch --> Matrix["Exact plugin × DSH matrix"]
+  Matrix --> Static["Static contract checks"]
+  Matrix --> Runtime["Disposable runner: install → register → load"]
+  Static --> Evidence["Reproducible compatibility evidence"]
+  Runtime --> Evidence
+  Evidence --> Issue["One fixable issue"]
+  Issue --> Fix["Author publishes a fix"]
+  Fix --> Watch
 ```
 
-Radar establishes deterministic facts; an optional Agent may explain project
-impact afterward. A model never decides whether versions match or turns missing
-evidence into a green result.
+Radar establishes the result with deterministic evidence. An optional DSH
+Agent can explain impact and suggest the next action, but a model never turns
+missing evidence into a pass.
 
-## What it answers
+## What you get
 
-| Question | Evidence returned |
-| --- | --- |
-| Does the declared plugin contract align with this DSH release? | Exact tarball, Node contract, install/registration/load evidence, and every direct peer's resolved host version. |
-| Is it a runtime break or a declaration drift? | Static literal-import classification beside the dynamic resolver result. |
-| What enters the DSH profile? | Exact npm/pnpm nodes, host-plane joins, duplicate versions, paths, and unresolved edges. |
-| Which plugins are exposed to an upstream dependency change? | A materialized reverse index from host package to exact plugin cells. |
-| What can the author repair? | One package/range/API boundary with the evidence needed to reproduce it. |
-| What happens after a break is found? | One managed issue is created, updated on repeat failures, reopened on regression, and closed only after a clean retest. |
+- An exact result for `plugin version × DSH version × Node/profile`, not a
+  timeless “compatible” badge.
+- Static dependency and peer-contract checks joined with real
+  install/register/load evidence from the published artifact.
+- A maintained result that is retested when DSH or the plugin changes.
+- One managed issue that is updated on repeat failures, reopened on regression,
+  and closed after a clean retest.
 
-## Proven on real DSH plugins
+## Upstream reports now closed
 
-- Imported a commit-pinned cohort of **8 repositories** from
-  [`awesome-dsh-plugin`](examples/dsh/awesome-observer/README.md); 6 independently
-  matched npm artifacts enter the isolated matrix and 2 remain correctly
-  GitHub-only.
-- In a fresh VM, tested `@zseven-w/dsh-openpencil@0.1.0-rc.1` against current
-  DSH `0.1.1-rc.1` on Node 24. Install, registration, direct import, and
-  headless boot passed; the exact host-contract check found **12/14** peers
-  aligned, one type-only peer declaration missing, and one runtime `react-dom`
-  range drift. [Read the reproducible case.](examples/dsh/install-observer/reports/2026-08-22-openpencil-node24.md)
-- Proved `dsh-better-sidebar@0.14.0` succeeds only after the documented
-  `node-pty` build is explicitly approved and the native toolchain is present.
-- Found that `@sanqi-normal/dsh-webui-market-plugin@0.5.4` could not form a
-  clean DSH dependency graph, gave the author an exact repair path, and added
-  the published `0.5.5` repair to the maintained isolated matrix.
-  [See the author-confirmed case.](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
-- Built a reverse index from **37 real plugin graphs and 1,025 dependency
-  coordinates**, while preserving 13 missing-graph targets as evidence gaps.
+We opened the following reports; their upstream maintainers have now closed
+them:
 
-Read the [live isolated matrix and negative controls](examples/dsh/install-observer/reports/2026-08-21-dsh-0.1.1-rc.1.md)
-or inspect the [first 50-plugin corpus](examples/dsh/first-batch/README.md).
+- [Sanqi-normal/dsh-webui-market-plugin#5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
+- [1na-ko/dsh-hdc-bridge#3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
+- [6Mikao9/dsh-wsl-workspace#6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
+- [3274375092/dsh-voice#2](https://github.com/3274375092/dsh-voice/issues/2)
 
-## Try it in 60 seconds
+## Run one check
 
 ```bash
-# Network-free product walkthrough
-npx --yes upstream-radar@0.41.0 demo
-
-# Static review of a public DSH plugin; no install or plugin execution
-npx --yes upstream-radar@0.41.0 scan \
-  https://github.com/PlutoKeating/dsh-lark-bot \
-  --fail-on never
-
-# Exact artifact review plus a DSH load matrix
 npx --yes upstream-radar@0.41.0 review dsh-plugin \
-  dsh-cloudflare-browser-run@0.1.3 \
-  --dsh-version 0.1.0-rc.8,0.1.1-rc.1
+  <package>@<version> \
+  --dsh-version <dsh-version>
 ```
 
-The code-executing path is deliberately separate. Run **Actions → Observe one
-DSH plugin install** to give one exact pair its own secret-free GitHub-hosted VM
-and restricted container.
+For code-executing checks, use the maintained
+[isolated observer workflow](.github/workflows/observe-dsh-plugin-install.yml):
+each pair receives a fresh, secret-free GitHub-hosted VM and restricted
+container.
 
-## Always-on now
+Inspect the [live compatibility matrix](examples/dsh/install-observer/README.md),
+the [first 50-plugin corpus](examples/dsh/first-batch/README.md), or the
+[architecture notes](docs/architecture.md).
 
-The scheduled observer watches DSH, plugin source/npm/lockfile evidence every
-day, then reconciles a checked-in **compatibility ledger** against the desired
-current matrix. An isolated run is selected when its exact cell is missing,
-older than seven days, or invalidated by a DSH/plugin coordinate, source graph,
-runtime, or build-policy change. A package update therefore accelerates a
-retest; it is no longer the only trigger.
-
-Every report must prove its exact plugin × DSH × Node runtime × build-approval
-cell before it can update the [ledger](compatibility-ledger.json). The Action
-also materializes a bounded [compatibility IR](compatibility-ir.json) and
-[reverse index](compatibility-reverse-index.json). The IR does not copy the
-entire pnpm tree: it preserves the compatibility frontier—the plugin's declared
-non-optional peer range, static use evidence, and concrete package version that
-the final DSH profile resolves.
-
-A Node-engine mismatch stops before plugin execution; a maintained target can
-also select its required Node profile explicitly. The profile lockfile and
-effective profile-plus-DSH-host graph are compared on every retest. An
-install/load green result cannot close a cell while a required direct host peer
-is missing, outside its declared range, or indeterminate.
-
-When all cells are current, the runtime lane stays quiet. Missing or malformed
-reports never turn green: they remain unsatisfied and are selected again.
-
-Actionable incompatibilities become managed issues in the Radar repository.
-The same stable cell owns the issue across plugin and DSH releases: repeated
-failures update it, a regression reopens it, and a later compatible isolated
-run comments with fresh evidence and closes it. `unknown` is deliberately not
-an accusation against a plugin; it fails the observer lane and waits for a
-trustworthy rerun instead of opening an incident.
-
-## Safety boundary
-
-| Radar does | Radar does not claim |
-| --- | --- |
-| Static graph and artifact checks without importing plugin code | An empty finding list proves safety |
-| Dynamic checks in a fresh VM and restricted, secret-free container | A shared-kernel container proves hostile code is harmless |
-| Exact-version advisory matching and dependency paths | Every matched plugin is exploitable |
-| Exact-pair compatibility results with explicit coverage | One successful load covers every plugin business action |
-
-An external symlink in a DSH profile never expands static read scope. Radar only
-uses an outside host plane after it has been discovered from the verified DSH
-process that is actually running the profile.
-
-## Use it in DSH or CI
-
-```bash
-# Generate a reviewable DSH inventory and wiring
-npx --yes upstream-radar@0.41.0 setup
-```
-
-The repository also ships a [reusable GitHub Action](action.yml), maintained
-[observer workflow](.github/workflows/upstream-observer.yml), and machine-readable
-[schemas](schemas/). See the [Chinese guide](docs/README.zh-CN.md) for complete
-configuration and [architecture notes](docs/architecture.md) for evidence and
-trust boundaries.
-
-## Development
-
-```bash
-pnpm install
-pnpm test
-pnpm run release:check
-```
-
-Apache-2.0 licensed. Contributions backed by a reproducible DSH plugin case are
-especially welcome.
+<p align="center">
+  <strong>If Upstream Radar helps the DSH ecosystem stay compatible, <a href="https://github.com/MicroMilo/upstream-radar">please give it a Star</a> ⭐</strong>
+</p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,84 @@
+<h1 align="center">Upstream Radar</h1>
+
+<p align="center"><strong>每次 DeepSeek Harness 发布后，在用户踩坑前找出哪些插件坏了。</strong></p>
+
+<p align="center">
+  <a href="README.md">English</a> · 简体中文
+</p>
+
+<p align="center">
+  <a href="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://www.npmjs.com/package/upstream-radar"><img alt="npm" src="https://img.shields.io/npm/v/upstream-radar"></a>
+  <a href="https://github.com/MicroMilo/upstream-radar/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/MicroMilo/upstream-radar"></a>
+  <a href="LICENSE"><img alt="Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
+</p>
+
+Upstream Radar 持续把一批真实插件发布物放到一次性隔离环境中，与不断变化的
+[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness)
+版本重新配对测试。某个组合坏了，就生成一条可复现的 Issue；作者发布修复后，
+Radar 会再次检查并关闭闭环。
+
+**维护 10 个真实插件发布物 · 37 张真实依赖图 · 1,025 个依赖坐标 · 4 条上游报告已关闭**
+
+## 为什么需要它
+
+仓库看起来正常，不代表用户实际安装的插件仍然可用。真实发布物必须同时适配某个
+DSH 版本、Node 运行时、profile 和依赖组合；其中任何一项更新，都可能让插件一夜
+之间失效。
+
+Upstream Radar 检查的是这层真实关系，而不只是分别看两个仓库。本地发布前检查
+回答“这个插件今天能不能过”；Radar 回答“生态变化后，维护中的哪些插件不再能过”。
+
+## 完整闭环
+
+```mermaid
+flowchart TB
+  Schedule["定时 GitHub Action"] --> Watch["观察 DSH 与插件发布"]
+  Watch --> Matrix["精确的插件 × DSH 测试矩阵"]
+  Matrix --> Static["静态契约检查"]
+  Matrix --> Runtime["一次性环境：安装 → 注册 → 加载"]
+  Static --> Evidence["可复现的兼容性证据"]
+  Runtime --> Evidence
+  Evidence --> Issue["一条可修复的 Issue"]
+  Issue --> Fix["作者发布修复"]
+  Fix --> Watch
+```
+
+Radar 用确定性证据得出结果。DSH Agent 可以补充影响解释和下一步建议，但模型不能
+把缺失的证据说成通过。
+
+## 你会得到什么
+
+- `插件版本 × DSH 版本 × Node/profile` 的精确结果，而不是永不过期的“兼容”标签。
+- 把静态依赖和 peer 契约，与真实发布物的安装、注册、加载结果放在一起判断。
+- DSH 或插件变化后自动重新检查，而不是只生成一次报告。
+- 同一问题持续更新；回归时重新打开；干净复测通过后自动关闭。
+
+## 已关闭的上游报告
+
+以下报告由我们提出，目前均已被对应上游维护者关闭：
+
+- [Sanqi-normal/dsh-webui-market-plugin#5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
+- [1na-ko/dsh-hdc-bridge#3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
+- [6Mikao9/dsh-wsl-workspace#6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
+- [3274375092/dsh-voice#2](https://github.com/3274375092/dsh-voice/issues/2)
+
+## 检查一个插件
+
+```bash
+npx --yes upstream-radar@0.41.0 review dsh-plugin \
+  <包名>@<版本> \
+  --dsh-version <DSH版本>
+```
+
+需要执行插件代码时，请使用仓库维护的
+[隔离观察工作流](.github/workflows/observe-dsh-plugin-install.yml)：每个组合都会获得
+一台全新的、无密钥的 GitHub 托管虚拟机和受限容器。
+
+你还可以查看[实时兼容性矩阵](examples/dsh/install-observer/README.md)、
+[第一批 50 个插件](examples/dsh/first-batch/README.md)和
+[架构说明](docs/architecture.md)。
+
+<p align="center">
+  <strong>如果 Upstream Radar 对 DSH 生态有帮助，欢迎<a href="https://github.com/MicroMilo/upstream-radar">点一个 Star</a> ⭐</strong>
+</p>


### PR DESCRIPTION
## Summary
- replace the technical landing page with a short outcome-led DSH compatibility story
- add a concise Simplified Chinese counterpart and language switcher
- list four upstream reports that are now closed
- keep one reproducible command, the core loop diagram, and a direct Star call to action

## Verification
- `pnpm test` (329/329)
- GitHub Markdown API renders both files and recognizes the Mermaid block
- all local README links resolve