### PR TITLE
Publish exact compatibility evidence for the first awesome-dsh cohort

### DIFF
--- a/.github/workflows/upstream-observer.yml
+++ b/.github/workflows/upstream-observer.yml
@@ -228,6 +228,15 @@ jobs:
             "$COMPATIBILITY_REVERSE_INDEX"
           cat "$LEDGER_REPORT" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Publish directory-consumable compatibility evidence
+        run: |
+          node scripts/write-dsh-directory-feed.mjs \
+            examples/dsh/awesome-observer/cohort.json \
+            examples/dsh/install-observer/targets.json \
+            compatibility-ledger.json \
+            feeds/dsh-plugin-compatibility.json \
+            feeds/dsh-plugin-compatibility.md
+
       - name: Keep compatibility evidence artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -238,6 +247,8 @@ jobs:
             compatibility-ledger.json
             compatibility-ir.json
             compatibility-reverse-index.json
+            feeds/dsh-plugin-compatibility.json
+            feeds/dsh-plugin-compatibility.md
           if-no-files-found: warn
           retention-days: 30
 
@@ -253,13 +264,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ ! -f compatibility-ledger.json || ! -f compatibility-ir.json || ! -f compatibility-reverse-index.json ]]; then
+          if [[ ! -f compatibility-ledger.json || ! -f compatibility-ir.json || ! -f compatibility-reverse-index.json || ! -f feeds/dsh-plugin-compatibility.json || ! -f feeds/dsh-plugin-compatibility.md ]]; then
             echo 'complete compatibility evidence was not produced; nothing to persist.'
             exit 0
           fi
           git config user.name 'upstream-radar[bot]'
           git config user.email 'upstream-radar[bot]@users.noreply.github.com'
-          git add -- compatibility-ledger.json compatibility-ir.json compatibility-reverse-index.json
+          git add -- compatibility-ledger.json compatibility-ir.json compatibility-reverse-index.json feeds/dsh-plugin-compatibility.json feeds/dsh-plugin-compatibility.md
           if git diff --cached --quiet; then
             echo 'No compatibility evidence changed; no commit created.'
             exit 0

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ each pair receives a fresh, secret-free GitHub-hosted VM and restricted
 container.
 
 Inspect the [live compatibility matrix](examples/dsh/install-observer/README.md),
+the [directory-consumable evidence feed](feeds/dsh-plugin-compatibility.md),
 the [first 50-plugin corpus](examples/dsh/first-batch/README.md), or the
 [architecture notes](docs/architecture.md).
 

--- a/examples/dsh/awesome-observer/README.md
+++ b/examples/dsh/awesome-observer/README.md
@@ -42,3 +42,13 @@ analysis tasks. An unchanged run updates nothing and schedules no VM.
 The initial compatibility baseline is dispatched explicitly once, using the
 same isolated workflow that later scheduled changes use. Results are checked in
 only after their exact DSH/plugin pairs and trace coverage have been reviewed.
+
+## Consumer feed
+
+The maintained ledger is joined back to the pinned catalog identities as a
+[machine-readable compatibility feed](../../../feeds/dsh-plugin-compatibility.json)
+and a [human-readable snapshot](../../../feeds/dsh-plugin-compatibility.md).
+The feed preserves exact plugin, DSH, Node, profile, artifact digest and expiry
+instead of stamping a timeless pass/fail badge onto a repository. A headless
+peer-contract gap is explicitly `needs-review`, not an author defect, until its
+intended web execution plane has also been observed.

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -1,0 +1,318 @@
+{
+  "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha1",
+  "generatedAt": "2026-08-23T08:02:26.261Z",
+  "producer": {
+    "name": "upstream-radar",
+    "version": "0.41.0",
+    "repository": "https://github.com/MicroMilo/upstream-radar",
+    "license": "Apache-2.0"
+  },
+  "sourceCatalog": {
+    "repository": "awesome-dsh-plugin/awesome-dsh-plugin",
+    "commit": "7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82",
+    "commitUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82",
+    "entryDirectory": "data/plugins",
+    "entryCount": 1837,
+    "license": "CC0-1.0"
+  },
+  "boundary": {
+    "claim": "exact-cell compatibility evidence; not a security review, endorsement, or timeless compatibility badge",
+    "executionPlane": "headless",
+    "profile": "headless",
+    "isolation": "fresh GitHub-hosted VM plus restricted container",
+    "consumptionRule": "Treat a cell as stale after recheckDueAt. needs-review and not-observed must never be rendered as pass or fail.",
+    "refreshAfterHours": 168
+  },
+  "summary": {
+    "total": 8,
+    "observed-compatible": 4,
+    "observed-incompatible": 0,
+    "needs-review": 2,
+    "not-observed": 2
+  },
+  "plugins": [
+    {
+      "id": "dsh-context",
+      "repository": "bowenliang123/dsh-context",
+      "repositoryUrl": "https://github.com/bowenliang123/dsh-context",
+      "catalogEntry": "data/plugins/bowenliang123__dsh-context.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/bowenliang123__dsh-context.yml",
+      "category": "usage",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-context",
+        "selectedVersion": "0.20.0",
+        "distTag": "latest"
+      },
+      "status": "observed-compatible",
+      "cells": [
+        {
+          "caseId": "context-node22",
+          "artifact": {
+            "spec": "dsh-context@0.25.3",
+            "sha256": "2fe8bd75e83f4c6e0ef69c87611e700011426ff5c83f1c661f45628e250593e2"
+          },
+          "dsh": {
+            "package": "@deepseek-ai/dsh",
+            "version": "0.1.1-rc.2"
+          },
+          "runtime": {
+            "nodeMajor": 22,
+            "nodeVersion": "22.23.2",
+            "platform": "linux",
+            "architecture": "x64"
+          },
+          "executionPlane": "headless",
+          "profile": "headless",
+          "status": "observed-compatible",
+          "radarResult": "compatible",
+          "observedAt": "2026-08-23T03:40:17.088Z",
+          "recheckDueAt": "2026-08-30T03:40:17.088Z",
+          "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version"
+        }
+      ],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-market",
+      "repository": "dsh-market/dsh-market",
+      "repositoryUrl": "https://github.com/dsh-market/dsh-market",
+      "catalogEntry": "data/plugins/dsh-market__dsh-market.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/dsh-market__dsh-market.yml",
+      "category": "market",
+      "distribution": {
+        "kind": "npm",
+        "name": "dshmarket",
+        "selectedVersion": "1.17.1",
+        "distTag": "latest"
+      },
+      "status": "observed-compatible",
+      "cells": [
+        {
+          "caseId": "dsh-market-node22",
+          "artifact": {
+            "spec": "dshmarket@1.19.0",
+            "sha256": "7428009ef928ebfd23e265c51601404124d249cd83b5bb1b9b1d2ca06fd429d2"
+          },
+          "dsh": {
+            "package": "@deepseek-ai/dsh",
+            "version": "0.1.1-rc.2"
+          },
+          "runtime": {
+            "nodeMajor": 22,
+            "nodeVersion": "22.23.2",
+            "platform": "linux",
+            "architecture": "x64"
+          },
+          "executionPlane": "headless",
+          "profile": "headless",
+          "status": "observed-compatible",
+          "radarResult": "compatible",
+          "observedAt": "2026-08-23T07:09:16.954Z",
+          "recheckDueAt": "2026-08-30T07:09:16.954Z",
+          "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version"
+        }
+      ],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "aegis",
+      "repository": "GanyuanRan/Aegis",
+      "repositoryUrl": "https://github.com/GanyuanRan/Aegis",
+      "catalogEntry": "data/plugins/GanyuanRan__Aegis.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/GanyuanRan__Aegis.yml",
+      "category": "skill",
+      "distribution": {
+        "kind": "github",
+        "reason": "The matching DSH install path is GitHub; the aegis npm coordinate belongs to a different project.",
+        "installSpec": "github:GanyuanRan/Aegis"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-cost-meter",
+      "repository": "Han-1413141/dsh-cost-meter",
+      "repositoryUrl": "https://github.com/Han-1413141/dsh-cost-meter",
+      "catalogEntry": "data/plugins/Han-1413141__dsh-cost-meter.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/Han-1413141__dsh-cost-meter.yml",
+      "category": "usage",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-cost-meter",
+        "selectedVersion": "1.5.31",
+        "distTag": "latest"
+      },
+      "status": "observed-compatible",
+      "cells": [
+        {
+          "caseId": "cost-meter-node22",
+          "artifact": {
+            "spec": "dsh-cost-meter@1.5.38",
+            "sha256": "304947c31e0c00fa21a25cdc9c2211bd02656c98d2fec9dd425c4e8aa5707bcb"
+          },
+          "dsh": {
+            "package": "@deepseek-ai/dsh",
+            "version": "0.1.1-rc.2"
+          },
+          "runtime": {
+            "nodeMajor": 22,
+            "nodeVersion": "22.23.2",
+            "platform": "linux",
+            "architecture": "x64"
+          },
+          "executionPlane": "headless",
+          "profile": "headless",
+          "status": "observed-compatible",
+          "radarResult": "compatible",
+          "observedAt": "2026-08-23T03:40:18.405Z",
+          "recheckDueAt": "2026-08-30T03:40:18.405Z",
+          "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version"
+        }
+      ],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-browser",
+      "repository": "Lum1104/dsh-browser",
+      "repositoryUrl": "https://github.com/Lum1104/dsh-browser",
+      "catalogEntry": "data/plugins/Lum1104__dsh-browser--packages-browser-bridge-browser.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/Lum1104__dsh-browser--packages-browser-bridge-browser.yml",
+      "category": "browser",
+      "distribution": {
+        "kind": "repository-installer",
+        "reason": "The bridge package is private and its README uses the repository installer; the unrelated dsh-browser npm name must not be substituted."
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-agent-teams",
+      "repository": "NanmiCoder/dsh-agent-teams",
+      "repositoryUrl": "https://github.com/NanmiCoder/dsh-agent-teams",
+      "catalogEntry": "data/plugins/NanmiCoder__dsh-agent-teams.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/NanmiCoder__dsh-agent-teams.yml",
+      "category": "workflow",
+      "distribution": {
+        "kind": "npm",
+        "name": "@nanmicoder/dsh-agent-teams",
+        "selectedVersion": "0.1.10",
+        "distTag": "latest"
+      },
+      "status": "observed-compatible",
+      "cells": [
+        {
+          "caseId": "agent-teams-node22",
+          "artifact": {
+            "spec": "@nanmicoder/dsh-agent-teams@0.1.13",
+            "sha256": "d9351c7e4637c7604fe882e8944ee5a5d77ec57647948d0ef67bc6c62e7f557a"
+          },
+          "dsh": {
+            "package": "@deepseek-ai/dsh",
+            "version": "0.1.1-rc.2"
+          },
+          "runtime": {
+            "nodeMajor": 22,
+            "nodeVersion": "22.23.2",
+            "platform": "linux",
+            "architecture": "x64"
+          },
+          "executionPlane": "headless",
+          "profile": "headless",
+          "status": "observed-compatible",
+          "radarResult": "compatible",
+          "observedAt": "2026-08-23T03:40:29.383Z",
+          "recheckDueAt": "2026-08-30T03:40:29.383Z",
+          "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version"
+        }
+      ],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-better-sidebar",
+      "repository": "omdsh-dev/DSH-better-sidebar",
+      "repositoryUrl": "https://github.com/omdsh-dev/DSH-better-sidebar",
+      "catalogEntry": "data/plugins/omdsh-dev__DSH-better-sidebar.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/omdsh-dev__DSH-better-sidebar.yml",
+      "category": "ui",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-better-sidebar",
+        "selectedVersion": "0.14.0",
+        "distTag": "latest"
+      },
+      "status": "needs-review",
+      "cells": [
+        {
+          "caseId": "better-sidebar-node22",
+          "artifact": {
+            "spec": "dsh-better-sidebar@0.15.2",
+            "sha256": "d932367e9b436e3f515394f55e90c5793253a51d357b9d390ab16cb9e91931a9"
+          },
+          "dsh": {
+            "package": "@deepseek-ai/dsh",
+            "version": "0.1.1-rc.2"
+          },
+          "runtime": {
+            "nodeMajor": 22,
+            "nodeVersion": "22.23.2",
+            "platform": "linux",
+            "architecture": "x64"
+          },
+          "executionPlane": "headless",
+          "profile": "headless",
+          "status": "needs-review",
+          "radarResult": "peer-contract-incompatible",
+          "observedAt": "2026-08-23T03:40:58.944Z",
+          "recheckDueAt": "2026-08-30T03:40:58.944Z",
+          "reason": "the exact artifact installed and loaded, but @deepseek-ai/dsh-client-ui-primitives@^0.1.0-rc.8 was not resolved by the DSH runtime (runtime-import-observed)"
+        }
+      ],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-openpencil",
+      "repository": "ZSeven-W/dsh-openpencil",
+      "repositoryUrl": "https://github.com/ZSeven-W/dsh-openpencil",
+      "catalogEntry": "data/plugins/ZSeven-W__dsh-openpencil.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/ZSeven-W__dsh-openpencil.yml",
+      "category": "ui",
+      "distribution": {
+        "kind": "npm",
+        "name": "@zseven-w/dsh-openpencil",
+        "selectedVersion": "0.1.0-rc.1",
+        "distTag": "latest"
+      },
+      "status": "needs-review",
+      "cells": [
+        {
+          "caseId": "openpencil-node24",
+          "artifact": {
+            "spec": "@zseven-w/dsh-openpencil@0.1.0-rc.1",
+            "sha256": "a4563e560e91bcd3a2a9302ee7dbee046b146c1bd0de6b27b7c7524fd52e77ca"
+          },
+          "dsh": {
+            "package": "@deepseek-ai/dsh",
+            "version": "0.1.1-rc.2"
+          },
+          "runtime": {
+            "nodeMajor": 24,
+            "nodeVersion": "24.19.0",
+            "platform": "linux",
+            "architecture": "x64"
+          },
+          "executionPlane": "headless",
+          "profile": "headless",
+          "status": "needs-review",
+          "radarResult": "peer-contract-incompatible",
+          "observedAt": "2026-08-23T03:40:15.559Z",
+          "recheckDueAt": "2026-08-30T03:40:15.559Z",
+          "reason": "the exact artifact installed and loaded, but @deepseek-ai/dsh-client-ui-slots@^0.1.0-rc.6 was not resolved by the DSH runtime (type-only-reference-observed)"
+        }
+      ],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    }
+  ]
+}

--- a/feeds/dsh-plugin-compatibility.md
+++ b/feeds/dsh-plugin-compatibility.md
@@ -1,0 +1,27 @@
+# DSH directory compatibility evidence
+
+Generated from catalog commit [`7f79f9c11b3c`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82) at `2026-08-23T08:02:26.261Z`.
+
+**4 observed compatible · 0 observed incompatible · 2 needs review · 2 not observed**
+
+| Catalog plugin | Exact artifact | Exact DSH / runtime | Evidence status | Observed |
+| --- | --- | --- | --- | --- |
+| [bowenliang123/dsh-context](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/bowenliang123__dsh-context.yml) | `dsh-context@0.25.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:17.088Z |
+| [dsh-market/dsh-market](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/dsh-market__dsh-market.yml) | `dshmarket@1.19.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T07:09:16.954Z |
+| [GanyuanRan/Aegis](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/GanyuanRan__Aegis.yml) | — | — | `not-observed` | — |
+| [Han-1413141/dsh-cost-meter](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/Han-1413141__dsh-cost-meter.yml) | `dsh-cost-meter@1.5.38` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:18.405Z |
+| [Lum1104/dsh-browser](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/Lum1104__dsh-browser--packages-browser-bridge-browser.yml) | — | — | `not-observed` | — |
+| [NanmiCoder/dsh-agent-teams](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/NanmiCoder__dsh-agent-teams.yml) | `@nanmicoder/dsh-agent-teams@0.1.13` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:29.383Z |
+| [omdsh-dev/DSH-better-sidebar](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/omdsh-dev__DSH-better-sidebar.yml) | `dsh-better-sidebar@0.15.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T03:40:58.944Z |
+| [ZSeven-W/dsh-openpencil](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/ZSeven-W__dsh-openpencil.yml) | `@zseven-w/dsh-openpencil@0.1.0-rc.1` | `0.1.1-rc.2` / Node 24 | `needs-review` | 2026-08-23T03:40:15.559Z |
+
+## Reading the status
+
+- `observed-compatible`: the exact artifact installed, registered and loaded in the stated headless cell.
+- `observed-incompatible`: the exact cell reproduced a runtime gate, install, registration or load failure.
+- `needs-review`: evidence exists, but Radar cannot yet separate a plugin defect from an uncovered execution plane or environment condition.
+- `not-observed`: the catalog entry is monitored statically but has no matching executable npm artifact in this cohort.
+
+A cell expires at its `recheckDueAt` value (168 hours after observation). Consumers must then show it as stale. This is exact compatibility evidence, not a security review or endorsement.
+
+[Machine-readable feed](dsh-plugin-compatibility.json) · [Full compatibility ledger](https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json)

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "showcase:observer": "pnpm run build && node scripts/upstream-observer-showcase.mjs",
     "monitor:dsh-findings": "pnpm run build && node scripts/monitor-dsh-findings.mjs",
     "refresh:dsh-batch": "pnpm run build && node scripts/refresh-dsh-batch-index.mjs",
+    "refresh:dsh-directory-feed": "pnpm run build && node scripts/write-dsh-directory-feed.mjs examples/dsh/awesome-observer/cohort.json examples/dsh/install-observer/targets.json compatibility-ledger.json feeds/dsh-plugin-compatibility.json feeds/dsh-plugin-compatibility.md",
     "showcase:pnpm-lock": "pnpm run build && node scripts/pnpm-lock-showcase.mjs",
     "showcase:pnpm-lock:monitor": "pnpm run build && node scripts/pnpm-lock-monitor-showcase.mjs",
     "showcase:npm-lock:monitor": "pnpm run build && node scripts/npm-lock-monitor-showcase.mjs",

--- a/scripts/sync-dsh-compatibility-issues.mjs
+++ b/scripts/sync-dsh-compatibility-issues.mjs
@@ -127,6 +127,7 @@ for (const action of plan.actions) {
 const summary = {
   repository,
   activeCompatibilityIncidents: plan.openCaseIds.length,
+  reviewOnlyCells: plan.reviewOnlyCaseIds.length,
   ignoredUnknownCells: plan.ignoredUnknownCaseIds.length,
   actions: applied,
 }
@@ -139,6 +140,7 @@ if (process.env.GITHUB_STEP_SUMMARY !== undefined) {
     '',
     `- Active compatibility incidents: **${summary.activeCompatibilityIncidents}**`,
     `- Created: **${applied.create}**; updated: **${applied.update}**; reopened: **${applied.reopen}**; resolved and closed: **${applied.close}**`,
+    `- Peer-contract cells held for execution-plane review: **${summary.reviewOnlyCells}**`,
     `- Unknown cells held for observer review: **${summary.ignoredUnknownCells}**`,
     '',
   ]

--- a/scripts/write-dsh-directory-feed.mjs
+++ b/scripts/write-dsh-directory-feed.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import {
+  buildDshDirectoryCompatibilityFeed,
+  renderDshDirectoryCompatibilityFeed,
+} from '../dist/src/dsh-directory-feed.js'
+
+const MAX_JSON_BYTES = 64 * 1024 * 1024
+
+async function readJson(path) {
+  const contents = await readFile(resolve(path), 'utf8')
+  if (Buffer.byteLength(contents) > MAX_JSON_BYTES) throw new Error(`${path} exceeds ${MAX_JSON_BYTES} bytes`)
+  return JSON.parse(contents)
+}
+
+const [cohortPath, targetsPath, ledgerPath, jsonPath, markdownPath] = process.argv.slice(2)
+if ([cohortPath, targetsPath, ledgerPath, jsonPath, markdownPath].some(value => value === undefined)) {
+  throw new Error('usage: write-dsh-directory-feed.mjs <cohort.json> <targets.json> <ledger.json> <feed.json> <feed.md>')
+}
+
+const feed = buildDshDirectoryCompatibilityFeed({
+  cohort: await readJson(cohortPath),
+  installTargets: await readJson(targetsPath),
+  ledger: await readJson(ledgerPath),
+  generatedAt: new Date().toISOString(),
+})
+
+await mkdir(dirname(resolve(jsonPath)), { recursive: true })
+await mkdir(dirname(resolve(markdownPath)), { recursive: true })
+await writeFile(resolve(jsonPath), `${JSON.stringify(feed, null, 2)}\n`, 'utf8')
+await writeFile(resolve(markdownPath), renderDshDirectoryCompatibilityFeed(feed), 'utf8')
+
+process.stdout.write(`${JSON.stringify({
+  feed: resolve(jsonPath),
+  total: feed.summary.total,
+  observedCompatible: feed.summary['observed-compatible'],
+  observedIncompatible: feed.summary['observed-incompatible'],
+  needsReview: feed.summary['needs-review'],
+  notObserved: feed.summary['not-observed'],
+}, null, 2)}\n`)

--- a/src/dsh-compatibility-issues.ts
+++ b/src/dsh-compatibility-issues.ts
@@ -6,7 +6,6 @@ import {
 const CASE_MARKER = /<!-- upstream-radar:dsh-compatibility-case=([a-z0-9][a-z0-9._-]{0,63}) -->/
 const ACTIONABLE_RESULTS = new Set<DshCompatibilityLedgerEntry['result']>([
   'runtime-incompatible',
-  'peer-contract-incompatible',
   'install-failed',
   'load-failed',
 ])
@@ -44,6 +43,7 @@ export type DshCompatibilityIssueAction =
 export interface DshCompatibilityIssuePlan {
   actions: DshCompatibilityIssueAction[]
   openCaseIds: string[]
+  reviewOnlyCaseIds: string[]
   ignoredUnknownCaseIds: string[]
 }
 
@@ -178,6 +178,23 @@ export function renderDshCompatibilityResolution(entry: DshCompatibilityLedgerEn
   ].join('\n')
 }
 
+export function renderDshCompatibilityReviewReclassification(entry: DshCompatibilityLedgerEntry): string {
+  return [
+    `<!-- upstream-radar:dsh-compatibility-review=${entry.caseId}:${entry.contractFingerprint} -->`,
+    '',
+    'Closing this managed incident because the current observation is a review signal, not a reproduced plugin failure.',
+    '',
+    `- Plugin: \`${inline(entry.plugin, 512)}\``,
+    `- DSH: \`@deepseek-ai/dsh@${inline(entry.dshVersion, 128)}\``,
+    `- Raw result retained in the ledger: \`${entry.result}\``,
+    `- Evidence gap: ${inline(entry.reason, 4_096)}`,
+    '',
+    'This cell used the headless profile. A missing or mismatched web-client peer from that Node resolution anchor does not prove the plugin fails in its intended browser execution plane. The evidence remains visible as `needs-review`; it will become author-actionable only after the intended plane reproduces an install, registration or load failure.',
+    '',
+    'Execution-plane coverage is tracked in #75.',
+  ].join('\n')
+}
+
 function existingByCase(issues: readonly DshCompatibilityExistingIssue[]): Map<string, DshCompatibilityExistingIssue> {
   const result = new Map<string, DshCompatibilityExistingIssue>()
   for (const issue of issues) {
@@ -202,12 +219,25 @@ export function buildDshCompatibilityIssuePlan(input: {
   const existing = existingByCase(input.existingIssues)
   const actions: DshCompatibilityIssueAction[] = []
   const openCaseIds: string[] = []
+  const reviewOnlyCaseIds: string[] = []
   const ignoredUnknownCaseIds: string[] = []
 
   for (const entry of ledger.entries) {
     const issue = existing.get(entry.caseId)
     if (entry.result === 'unknown') {
       ignoredUnknownCaseIds.push(entry.caseId)
+      continue
+    }
+    if (entry.result === 'peer-contract-incompatible') {
+      reviewOnlyCaseIds.push(entry.caseId)
+      if (issue?.state === 'open') {
+        actions.push({
+          kind: 'close',
+          caseId: entry.caseId,
+          issueNumber: issue.number,
+          comment: renderDshCompatibilityReviewReclassification(entry),
+        })
+      }
       continue
     }
     if (entry.result === 'compatible') {
@@ -236,6 +266,7 @@ export function buildDshCompatibilityIssuePlan(input: {
   return {
     actions,
     openCaseIds: openCaseIds.sort(),
+    reviewOnlyCaseIds: reviewOnlyCaseIds.sort(),
     ignoredUnknownCaseIds: ignoredUnknownCaseIds.sort(),
   }
 }

--- a/src/dsh-directory-feed.ts
+++ b/src/dsh-directory-feed.ts
@@ -1,0 +1,369 @@
+import { parseDshCompatibilityLedger, type DshCompatibilityLedgerEntry } from './dsh-compatibility-ledger.js'
+import { parseDshInstallTargets } from './dsh-install-plan.js'
+import { parseNpmSpec } from './npm.js'
+import { TOOL_VERSION } from './version.js'
+
+export const AWESOME_DSH_COHORT_SCHEMA = 'upstream-radar.awesome-dsh-cohort/v1alpha1' as const
+export const DSH_DIRECTORY_COMPATIBILITY_FEED_SCHEMA = 'upstream-radar.dsh-directory-compatibility-feed/v1alpha1' as const
+
+const MAX_COHORT_PLUGINS = 50
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
+const CATALOG_ENTRY = /^data\/plugins\/[A-Za-z0-9_.@-]+\.ya?ml$/
+
+export type DshDirectoryEvidenceStatus =
+  | 'observed-compatible'
+  | 'observed-incompatible'
+  | 'needs-review'
+  | 'not-observed'
+
+export interface AwesomeDshCohortPlugin {
+  id: string
+  catalogEntry: string
+  repository: string
+  category: string
+  distribution:
+    | { kind: 'npm'; name: string; selectedVersion: string; distTag?: string }
+    | { kind: 'github'; installSpec?: string; reason: string }
+    | { kind: 'repository-installer'; reason: string }
+}
+
+export interface AwesomeDshCohort {
+  schema: typeof AWESOME_DSH_COHORT_SCHEMA
+  selectedAt: string
+  source: {
+    repository: string
+    commit: string
+    commitUrl: string
+    entryDirectory: string
+    entryCount: number
+    license: string
+  }
+  plugins: AwesomeDshCohortPlugin[]
+}
+
+export interface DshDirectoryEvidenceCell {
+  caseId: string
+  artifact: {
+    spec: string
+    sha256?: string
+  }
+  dsh: {
+    package: '@deepseek-ai/dsh'
+    version: string
+  }
+  runtime: {
+    nodeMajor: number
+    nodeVersion: string
+    platform: string
+    architecture: string
+  }
+  executionPlane: 'headless'
+  profile: 'headless'
+  status: Exclude<DshDirectoryEvidenceStatus, 'not-observed'>
+  radarResult: DshCompatibilityLedgerEntry['result']
+  observedAt: string
+  recheckDueAt: string
+  reason: string
+}
+
+export interface DshDirectoryCompatibilityEntry {
+  id: string
+  repository: string
+  repositoryUrl: string
+  catalogEntry: string
+  catalogEntryUrl: string
+  category: string
+  distribution: AwesomeDshCohortPlugin['distribution']
+  status: DshDirectoryEvidenceStatus
+  cells: DshDirectoryEvidenceCell[]
+  evidenceUrl: string
+}
+
+export interface DshDirectoryCompatibilityFeed {
+  schema: typeof DSH_DIRECTORY_COMPATIBILITY_FEED_SCHEMA
+  generatedAt: string
+  producer: {
+    name: 'upstream-radar'
+    version: string
+    repository: string
+    license: 'Apache-2.0'
+  }
+  sourceCatalog: AwesomeDshCohort['source']
+  boundary: {
+    claim: 'exact-cell compatibility evidence; not a security review, endorsement, or timeless compatibility badge'
+    executionPlane: 'headless'
+    profile: 'headless'
+    isolation: 'fresh GitHub-hosted VM plus restricted container'
+    consumptionRule: string
+    refreshAfterHours: number
+  }
+  summary: Record<DshDirectoryEvidenceStatus, number> & { total: number }
+  plugins: DshDirectoryCompatibilityEntry[]
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${label} must be an object`)
+  return value as Record<string, unknown>
+}
+
+function boundedString(value: unknown, label: string, maximum: number): string {
+  if (typeof value !== 'string' || value.trim() === '' || value.length > maximum) {
+    throw new Error(`${label} must be a non-empty string no longer than ${maximum} characters`)
+  }
+  return value
+}
+
+function timestamp(value: unknown, label: string): string {
+  const parsed = boundedString(value, label, 64)
+  if (!Number.isFinite(Date.parse(parsed))) throw new Error(`${label} must be an ISO timestamp`)
+  return parsed
+}
+
+function repository(value: unknown, label: string): string {
+  const parsed = boundedString(value, label, 256)
+  if (!REPOSITORY.test(parsed)) throw new Error(`${label} must be an owner/repository coordinate`)
+  return parsed
+}
+
+function httpsUrl(value: unknown, label: string): string {
+  const parsed = new URL(boundedString(value, label, 2_048))
+  if (parsed.protocol !== 'https:' || parsed.username !== '' || parsed.password !== '') {
+    throw new Error(`${label} must be a credential-free HTTPS URL`)
+  }
+  return parsed.toString()
+}
+
+function parseDistribution(value: unknown, label: string): AwesomeDshCohortPlugin['distribution'] {
+  const item = record(value, label)
+  const kind = boundedString(item.kind, `${label}.kind`, 64)
+  if (kind === 'npm') {
+    const name = boundedString(item.name, `${label}.name`, 214)
+    const selectedVersion = boundedString(item.selectedVersion, `${label}.selectedVersion`, 256)
+    parseNpmSpec(`${name}@${selectedVersion}`)
+    const distTag = item.distTag === undefined ? undefined : boundedString(item.distTag, `${label}.distTag`, 128)
+    return { kind, name, selectedVersion, ...(distTag === undefined ? {} : { distTag }) }
+  }
+  if (kind === 'github') {
+    const reason = boundedString(item.reason, `${label}.reason`, 2_048)
+    const installSpec = item.installSpec === undefined
+      ? undefined
+      : boundedString(item.installSpec, `${label}.installSpec`, 512)
+    return { kind, reason, ...(installSpec === undefined ? {} : { installSpec }) }
+  }
+  if (kind === 'repository-installer') {
+    return { kind, reason: boundedString(item.reason, `${label}.reason`, 2_048) }
+  }
+  throw new Error(`${label}.kind is unsupported`)
+}
+
+export function parseAwesomeDshCohort(input: unknown): AwesomeDshCohort {
+  const root = record(input, 'awesome-dsh-plugin cohort')
+  if (root.schema !== AWESOME_DSH_COHORT_SCHEMA) {
+    throw new Error(`awesome-dsh-plugin cohort schema must be ${AWESOME_DSH_COHORT_SCHEMA}`)
+  }
+  const source = record(root.source, 'awesome-dsh-plugin cohort source')
+  const commit = boundedString(source.commit, 'awesome-dsh-plugin cohort source.commit', 40)
+  if (!/^[a-f0-9]{40}$/.test(commit)) throw new Error('awesome-dsh-plugin cohort source.commit must be a full Git commit')
+  const entryCount = Number(source.entryCount)
+  if (!Number.isSafeInteger(entryCount) || entryCount < 1 || entryCount > 100_000) {
+    throw new Error('awesome-dsh-plugin cohort source.entryCount must be a positive bounded integer')
+  }
+  if (!Array.isArray(root.plugins) || root.plugins.length === 0 || root.plugins.length > MAX_COHORT_PLUGINS) {
+    throw new Error(`awesome-dsh-plugin cohort plugins must contain between 1 and ${MAX_COHORT_PLUGINS} entries`)
+  }
+  const ids = new Set<string>()
+  const repositories = new Set<string>()
+  const plugins = root.plugins.map((value, index): AwesomeDshCohortPlugin => {
+    const item = record(value, `plugins[${index}]`)
+    const id = boundedString(item.id, `plugins[${index}].id`, 64)
+    if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(id)) throw new Error(`plugins[${index}].id must be a short lowercase label`)
+    if (ids.has(id)) throw new Error(`duplicate awesome-dsh-plugin cohort id: ${id}`)
+    ids.add(id)
+    const repositoryName = repository(item.repository, `plugins[${index}].repository`)
+    if (repositories.has(repositoryName)) throw new Error(`duplicate awesome-dsh-plugin cohort repository: ${repositoryName}`)
+    repositories.add(repositoryName)
+    const catalogEntry = boundedString(item.catalogEntry, `plugins[${index}].catalogEntry`, 512)
+    if (!CATALOG_ENTRY.test(catalogEntry)) throw new Error(`plugins[${index}].catalogEntry must identify one catalog YAML entry`)
+    return {
+      id,
+      catalogEntry,
+      repository: repositoryName,
+      category: boundedString(item.category, `plugins[${index}].category`, 64),
+      distribution: parseDistribution(item.distribution, `plugins[${index}].distribution`),
+    }
+  })
+  plugins.sort((left, right) => left.repository.localeCompare(right.repository))
+  return {
+    schema: AWESOME_DSH_COHORT_SCHEMA,
+    selectedAt: timestamp(root.selectedAt, 'awesome-dsh-plugin cohort selectedAt'),
+    source: {
+      repository: repository(source.repository, 'awesome-dsh-plugin cohort source.repository'),
+      commit,
+      commitUrl: httpsUrl(source.commitUrl, 'awesome-dsh-plugin cohort source.commitUrl'),
+      entryDirectory: boundedString(source.entryDirectory, 'awesome-dsh-plugin cohort source.entryDirectory', 512),
+      entryCount,
+      license: boundedString(source.license, 'awesome-dsh-plugin cohort source.license', 128),
+    },
+    plugins,
+  }
+}
+
+function cellStatus(result: DshCompatibilityLedgerEntry['result']): Exclude<DshDirectoryEvidenceStatus, 'not-observed'> {
+  if (result === 'compatible') return 'observed-compatible'
+  if (result === 'runtime-incompatible' || result === 'install-failed' || result === 'load-failed') {
+    return 'observed-incompatible'
+  }
+  return 'needs-review'
+}
+
+function aggregateStatus(cells: readonly DshDirectoryEvidenceCell[]): DshDirectoryEvidenceStatus {
+  if (cells.length === 0) return 'not-observed'
+  if (cells.some(cell => cell.status === 'observed-incompatible')) return 'observed-incompatible'
+  if (cells.some(cell => cell.status === 'needs-review')) return 'needs-review'
+  return 'observed-compatible'
+}
+
+function dueAt(observedAt: string, refreshAfterHours: number): string {
+  return new Date(Date.parse(observedAt) + refreshAfterHours * 60 * 60 * 1_000).toISOString()
+}
+
+function normalizedRepositoryBaseUrl(value: string): string {
+  const parsed = new URL(value)
+  if (parsed.protocol !== 'https:' || parsed.username !== '' || parsed.password !== '' || parsed.search !== '' || parsed.hash !== '') {
+    throw new Error('repositoryBaseUrl must be a credential-free HTTPS URL without query or fragment')
+  }
+  return parsed.toString().replace(/\/$/, '')
+}
+
+export function buildDshDirectoryCompatibilityFeed(input: {
+  cohort: unknown
+  installTargets: unknown
+  ledger: unknown
+  generatedAt: string
+  repositoryBaseUrl?: string
+}): DshDirectoryCompatibilityFeed {
+  const cohort = parseAwesomeDshCohort(input.cohort)
+  const installTargets = parseDshInstallTargets(input.installTargets)
+  const ledger = parseDshCompatibilityLedger(input.ledger)
+  const generatedAt = timestamp(input.generatedAt, 'directory feed generatedAt')
+  const repositoryBaseUrl = normalizedRepositoryBaseUrl(input.repositoryBaseUrl ?? 'https://github.com/MicroMilo/upstream-radar')
+  const targetByObserverId = new Map(installTargets.plugins
+    .filter(target => target.observerTargetId !== undefined)
+    .map(target => [target.observerTargetId as string, target]))
+
+  const plugins = cohort.plugins.map((plugin): DshDirectoryCompatibilityEntry => {
+    const installTarget = targetByObserverId.get(plugin.id)
+    const observations = installTarget === undefined
+      ? []
+      : ledger.entries.filter(entry => entry.targetId === installTarget.id)
+    const cells = observations.map((entry): DshDirectoryEvidenceCell => ({
+      caseId: entry.caseId,
+      artifact: {
+        spec: entry.plugin,
+        ...(entry.artifact.sha256 === undefined ? {} : { sha256: entry.artifact.sha256 }),
+      },
+      dsh: { package: '@deepseek-ai/dsh', version: entry.dshVersion },
+      runtime: {
+        nodeMajor: entry.runtime.nodeMajor,
+        nodeVersion: entry.runtime.nodeVersion,
+        platform: entry.runtime.platform,
+        architecture: entry.runtime.architecture,
+      },
+      executionPlane: 'headless',
+      profile: 'headless',
+      status: cellStatus(entry.result),
+      radarResult: entry.result,
+      observedAt: entry.observedAt,
+      recheckDueAt: dueAt(entry.observedAt, installTargets.refreshAfterHours),
+      reason: entry.reason,
+    })).sort((left, right) => left.caseId.localeCompare(right.caseId))
+    return {
+      id: plugin.id,
+      repository: plugin.repository,
+      repositoryUrl: `https://github.com/${plugin.repository}`,
+      catalogEntry: plugin.catalogEntry,
+      catalogEntryUrl: `https://github.com/${cohort.source.repository}/blob/${cohort.source.commit}/${plugin.catalogEntry}`,
+      category: plugin.category,
+      distribution: plugin.distribution,
+      status: aggregateStatus(cells),
+      cells,
+      evidenceUrl: `${repositoryBaseUrl}/blob/main/compatibility-ledger.json`,
+    }
+  }).sort((left, right) => left.repository.localeCompare(right.repository))
+
+  const summary: DshDirectoryCompatibilityFeed['summary'] = {
+    total: plugins.length,
+    'observed-compatible': 0,
+    'observed-incompatible': 0,
+    'needs-review': 0,
+    'not-observed': 0,
+  }
+  for (const plugin of plugins) summary[plugin.status] += 1
+
+  return {
+    schema: DSH_DIRECTORY_COMPATIBILITY_FEED_SCHEMA,
+    generatedAt,
+    producer: { name: 'upstream-radar', version: TOOL_VERSION, repository: repositoryBaseUrl, license: 'Apache-2.0' },
+    sourceCatalog: cohort.source,
+    boundary: {
+      claim: 'exact-cell compatibility evidence; not a security review, endorsement, or timeless compatibility badge',
+      executionPlane: 'headless',
+      profile: 'headless',
+      isolation: 'fresh GitHub-hosted VM plus restricted container',
+      consumptionRule: 'Treat a cell as stale after recheckDueAt. needs-review and not-observed must never be rendered as pass or fail.',
+      refreshAfterHours: installTargets.refreshAfterHours,
+    },
+    summary,
+    plugins,
+  }
+}
+
+function markdown(value: string): string {
+  return value.replace(/[|<>\r\n]/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+function cellCoordinate(entry: DshDirectoryCompatibilityEntry): string {
+  if (entry.cells.length === 0) return '—'
+  return entry.cells.map(cell => `\`${markdown(cell.artifact.spec)}\``).join('<br>')
+}
+
+function dshCoordinate(entry: DshDirectoryCompatibilityEntry): string {
+  if (entry.cells.length === 0) return '—'
+  return entry.cells.map(cell => `\`${markdown(cell.dsh.version)}\` / Node ${cell.runtime.nodeMajor}`).join('<br>')
+}
+
+function observedCoordinate(entry: DshDirectoryCompatibilityEntry): string {
+  if (entry.cells.length === 0) return '—'
+  return entry.cells.map(cell => markdown(cell.observedAt)).join('<br>')
+}
+
+export function renderDshDirectoryCompatibilityFeed(feed: DshDirectoryCompatibilityFeed): string {
+  const lines = [
+    '# DSH directory compatibility evidence',
+    '',
+    `Generated from catalog commit [\`${feed.sourceCatalog.commit.slice(0, 12)}\`](${feed.sourceCatalog.commitUrl}) at \`${feed.generatedAt}\`.`,
+    '',
+    `**${feed.summary['observed-compatible']} observed compatible · ${feed.summary['observed-incompatible']} observed incompatible · ${feed.summary['needs-review']} needs review · ${feed.summary['not-observed']} not observed**`,
+    '',
+    '| Catalog plugin | Exact artifact | Exact DSH / runtime | Evidence status | Observed |',
+    '| --- | --- | --- | --- | --- |',
+  ]
+  for (const entry of feed.plugins) {
+    lines.push(`| [${markdown(entry.repository)}](${entry.catalogEntryUrl}) | ${cellCoordinate(entry)} | ${dshCoordinate(entry)} | \`${entry.status}\` | ${observedCoordinate(entry)} |`)
+  }
+  lines.push(
+    '',
+    '## Reading the status',
+    '',
+    '- `observed-compatible`: the exact artifact installed, registered and loaded in the stated headless cell.',
+    '- `observed-incompatible`: the exact cell reproduced a runtime gate, install, registration or load failure.',
+    '- `needs-review`: evidence exists, but Radar cannot yet separate a plugin defect from an uncovered execution plane or environment condition.',
+    '- `not-observed`: the catalog entry is monitored statically but has no matching executable npm artifact in this cohort.',
+    '',
+    `A cell expires at its \`recheckDueAt\` value (${feed.boundary.refreshAfterHours} hours after observation). Consumers must then show it as stale. This is exact compatibility evidence, not a security review or endorsement.`,
+    '',
+    `[Machine-readable feed](dsh-plugin-compatibility.json) · [Full compatibility ledger](${feed.producer.repository}/blob/main/compatibility-ledger.json)`,
+    '',
+  )
+  return lines.join('\n')
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ export {
   dshCompatibilityIssueCaseId,
   dshCompatibilityIssueMarker,
   renderDshCompatibilityIssue,
+  renderDshCompatibilityReviewReclassification,
   renderDshCompatibilityResolution,
   type DshCompatibilityExistingIssue,
   type DshCompatibilityIssueAction,
@@ -164,6 +165,19 @@ export {
   type DshInstallTarget,
   type DshInstallTargets,
 } from './dsh-install-plan.js'
+export {
+  AWESOME_DSH_COHORT_SCHEMA,
+  DSH_DIRECTORY_COMPATIBILITY_FEED_SCHEMA,
+  buildDshDirectoryCompatibilityFeed,
+  parseAwesomeDshCohort,
+  renderDshDirectoryCompatibilityFeed,
+  type AwesomeDshCohort,
+  type AwesomeDshCohortPlugin,
+  type DshDirectoryCompatibilityEntry,
+  type DshDirectoryCompatibilityFeed,
+  type DshDirectoryEvidenceCell,
+  type DshDirectoryEvidenceStatus,
+} from './dsh-directory-feed.js'
 export {
   DSH_PLUGIN_REVIEW_SCHEMA,
   renderDshPluginReview,

--- a/test/dsh-compatibility-issues.test.ts
+++ b/test/dsh-compatibility-issues.test.ts
@@ -105,18 +105,18 @@ function issue(value: DshCompatibilityLedgerEntry, state: 'open' | 'closed' = 'o
 describe('DSH compatibility issue reconciliation', () => {
   it('creates one managed issue for an actionable incompatibility', () => {
     const plan = buildDshCompatibilityIssuePlan({
-      ledger: ledger(entry('peer-contract-incompatible')),
+      ledger: ledger(entry('load-failed')),
       existingIssues: [],
       runUrl: 'https://github.com/MicroMilo/upstream-radar/actions/runs/1',
     })
     assert.equal(plan.actions.length, 1)
     assert.equal(plan.actions[0]?.kind, 'create')
-    assert.match(plan.actions[0]?.kind === 'create' ? plan.actions[0].body : '', /react-dom/)
+    assert.match(plan.actions[0]?.kind === 'create' ? plan.actions[0].body : '', /Reproduce the DSH registration/)
     assert.deepEqual(plan.openCaseIds, ['openpencil-node24'])
   })
 
   it('is quiet when the desired open issue already matches the ledger', () => {
-    const incompatible = entry('peer-contract-incompatible')
+    const incompatible = entry('load-failed')
     const plan = buildDshCompatibilityIssuePlan({
       ledger: ledger(incompatible),
       existingIssues: [issue(incompatible)],
@@ -159,5 +159,23 @@ describe('DSH compatibility issue reconciliation', () => {
     const plan = buildDshCompatibilityIssuePlan({ ledger: ledger(entry('unknown')), existingIssues: [] })
     assert.deepEqual(plan.actions, [])
     assert.deepEqual(plan.ignoredUnknownCaseIds, ['openpencil-node24'])
+  })
+
+  it('keeps a headless peer-contract gap as review evidence instead of creating an incident', () => {
+    const review = entry('peer-contract-incompatible')
+    const plan = buildDshCompatibilityIssuePlan({ ledger: ledger(review), existingIssues: [] })
+    assert.deepEqual(plan.actions, [])
+    assert.deepEqual(plan.openCaseIds, [])
+    assert.deepEqual(plan.reviewOnlyCaseIds, ['openpencil-node24'])
+  })
+
+  it('closes an old peer-contract incident after the evidence is reclassified', () => {
+    const review = entry('peer-contract-incompatible')
+    const plan = buildDshCompatibilityIssuePlan({
+      ledger: ledger(review),
+      existingIssues: [issue(review)],
+    })
+    assert.equal(plan.actions[0]?.kind, 'close')
+    assert.match(plan.actions[0]?.kind === 'close' ? plan.actions[0].comment : '', /review signal, not a reproduced plugin failure/)
   })
 })

--- a/test/dsh-directory-feed.test.ts
+++ b/test/dsh-directory-feed.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import {
+  AWESOME_DSH_COHORT_SCHEMA,
+  buildDshDirectoryCompatibilityFeed,
+  renderDshDirectoryCompatibilityFeed,
+} from '../src/dsh-directory-feed.js'
+import { DSH_COMPATIBILITY_LEDGER_SCHEMA, type DshCompatibilityLedgerEntry } from '../src/dsh-compatibility-ledger.js'
+import { DSH_INSTALL_TARGETS_SCHEMA } from '../src/dsh-install-plan.js'
+
+function ledgerEntry(targetId: string, result: DshCompatibilityLedgerEntry['result']): DshCompatibilityLedgerEntry {
+  return {
+    caseId: `${targetId}-node22`,
+    targetId,
+    plugin: `${targetId}@1.0.0`,
+    dshVersion: '0.1.1-rc.2',
+    runtime: {
+      nodeMajor: 22,
+      nodeVersion: '22.23.2',
+      platform: 'linux',
+      architecture: 'x64',
+      pnpmVersion: '11.7.0',
+    },
+    staticFingerprint: `sha256:${'a'.repeat(64)}`,
+    contractFingerprint: `sha256:${'b'.repeat(64)}`,
+    observedAt: '2026-08-23T00:00:00.000Z',
+    result,
+    reason: `${result} evidence`,
+    artifact: { lifecycleScripts: [], sha256: 'c'.repeat(64) },
+    observer: {
+      schema: 'upstream-radar.dsh-install-observation/v1alpha1',
+      version: '0.41.0',
+    },
+  }
+}
+
+function fixture() {
+  const ids = ['clean', 'broken', 'peer-gap', 'unknown']
+  return {
+    cohort: {
+      schema: AWESOME_DSH_COHORT_SCHEMA,
+      selectedAt: '2026-08-22T00:00:00.000Z',
+      source: {
+        repository: 'awesome-dsh-plugin/awesome-dsh-plugin',
+        commit: 'd'.repeat(40),
+        commitUrl: `https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/${'d'.repeat(40)}`,
+        entryDirectory: 'data/plugins',
+        entryCount: 100,
+        license: 'CC0-1.0',
+      },
+      plugins: [...ids, 'source-only'].map(id => ({
+        id,
+        catalogEntry: `data/plugins/example__${id}.yml`,
+        repository: `example/${id}`,
+        category: 'dev',
+        distribution: id === 'source-only'
+          ? { kind: 'repository-installer', reason: 'no matching public npm artifact' }
+          : { kind: 'npm', name: id, selectedVersion: '1.0.0', distTag: 'latest' },
+      })),
+    },
+    installTargets: {
+      schema: DSH_INSTALL_TARGETS_SCHEMA,
+      refreshAfterHours: 168,
+      runtimeProfiles: [{ id: 'node22', nodeMajor: 22 }],
+      plugins: ids.map(id => ({
+        id,
+        spec: `${id}@1.0.0`,
+        observerTargetId: id,
+        reason: `observe ${id}`,
+      })),
+    },
+    ledger: {
+      schema: DSH_COMPATIBILITY_LEDGER_SCHEMA,
+      entries: [
+        ledgerEntry('clean', 'compatible'),
+        ledgerEntry('broken', 'load-failed'),
+        ledgerEntry('peer-gap', 'peer-contract-incompatible'),
+        ledgerEntry('unknown', 'unknown'),
+      ],
+    },
+  }
+}
+
+describe('DSH directory compatibility feed', () => {
+  it('publishes exact evidence without turning coverage gaps into pass or fail', () => {
+    const input = fixture()
+    const feed = buildDshDirectoryCompatibilityFeed({
+      ...input,
+      generatedAt: '2026-08-23T01:00:00.000Z',
+    })
+
+    assert.deepEqual(feed.summary, {
+      total: 5,
+      'observed-compatible': 1,
+      'observed-incompatible': 1,
+      'needs-review': 2,
+      'not-observed': 1,
+    })
+    assert.equal(feed.plugins.find(item => item.id === 'clean')?.status, 'observed-compatible')
+    assert.equal(feed.plugins.find(item => item.id === 'broken')?.status, 'observed-incompatible')
+    assert.equal(feed.plugins.find(item => item.id === 'peer-gap')?.status, 'needs-review')
+    assert.equal(feed.plugins.find(item => item.id === 'unknown')?.status, 'needs-review')
+    assert.equal(feed.plugins.find(item => item.id === 'source-only')?.status, 'not-observed')
+    assert.equal(feed.plugins.find(item => item.id === 'clean')?.cells[0]?.recheckDueAt, '2026-08-30T00:00:00.000Z')
+    assert.equal(feed.producer.license, 'Apache-2.0')
+  })
+
+  it('renders a consumer-readable boundary and status table', () => {
+    const feed = buildDshDirectoryCompatibilityFeed({
+      ...fixture(),
+      generatedAt: '2026-08-23T01:00:00.000Z',
+    })
+    const markdown = renderDshDirectoryCompatibilityFeed(feed)
+    assert.match(markdown, /1 observed compatible · 1 observed incompatible · 2 needs review · 1 not observed/)
+    assert.match(markdown, /must then show it as stale/)
+    assert.match(markdown, /not a security review or endorsement/)
+  })
+
+  it('joins the checked-in awesome directory cohort to maintained isolated evidence', async () => {
+    const cohort = JSON.parse(await readFile('examples/dsh/awesome-observer/cohort.json', 'utf8')) as unknown
+    const installTargets = JSON.parse(await readFile('examples/dsh/install-observer/targets.json', 'utf8')) as unknown
+    const ledger = JSON.parse(await readFile('compatibility-ledger.json', 'utf8')) as unknown
+    const feed = buildDshDirectoryCompatibilityFeed({
+      cohort,
+      installTargets,
+      ledger,
+      generatedAt: '2026-08-23T08:00:00.000Z',
+    })
+
+    assert.equal(feed.plugins.length, 8)
+    assert.equal(feed.plugins.find(item => item.id === 'dsh-market')?.status, 'observed-compatible')
+    assert.equal(feed.plugins.find(item => item.id === 'dsh-better-sidebar')?.status, 'needs-review')
+    assert.equal(feed.plugins.find(item => item.id === 'dsh-openpencil')?.status, 'needs-review')
+    assert.equal(feed.plugins.find(item => item.id === 'dsh-browser')?.status, 'not-observed')
+    assert.equal(feed.plugins.filter(item => item.status === 'observed-incompatible').length, 0)
+  })
+})


### PR DESCRIPTION
## What

- join the pinned eight-plugin awesome-dsh cohort to the maintained isolated compatibility ledger
- publish JSON and Markdown evidence feeds with exact artifact, DSH, Node, profile, digest, and expiry
- keep peer-contract and unknown coverage gaps as `needs-review` instead of external failures
- regenerate and persist the feed after every dynamic reconciliation
- reclassify existing headless peer-contract incidents as review-only

## Current first batch

- 4 observed compatible
- 0 observed incompatible
- 2 needs review
- 2 not observed (source-only install paths)

## Verification

- `pnpm run check`
- `pnpm test` (332 tests)
- targeted issue/feed tests after review-only reclassification
