### PR TITLE
Expand the maintained DSH compatibility cohort to 50 plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ plugins against changing
 releases in disposable runners. When a pair breaks, it produces a reproducible
 issue; when the author ships a fix, it retests and closes the loop.
 
-**10 maintained plugin artifacts · 37 real dependency graphs · 1,025 dependency coordinates · 4 upstream reports closed**
+**50 maintained install/load targets · 50 catalog entries across all 21 categories · 4 upstream reports closed**
 
 ## Why it exists
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@ Upstream Radar 持续把一批真实插件发布物放到一次性隔离环境�
 版本重新配对测试。某个组合坏了，就生成一条可复现的 Issue；作者发布修复后，
 Radar 会再次检查并关闭闭环。
 
-**维护 10 个真实插件发布物 · 37 张真实依赖图 · 1,025 个依赖坐标 · 4 条上游报告已关闭**
+**维护 50 个安装/加载目标 · 覆盖目录全部 21 个类别 · 4 条上游报告已关闭**
 
 ## 为什么需要它
 
@@ -76,6 +76,7 @@ npx --yes upstream-radar@0.41.0 review dsh-plugin \
 一台全新的、无密钥的 GitHub 托管虚拟机和受限容器。
 
 你还可以查看[实时兼容性矩阵](examples/dsh/install-observer/README.md)、
+[可供目录消费的兼容性结果](feeds/dsh-plugin-compatibility.md)、
 [第一批 50 个插件](examples/dsh/first-batch/README.md)和
 [架构说明](docs/architecture.md)。
 

--- a/examples/dsh/awesome-observer/README.md
+++ b/examples/dsh/awesome-observer/README.md
@@ -1,26 +1,33 @@
 # awesome-dsh-plugin monitored cohort
 
-This directory binds a small operational cohort to one immutable snapshot of
+This directory binds an operational 50-plugin cohort to one immutable snapshot of
 the public [`awesome-dsh-plugin`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
 catalog. The catalog is a discovery source, not a security review or an install
 instruction.
 
 ## What was imported
 
-[`cohort.json`](cohort.json) records the exact catalog commit and eight selected
-repositories across seven DSH integration surfaces. Selection is intentionally
-small enough that every identity can be checked before execution:
+[`cohort.json`](cohort.json) records the exact catalog commit and 50 selected
+repositories across all 21 catalog categories. Every executable entry was
+included only after its catalog URL, source package name, npm package name and
+npm repository metadata agreed:
 
 | Monitoring lane | Count | Targets |
 | --- | ---: | --- |
-| Source + npm coordinate + dependency graph + isolated install/load | 6 | Agent Teams, Better Sidebar, Context, Cost Meter, DSH Market, OpenPencil |
-| Source + dependency graph only | 2 | dsh-browser, Aegis |
+| Source + npm coordinate + dependency graph + isolated install/load | 46 | Exact npm artifacts selected for adoption and category coverage |
+| Source + dependency graph only | 4 | dsh-browser, Aegis, Ouroboros DSH integration, API Relay Audit |
 
-The two source-only targets are not evidence gaps accidentally presented as npm
-packages. `dsh-browser` uses a repository-specific installer and its bridge
-package is private. Aegis documents a GitHub install while the same unscoped npm
-name belongs to another project. Radar therefore records their commits and
-graphs but never executes an unrelated npm artifact.
+The four source-only targets are not evidence gaps accidentally presented as
+npm packages. Their cataloged install paths are GitHub or repository-specific;
+`dsh-browser` also has a private bridge package, while the unscoped `aegis` npm
+name belongs to another project. Radar records their commits and graphs but
+never substitutes an unrelated npm artifact.
+
+The cohort is adoption-stratified, not simply the first 50 directory rows: it
+prioritizes downloads and Stars, limits one entry per repository and four per
+category, and still covers every category. Expanding from 8 to 50 also makes a
+clean run informative: with zero observed failures, the rough 95% upper bound
+on the underlying failure rate falls from about 37.5% to 6%.
 
 ## How the loop closes
 
@@ -34,14 +41,12 @@ pinned catalog entry
   -> install/register/load report against the changed DSH release
 ```
 
-The first observation of a repository is a baseline and does not execute code.
-After that, a new exact DSH release tests all six npm targets; a new exact plugin
-publication tests only its mapped target. Source-only commits remain static
-analysis tasks. An unchanged run updates nothing and schedules no VM.
-
-The initial compatibility baseline is dispatched explicitly once, using the
-same isolated workflow that later scheduled changes use. Results are checked in
-only after their exact DSH/plugin pairs and trace coverage have been reviewed.
+Every daily pass reconciles the current matrix, not only repository diffs.
+Missing, stale or statically invalidated npm cells are scheduled even when no
+new release appeared. A new exact DSH release invalidates every executable
+cell; a new plugin publication invalidates only its mapped cell. Source-only
+commits remain static analysis tasks. A run with fresh unchanged evidence
+schedules no VM.
 
 ## Consumer feed
 

--- a/examples/dsh/awesome-observer/cohort.json
+++ b/examples/dsh/awesome-observer/cohort.json
@@ -1,20 +1,605 @@
 {
   "schema": "upstream-radar.awesome-dsh-cohort/v1alpha1",
-  "selectedAt": "2026-08-21T09:04:58Z",
+  "selectedAt": "2026-08-23T10:19:24.671Z",
   "source": {
     "repository": "awesome-dsh-plugin/awesome-dsh-plugin",
-    "commit": "7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82",
-    "commitUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82",
+    "commit": "2e19b3c5bd42f2f688eba9df7933ace9e13e66ea",
+    "commitUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea",
     "entryDirectory": "data/plugins",
-    "entryCount": 1837,
+    "entryCount": 1884,
     "license": "CC0-1.0"
   },
   "selection": {
-    "strategy": "small-diverse-maintained-cohort",
-    "reason": "Exercise browser, UI, market, context, multi-agent, cost and skill integration surfaces before expanding execution.",
-    "trustBoundary": "The catalog discovers repositories only. Repository identity, source package identity and npm distribution identity are observed independently."
+    "strategy": "adoption-stratified-identity-checked-cohort",
+    "reason": "Cover every catalog category while prioritizing higher-download and higher-star plugins, with one repository per entry and a maximum of four entries per category.",
+    "executableCoverage": "46 exact npm artifacts; four repository-only install paths remain static-only.",
+    "trustBoundary": "The catalog discovers candidates and adoption signals only. Catalog entry, source package and npm distribution identities were verified independently before inclusion."
   },
   "plugins": [
+    {
+      "id": "dsh-plugin-mall",
+      "catalogEntry": "data/plugins/1e0zj__dsh-plugin-mall.yml",
+      "catalogUrl": "https://github.com/1e0zj/dsh-plugin-mall",
+      "repository": "1e0zj/dsh-plugin-mall",
+      "ref": "main",
+      "category": "market",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "@1e0zj/dsh-plugin-mall",
+        "version": "0.4.7"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@1e0zj/dsh-plugin-mall",
+        "selectedVersion": "0.4.7",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4446,
+        "stars": 2,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-awiki",
+      "catalogEntry": "data/plugins/AgentConnect__dsh-awiki.yml",
+      "catalogUrl": "https://github.com/AgentConnect/dsh-awiki",
+      "repository": "AgentConnect/dsh-awiki",
+      "ref": "main",
+      "category": "identity",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@awiki/dsh-plugin",
+        "version": "0.3.2"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@awiki/dsh-plugin",
+        "selectedVersion": "0.3.2",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 1984,
+        "stars": 10,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-auto-memory",
+      "catalogEntry": "data/plugins/Aik358__dsh-auto-memory.yml",
+      "catalogUrl": "https://github.com/Aik358/dsh-auto-memory",
+      "repository": "Aik358/dsh-auto-memory",
+      "ref": "main",
+      "category": "memory",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "@a9i5k4/dsh-auto-memory",
+        "version": "0.1.29"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@a9i5k4/dsh-auto-memory",
+        "selectedVersion": "0.1.29",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4699,
+        "stars": 27,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-update-checker",
+      "catalogEntry": "data/plugins/Airmetro__dsh-update-checker.yml",
+      "catalogUrl": "https://github.com/Airmetro/dsh-update-checker",
+      "repository": "Airmetro/dsh-update-checker",
+      "ref": "main",
+      "category": "dev",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-update-checker",
+        "version": "1.4.15"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-update-checker",
+        "selectedVersion": "1.4.15",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 5408,
+        "stars": 8,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-agy-link",
+      "catalogEntry": "data/plugins/amlyczz__dsh-agy-link.yml",
+      "catalogUrl": "https://github.com/amlyczz/dsh-agy-link",
+      "repository": "amlyczz/dsh-agy-link",
+      "ref": "main",
+      "category": "model",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-agy-link",
+        "version": "0.4.13"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-agy-link",
+        "selectedVersion": "0.4.13",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4001,
+        "stars": 10,
+        "nodeEngine": ">=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-vision-toolkit",
+      "catalogEntry": "data/plugins/Anionex__dsh-vision-toolkit.yml",
+      "catalogUrl": "https://github.com/Anionex/dsh-vision-toolkit",
+      "repository": "Anionex/dsh-vision-toolkit",
+      "ref": "main",
+      "category": "vision",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@anionex/dsh-vision-toolkit",
+        "version": "0.1.38"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@anionex/dsh-vision-toolkit",
+        "selectedVersion": "0.1.38",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 27048,
+        "stars": 809,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-find-plugin",
+      "catalogEntry": "data/plugins/awesome-dsh-plugin__dsh-find-plugin.yml",
+      "catalogUrl": "https://github.com/awesome-dsh-plugin/dsh-find-plugin",
+      "repository": "awesome-dsh-plugin/dsh-find-plugin",
+      "ref": "main",
+      "category": "market",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-find-plugin",
+        "version": "0.3.7"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-find-plugin",
+        "selectedVersion": "0.3.7",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 10503,
+        "stars": 79,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-remote-plugin",
+      "catalogEntry": "data/plugins/Blank-not-black__dsh-Remote--packages-plugin.yml",
+      "catalogUrl": "https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin",
+      "repository": "Blank-not-black/dsh-Remote",
+      "ref": "main",
+      "category": "remote",
+      "packagePath": "packages/plugin/package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-remote-plugin",
+        "version": "0.6.10"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-remote-plugin",
+        "selectedVersion": "0.6.10",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4499,
+        "stars": 18,
+        "nodeEngine": ">=18",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-context",
+      "catalogEntry": "data/plugins/bowenliang123__dsh-context.yml",
+      "catalogUrl": "https://github.com/bowenliang123/dsh-context",
+      "repository": "bowenliang123/dsh-context",
+      "ref": "main",
+      "category": "usage",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-context",
+        "version": "0.25.3"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-context",
+        "selectedVersion": "0.25.3",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 18345,
+        "stars": 827,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-tui",
+      "catalogEntry": "data/plugins/ccch1mneyyy__dsh-TUI.yml",
+      "catalogUrl": "https://github.com/ccch1mneyyy/dsh-TUI",
+      "repository": "ccch1mneyyy/dsh-TUI",
+      "ref": "main",
+      "category": "ui",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@deepseek-harness-tui/dsh-tui",
+        "version": "0.9.0"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@deepseek-harness-tui/dsh-tui",
+        "selectedVersion": "0.9.0",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 29066,
+        "stars": 2320,
+        "nodeEngine": "^22.19 || >=24",
+        "lifecycleScripts": [
+          "prepare"
+        ]
+      }
+    },
+    {
+      "id": "dsh-vibe-math",
+      "catalogEntry": "data/plugins/ChongCyrus__Vibe-Mathematics.yml",
+      "catalogUrl": "https://github.com/ChongCyrus/Vibe-Mathematics",
+      "repository": "ChongCyrus/Vibe-Mathematics",
+      "ref": "main",
+      "category": "workflow",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-vibe-math",
+        "version": "1.0.2"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-vibe-math",
+        "selectedVersion": "1.0.2",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4237,
+        "stars": 5,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-free-search",
+      "catalogEntry": "data/plugins/DDDMUC__dsh-free-search.yml",
+      "catalogUrl": "https://github.com/DDDMUC/dsh-free-search",
+      "repository": "DDDMUC/dsh-free-search",
+      "ref": "master",
+      "category": "browser",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-free-search",
+        "version": "0.4.12"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-free-search",
+        "selectedVersion": "0.4.12",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4338,
+        "stars": 48,
+        "nodeEngine": ">=20",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-market",
+      "catalogEntry": "data/plugins/dsh-market__dsh-market.yml",
+      "catalogUrl": "https://github.com/dsh-market/dsh-market",
+      "repository": "dsh-market/dsh-market",
+      "ref": "main",
+      "category": "market",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dshmarket",
+        "version": "1.19.0"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dshmarket",
+        "selectedVersion": "1.19.0",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 154620,
+        "stars": 1867,
+        "nodeEngine": null,
+        "lifecycleScripts": [
+          "prepare"
+        ]
+      }
+    },
+    {
+      "id": "dsh-wallpaper-engine",
+      "catalogEntry": "data/plugins/elysia395__dsh-wallpaper-engine.yml",
+      "catalogUrl": "https://github.com/elysia395/dsh-wallpaper-engine",
+      "repository": "elysia395/dsh-wallpaper-engine",
+      "ref": "main",
+      "category": "theme",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-plugin-wallpaper-engine",
+        "version": "0.5.1"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-plugin-wallpaper-engine",
+        "selectedVersion": "0.5.1",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4132,
+        "stars": 153,
+        "nodeEngine": null,
+        "lifecycleScripts": [
+          "prepare"
+        ]
+      }
+    },
+    {
+      "id": "deepseek-harness-wallet",
+      "catalogEntry": "data/plugins/feibi-mochi__deepseek-harness-control-center.yml",
+      "catalogUrl": "https://github.com/feibi-mochi/deepseek-harness-control-center",
+      "repository": "feibi-mochi/deepseek-harness-control-center",
+      "ref": "main",
+      "category": "usage",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "deepseek-harness-wallet",
+        "version": "0.3.1"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "deepseek-harness-wallet",
+        "selectedVersion": "0.3.1",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 5374,
+        "stars": 60,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-remote",
+      "catalogEntry": "data/plugins/flymysql__dsh-remote.yml",
+      "catalogUrl": "https://github.com/flymysql/dsh-remote",
+      "repository": "flymysql/dsh-remote",
+      "ref": "main",
+      "category": "tools",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-remote",
+        "version": "0.8.7"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-remote",
+        "selectedVersion": "0.8.7",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 5063,
+        "stars": 32,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-codex-connect",
+      "catalogEntry": "data/plugins/franksong2702__dsh-codex-connect.yml",
+      "catalogUrl": "https://github.com/franksong2702/dsh-codex-connect",
+      "repository": "franksong2702/dsh-codex-connect",
+      "ref": "main",
+      "category": "model",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-codex-connect",
+        "version": "0.1.0-alpha.4.15"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-codex-connect",
+        "selectedVersion": "0.1.0-alpha.4.14",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 5089,
+        "stars": 40,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-chatvoice",
+      "catalogEntry": "data/plugins/FuzzySoul__dsh-chatvoice.yml",
+      "catalogUrl": "https://github.com/FuzzySoul/dsh-chatvoice",
+      "repository": "FuzzySoul/dsh-chatvoice",
+      "ref": "main",
+      "category": "voice",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-chatvoice",
+        "version": "0.1.7"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-chatvoice",
+        "selectedVersion": "0.1.7",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 1567,
+        "stars": 1,
+        "nodeEngine": ">=18",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "aegis",
+      "catalogEntry": "data/plugins/GanyuanRan__Aegis.yml",
+      "catalogUrl": "https://github.com/GanyuanRan/Aegis",
+      "repository": "GanyuanRan/Aegis",
+      "ref": "main",
+      "category": "skill",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "aegis",
+        "version": "2.8.7"
+      },
+      "distribution": {
+        "kind": "github",
+        "installSpec": "github:GanyuanRan/Aegis",
+        "reason": "The matching DSH install path is GitHub; the aegis npm coordinate belongs to a different project."
+      },
+      "signals": {
+        "downloads": null,
+        "stars": 1113
+      }
+    },
+    {
+      "id": "dsh-cost-meter",
+      "catalogEntry": "data/plugins/Han-1413141__dsh-cost-meter.yml",
+      "catalogUrl": "https://github.com/Han-1413141/dsh-cost-meter",
+      "repository": "Han-1413141/dsh-cost-meter",
+      "ref": "master",
+      "category": "usage",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-cost-meter",
+        "version": "1.5.41"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-cost-meter",
+        "selectedVersion": "1.5.38",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 10145,
+        "stars": 162,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "modsearch",
+      "catalogEntry": "data/plugins/liustack__modsearch.yml",
+      "catalogUrl": "https://github.com/liustack/modsearch",
+      "repository": "liustack/modsearch",
+      "ref": "main",
+      "category": "browser",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@liustack/modsearch",
+        "version": "5.9.0"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@liustack/modsearch",
+        "selectedVersion": "5.9.0",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 14253,
+        "stars": 229,
+        "nodeEngine": ">=22.13",
+        "lifecycleScripts": []
+      }
+    },
     {
       "id": "dsh-browser",
       "catalogEntry": "data/plugins/Lum1104__dsh-browser--packages-browser-bridge-browser.yml",
@@ -35,98 +620,120 @@
       "distribution": {
         "kind": "repository-installer",
         "reason": "The bridge package is private and its README uses the repository installer; the unrelated dsh-browser npm name must not be substituted."
+      },
+      "signals": {
+        "downloads": null,
+        "stars": 396
       }
     },
     {
-      "id": "dsh-better-sidebar",
-      "catalogEntry": "data/plugins/omdsh-dev__DSH-better-sidebar.yml",
-      "catalogUrl": "https://github.com/omdsh-dev/DSH-better-sidebar",
-      "repository": "omdsh-dev/DSH-better-sidebar",
+      "id": "dsh-commandcode-provider",
+      "catalogEntry": "data/plugins/Mars-Sea__dsh-commandcode-provider.yml",
+      "catalogUrl": "https://github.com/Mars-Sea/dsh-commandcode-provider",
+      "repository": "Mars-Sea/dsh-commandcode-provider",
       "ref": "main",
-      "category": "ui",
+      "category": "model",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@mars-sea/dsh-commandcode-provider",
+        "version": "0.8.0"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@mars-sea/dsh-commandcode-provider",
+        "selectedVersion": "0.8.0",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4193,
+        "stars": 87,
+        "nodeEngine": ">=22",
+        "lifecycleScripts": [
+          "prepare"
+        ]
+      }
+    },
+    {
+      "id": "dsh-agency-agents",
+      "catalogEntry": "data/plugins/MichengAI__dsh-agency-agents.yml",
+      "catalogUrl": "https://github.com/MichengAI/dsh-agency-agents",
+      "repository": "MichengAI/dsh-agency-agents",
+      "ref": "main",
+      "category": "skill",
       "packagePath": "package.json",
       "lockfile": {
         "path": "pnpm-lock.yaml",
         "type": "pnpm"
       },
       "sourceCoordinateAtSelection": {
-        "name": "dsh-better-sidebar",
-        "version": "0.14.1"
+        "name": "@michengai/dsh-agency-agents",
+        "version": "0.1.20"
       },
       "distribution": {
         "kind": "npm",
-        "name": "dsh-better-sidebar",
-        "selectedVersion": "0.14.0",
+        "name": "@michengai/dsh-agency-agents",
+        "selectedVersion": "0.1.20",
         "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 3961,
+        "stars": 16,
+        "nodeEngine": null,
+        "lifecycleScripts": []
       }
     },
     {
-      "id": "dsh-market",
-      "catalogEntry": "data/plugins/dsh-market__dsh-market.yml",
-      "catalogUrl": "https://github.com/dsh-market/dsh-market",
-      "repository": "dsh-market/dsh-market",
+      "id": "dsh-mneme",
+      "catalogEntry": "data/plugins/modusensus__dsh-mneme--dsh-mneme.yml",
+      "catalogUrl": "https://github.com/modusensus/dsh-mneme/tree/main/dsh-mneme",
+      "repository": "modusensus/dsh-mneme",
       "ref": "main",
-      "category": "market",
-      "packagePath": "package.json",
-      "lockfile": {
-        "path": "pnpm-lock.yaml",
-        "type": "pnpm"
-      },
+      "category": "memory",
+      "packagePath": "dsh-mneme/package.json",
       "sourceCoordinateAtSelection": {
-        "name": "dshmarket",
-        "version": "1.17.1"
+        "name": "@modusensus/dsh-mneme",
+        "version": "0.6.10"
       },
       "distribution": {
         "kind": "npm",
-        "name": "dshmarket",
-        "selectedVersion": "1.17.1",
+        "name": "@modusensus/dsh-mneme",
+        "selectedVersion": "0.6.10",
         "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 8624,
+        "stars": 33,
+        "nodeEngine": null,
+        "lifecycleScripts": []
       }
     },
     {
-      "id": "dsh-openpencil",
-      "catalogEntry": "data/plugins/ZSeven-W__dsh-openpencil.yml",
-      "catalogUrl": "https://github.com/ZSeven-W/dsh-openpencil",
-      "repository": "ZSeven-W/dsh-openpencil",
+      "id": "dsh-doctor",
+      "catalogEntry": "data/plugins/moonquake2004__dsh-doctor--plugin.yml",
+      "catalogUrl": "https://github.com/moonquake2004/dsh-doctor/tree/main/plugin",
+      "repository": "moonquake2004/dsh-doctor",
       "ref": "main",
-      "category": "ui",
-      "packagePath": "package.json",
-      "lockfile": {
-        "path": "pnpm-lock.yaml",
-        "type": "pnpm"
-      },
+      "category": "dev",
+      "packagePath": "plugin/package.json",
       "sourceCoordinateAtSelection": {
-        "name": "@zseven-w/dsh-openpencil",
-        "version": "0.1.0-rc.1"
+        "name": "@moonquake2004/dsh-doctor",
+        "version": "0.4.3"
       },
       "distribution": {
         "kind": "npm",
-        "name": "@zseven-w/dsh-openpencil",
-        "selectedVersion": "0.1.0-rc.1",
+        "name": "@moonquake2004/dsh-doctor",
+        "selectedVersion": "0.4.3",
         "distTag": "latest"
-      }
-    },
-    {
-      "id": "dsh-context",
-      "catalogEntry": "data/plugins/bowenliang123__dsh-context.yml",
-      "catalogUrl": "https://github.com/bowenliang123/dsh-context",
-      "repository": "bowenliang123/dsh-context",
-      "ref": "main",
-      "category": "usage",
-      "packagePath": "package.json",
-      "lockfile": {
-        "path": "pnpm-lock.yaml",
-        "type": "pnpm"
       },
-      "sourceCoordinateAtSelection": {
-        "name": "dsh-context",
-        "version": "0.20.0"
-      },
-      "distribution": {
-        "kind": "npm",
-        "name": "dsh-context",
-        "selectedVersion": "0.20.0",
-        "distTag": "latest"
+      "signals": {
+        "downloads": 2802,
+        "stars": 1,
+        "nodeEngine": null,
+        "lifecycleScripts": []
       }
     },
     {
@@ -143,54 +750,655 @@
       },
       "sourceCoordinateAtSelection": {
         "name": "@nanmicoder/dsh-agent-teams",
-        "version": "0.1.10"
+        "version": "0.1.13"
       },
       "distribution": {
         "kind": "npm",
         "name": "@nanmicoder/dsh-agent-teams",
-        "selectedVersion": "0.1.10",
+        "selectedVersion": "0.1.13",
         "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 19057,
+        "stars": 841,
+        "nodeEngine": "^22.19.0 || >=24",
+        "lifecycleScripts": []
       }
     },
     {
-      "id": "dsh-cost-meter",
-      "catalogEntry": "data/plugins/Han-1413141__dsh-cost-meter.yml",
-      "catalogUrl": "https://github.com/Han-1413141/dsh-cost-meter",
-      "repository": "Han-1413141/dsh-cost-meter",
-      "ref": "master",
-      "category": "usage",
+      "id": "dsh-chat-import",
+      "catalogEntry": "data/plugins/Nwflower__dsh-chat-import.yml",
+      "catalogUrl": "https://github.com/Nwflower/dsh-chat-import",
+      "repository": "Nwflower/dsh-chat-import",
+      "ref": "main",
+      "category": "session",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-chat-import",
+        "version": "0.6.2"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-chat-import",
+        "selectedVersion": "0.6.2",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 7662,
+        "stars": 90,
+        "nodeEngine": ">=22.13",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-better-sidebar",
+      "catalogEntry": "data/plugins/omdsh-dev__DSH-better-sidebar.yml",
+      "catalogUrl": "https://github.com/omdsh-dev/DSH-better-sidebar",
+      "repository": "omdsh-dev/DSH-better-sidebar",
+      "ref": "main",
+      "category": "ui",
       "packagePath": "package.json",
       "lockfile": {
         "path": "pnpm-lock.yaml",
         "type": "pnpm"
       },
       "sourceCoordinateAtSelection": {
-        "name": "dsh-cost-meter",
-        "version": "1.5.31"
+        "name": "dsh-better-sidebar",
+        "version": "0.15.2"
       },
       "distribution": {
         "kind": "npm",
-        "name": "dsh-cost-meter",
-        "selectedVersion": "1.5.31",
+        "name": "dsh-better-sidebar",
+        "selectedVersion": "0.15.2",
         "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 95109,
+        "stars": 2666,
+        "nodeEngine": ">=20",
+        "lifecycleScripts": []
       }
     },
     {
-      "id": "aegis",
-      "catalogEntry": "data/plugins/GanyuanRan__Aegis.yml",
-      "catalogUrl": "https://github.com/GanyuanRan/Aegis",
-      "repository": "GanyuanRan/Aegis",
+      "id": "deepseek-harness-acp",
+      "catalogEntry": "data/plugins/openma-ai__deepseek-harness-acp.yml",
+      "catalogUrl": "https://github.com/openma-ai/deepseek-harness-acp",
+      "repository": "openma-ai/deepseek-harness-acp",
       "ref": "main",
-      "category": "skill",
+      "category": "notify",
       "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
       "sourceCoordinateAtSelection": {
-        "name": "aegis",
-        "version": "2.8.4"
+        "name": "@openma/deepseek-harness-acp",
+        "version": "0.4.24"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@openma/deepseek-harness-acp",
+        "selectedVersion": "0.4.24",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 6022,
+        "stars": 14,
+        "nodeEngine": ">=22.15",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-pet",
+      "catalogEntry": "data/plugins/PC2005-cloud__dsh-pet--dsh-pet.yml",
+      "catalogUrl": "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet",
+      "repository": "PC2005-cloud/dsh-pet",
+      "ref": "main",
+      "category": "fun",
+      "packagePath": "dsh-pet/package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-pet",
+        "version": "0.1.7"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-pet",
+        "selectedVersion": "0.1.7",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4288,
+        "stars": 332,
+        "nodeEngine": null,
+        "lifecycleScripts": [
+          "prepare"
+        ]
+      }
+    },
+    {
+      "id": "ouroboros-dsh-plugin",
+      "catalogEntry": "data/plugins/Q00__ouroboros--integrations-dsh-plugin.yml",
+      "catalogUrl": "https://github.com/Q00/ouroboros/tree/main/integrations/dsh-plugin",
+      "repository": "Q00/ouroboros",
+      "ref": "main",
+      "category": "workflow",
+      "packagePath": "integrations/dsh-plugin/package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-ouroboros",
+        "version": "0.1.0"
       },
       "distribution": {
         "kind": "github",
-        "installSpec": "github:GanyuanRan/Aegis",
-        "reason": "The matching DSH install path is GitHub; the aegis npm coordinate belongs to a different project."
+        "installSpec": "github:Q00/ouroboros#path:/integrations/dsh-plugin",
+        "reason": "The catalog install path is GitHub and no matching npm distribution is declared."
+      },
+      "signals": {
+        "downloads": null,
+        "stars": 5623
+      }
+    },
+    {
+      "id": "dsh-extension-hub",
+      "catalogEntry": "data/plugins/Relistencode__dsh-extension-hub.yml",
+      "catalogUrl": "https://github.com/Relistencode/dsh-extension-hub",
+      "repository": "Relistencode/dsh-extension-hub",
+      "ref": "main",
+      "category": "market",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-extension-hub",
+        "version": "0.2.19"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-extension-hub",
+        "selectedVersion": "0.2.19",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4202,
+        "stars": 8,
+        "nodeEngine": ">=22",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-dream-skin",
+      "catalogEntry": "data/plugins/RevolutionLA__dsh-dream-skin.yml",
+      "catalogUrl": "https://github.com/RevolutionLA/dsh-dream-skin",
+      "repository": "RevolutionLA/dsh-dream-skin",
+      "ref": "main",
+      "category": "theme",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-dream-skin",
+        "version": "0.4.10"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-dream-skin",
+        "selectedVersion": "0.4.10",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 8623,
+        "stars": 84,
+        "nodeEngine": ">=18",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-mobile",
+      "catalogEntry": "data/plugins/saya-ch__dsh-mobile.yml",
+      "catalogUrl": "https://github.com/saya-ch/dsh-mobile",
+      "repository": "saya-ch/dsh-mobile",
+      "ref": "main",
+      "category": "remote",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-mobile",
+        "version": "0.1.4"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-mobile",
+        "selectedVersion": "0.1.4",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 6135,
+        "stars": 120,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-pocket",
+      "catalogEntry": "data/plugins/shaobeichen__dsh-pocket.yml",
+      "catalogUrl": "https://github.com/shaobeichen/dsh-pocket",
+      "repository": "shaobeichen/dsh-pocket",
+      "ref": "main",
+      "category": "notify",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-pocket",
+        "version": "1.12.3"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-pocket",
+        "selectedVersion": "1.12.3",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 15135,
+        "stars": 463,
+        "nodeEngine": ">=22",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-auth-gate",
+      "catalogEntry": "data/plugins/TecFancy__dsh-auth-gate.yml",
+      "catalogUrl": "https://github.com/TecFancy/dsh-auth-gate",
+      "repository": "TecFancy/dsh-auth-gate",
+      "ref": "main",
+      "category": "security",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-auth-gate",
+        "version": "0.7.2"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-auth-gate",
+        "selectedVersion": "0.7.2",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 3527,
+        "stars": 4,
+        "nodeEngine": ">=22.19.0",
+        "lifecycleScripts": [
+          "prepare"
+        ]
+      }
+    },
+    {
+      "id": "dsh-notifier",
+      "catalogEntry": "data/plugins/THEWOLFWALKER__dsh-notifier.yml",
+      "catalogUrl": "https://github.com/THEWOLFWALKER/dsh-notifier",
+      "repository": "THEWOLFWALKER/dsh-notifier",
+      "ref": "main",
+      "category": "notify",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-notifier",
+        "version": "0.8.5"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-notifier",
+        "selectedVersion": "0.8.6",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 7331,
+        "stars": 58,
+        "nodeEngine": ">=22",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "api-relay-audit",
+      "catalogEntry": "data/plugins/toby-bridges__api-relay-audit.yml",
+      "catalogUrl": "https://github.com/toby-bridges/api-relay-audit",
+      "repository": "toby-bridges/api-relay-audit",
+      "ref": "master",
+      "category": "security",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-api-relay-audit",
+        "version": "2.4.0",
+        "private": true
+      },
+      "distribution": {
+        "kind": "github",
+        "installSpec": "github:toby-bridges/api-relay-audit",
+        "reason": "The catalog install path is GitHub and no matching npm distribution is declared."
+      },
+      "signals": {
+        "downloads": null,
+        "stars": 799
+      }
+    },
+    {
+      "id": "dsh-tool-lens",
+      "catalogEntry": "data/plugins/trench-xinxin__dsh-tool-lens.yml",
+      "catalogUrl": "https://github.com/trench-xinxin/dsh-tool-lens",
+      "repository": "trench-xinxin/dsh-tool-lens",
+      "ref": "main",
+      "category": "tools",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@trench-xinxin/dsh-tool-lens",
+        "version": "2.0.5"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@trench-xinxin/dsh-tool-lens",
+        "selectedVersion": "2.0.5",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 5186,
+        "stars": 2,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "archify-dsh",
+      "catalogEntry": "data/plugins/tt-a1i__archify--integrations-deepseek-harness.yml",
+      "catalogUrl": "https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness",
+      "repository": "tt-a1i/archify",
+      "ref": "main",
+      "category": "docs",
+      "packagePath": "integrations/deepseek-harness/package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "@tt-a1i/archify-dsh",
+        "version": "0.1.0"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@tt-a1i/archify-dsh",
+        "selectedVersion": "0.1.0",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 7046,
+        "stars": 15069,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "hindsight-coding-agents",
+      "catalogEntry": "data/plugins/vectorize-io__hindsight--hindsight-integrations-coding-agents.yml",
+      "catalogUrl": "https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/coding-agents",
+      "repository": "vectorize-io/hindsight",
+      "ref": "main",
+      "category": "memory",
+      "packagePath": "hindsight-integrations/coding-agents/package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@vectorize-io/hindsight-coding-agents",
+        "version": "0.4.1"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@vectorize-io/hindsight-coding-agents",
+        "selectedVersion": "0.4.1",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 18785,
+        "stars": 20935,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-git-worktree",
+      "catalogEntry": "data/plugins/wloops__dsh-git-worktree.yml",
+      "catalogUrl": "https://github.com/wloops/dsh-git-worktree",
+      "repository": "wloops/dsh-git-worktree",
+      "ref": "master",
+      "category": "git",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-git-worktree",
+        "version": "0.4.0"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-git-worktree",
+        "selectedVersion": "0.4.0",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 1695,
+        "stars": 3,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": [
+          "prepare"
+        ]
+      }
+    },
+    {
+      "id": "dsh-builtin-browser",
+      "catalogEntry": "data/plugins/wqty123__dsh-browser.yml",
+      "catalogUrl": "https://github.com/wqty123/dsh-browser",
+      "repository": "wqty123/dsh-browser",
+      "ref": "master",
+      "category": "browser",
+      "packagePath": "package.json",
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-builtin-browser",
+        "version": "0.1.15"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-builtin-browser",
+        "selectedVersion": "0.1.15",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4077,
+        "stars": 18,
+        "nodeEngine": ">=22.19",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-config-manager",
+      "catalogEntry": "data/plugins/xiajiajun516__dsh-config-manager.yml",
+      "catalogUrl": "https://github.com/xiajiajun516/dsh-config-manager",
+      "repository": "xiajiajun516/dsh-config-manager",
+      "ref": "main",
+      "category": "tools",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-config-manager",
+        "version": "0.1.45"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-config-manager",
+        "selectedVersion": "0.1.45",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 7261,
+        "stars": 12,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-im",
+      "catalogEntry": "data/plugins/xmanrui__dsh-im.yml",
+      "catalogUrl": "https://github.com/xmanrui/dsh-im",
+      "repository": "xmanrui/dsh-im",
+      "ref": "main",
+      "category": "notify",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "package-lock.json",
+        "type": "npm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@xmanrui/dsh-im",
+        "version": "1.0.2"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@xmanrui/dsh-im",
+        "selectedVersion": "1.0.2",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 6895,
+        "stars": 553,
+        "nodeEngine": ">=22.19",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-plugin-writing-guard",
+      "catalogEntry": "data/plugins/xmutfyh__dsh-plugin-writing-guard.yml",
+      "catalogUrl": "https://github.com/xmutfyh/dsh-plugin-writing-guard",
+      "repository": "xmutfyh/dsh-plugin-writing-guard",
+      "ref": "master",
+      "category": "tools",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-plugin-writing-guard",
+        "version": "1.6.2"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-plugin-writing-guard",
+        "selectedVersion": "1.6.1",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 4492,
+        "stars": 19,
+        "nodeEngine": ">=18",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-vision-router",
+      "catalogEntry": "data/plugins/ysr666__dsh-vision-router.yml",
+      "catalogUrl": "https://github.com/ysr666/dsh-vision-router",
+      "repository": "ysr666/dsh-vision-router",
+      "ref": "main",
+      "category": "vision",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "dsh-vision-router",
+        "version": "1.7.7"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-vision-router",
+        "selectedVersion": "1.7.7",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 34822,
+        "stars": 938,
+        "nodeEngine": "^22.19.0 || >=24.0.0",
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-web-ui-all",
+      "catalogEntry": "data/plugins/zhu1090093659__dsh-web-ui--packages-dsh-web-ui-all.yml",
+      "catalogUrl": "https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-web-ui-all",
+      "repository": "zhu1090093659/dsh-web-ui",
+      "ref": "main",
+      "category": "ui",
+      "packagePath": "packages/dsh-web-ui-all/package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@linxin666/dsh-web-ui-all",
+        "version": "0.2.9"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@linxin666/dsh-web-ui-all",
+        "selectedVersion": "0.2.9",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 114128,
+        "stars": 5612,
+        "nodeEngine": null,
+        "lifecycleScripts": []
+      }
+    },
+    {
+      "id": "dsh-openpencil",
+      "catalogEntry": "data/plugins/ZSeven-W__dsh-openpencil.yml",
+      "catalogUrl": "https://github.com/ZSeven-W/dsh-openpencil",
+      "repository": "ZSeven-W/dsh-openpencil",
+      "ref": "main",
+      "category": "ui",
+      "packagePath": "package.json",
+      "lockfile": {
+        "path": "pnpm-lock.yaml",
+        "type": "pnpm"
+      },
+      "sourceCoordinateAtSelection": {
+        "name": "@zseven-w/dsh-openpencil",
+        "version": "0.1.0-rc.2"
+      },
+      "distribution": {
+        "kind": "npm",
+        "name": "@zseven-w/dsh-openpencil",
+        "selectedVersion": "0.1.0-rc.1",
+        "distTag": "latest"
+      },
+      "signals": {
+        "downloads": 3298,
+        "stars": 147,
+        "nodeEngine": ">=24.11.0",
+        "lifecycleScripts": []
       }
     }
   ]

--- a/examples/dsh/install-observer/README.md
+++ b/examples/dsh/install-observer/README.md
@@ -1,12 +1,11 @@
 # DSH isolated install observer
 
-This directory is the maintained dynamic-test corpus for Upstream Radar. It is
-small on purpose: static checks cover the wider plugin inventory every day;
-dynamic code execution establishes behavior evidence for the current active
-matrix. The corpus currently contains ten published plugins: the original
-three behavior cases, six identity-checked targets imported from the
-[`awesome-dsh-plugin` cohort](../awesome-observer/README.md), and the published
-repair for the first author-confirmed dependency case.
+This directory is the maintained dynamic-test corpus for Upstream Radar.
+Static checks cover source and dependency changes every day; isolated execution
+establishes behavior evidence for the current active matrix. The corpus now
+contains 50 exact published plugins: 46 identity-checked npm artifacts imported
+from the [`awesome-dsh-plugin` cohort](../awesome-observer/README.md), plus four
+maintained behavior and repair cases.
 
 ## What runs where
 
@@ -47,8 +46,10 @@ toolchain.
 
 ## When the matrix runs
 
-[`targets.json`](targets.json) is not a popularity list. It is the set of exact
-plugins whose install/load behavior we commit to retesting. The durable
+[`targets.json`](targets.json) is not a popularity ranking. Adoption signals
+help choose the cohort, but identity, category coverage and executable evidence
+decide admission. It is the set of exact plugins whose install/load behavior we
+commit to retesting. The durable
 [`compatibility-ledger.json`](../../../compatibility-ledger.json) holds the most
 recent evidence for every active plugin × DSH × Node/runtime-policy cell.
 The same reconciliation writes a compact

--- a/examples/dsh/install-observer/targets.json
+++ b/examples/dsh/install-observer/targets.json
@@ -2,15 +2,23 @@
   "schema": "upstream-radar.dsh-install-targets/v1alpha1",
   "refreshAfterHours": 168,
   "runtimeProfiles": [
-    { "id": "node22", "nodeMajor": 22 },
-    { "id": "node24", "nodeMajor": 24 }
+    {
+      "id": "node22",
+      "nodeMajor": 22
+    },
+    {
+      "id": "node24",
+      "nodeMajor": 24
+    }
   ],
   "plugins": [
     {
       "id": "feishu-bot",
       "spec": "dsh-feishu-bot@0.16.0",
       "observerTargetId": "dsh-feishu-bot",
-      "allowedBuilds": ["protobufjs"],
+      "allowedBuilds": [
+        "protobufjs"
+      ],
       "reason": "A real messaging plugin with a large DSH dependency surface and a reachable protobuf build step."
     },
     {
@@ -26,47 +34,294 @@
       "reason": "A plugin whose native dependency makes install behavior materially different from manifest-only review."
     },
     {
-      "id": "agent-teams",
-      "spec": "@nanmicoder/dsh-agent-teams@0.1.10",
-      "observerTargetId": "dsh-agent-teams",
-      "reason": "A popular multi-agent workflow plugin imported from the awesome-dsh-plugin maintained cohort."
-    },
-    {
-      "id": "better-sidebar",
-      "spec": "dsh-better-sidebar@0.14.0",
-      "observerTargetId": "dsh-better-sidebar",
-      "allowedBuilds": ["node-pty"],
-      "reason": "A high-adoption UI workbench with a broad DSH peer surface and a native terminal dependency."
-    },
-    {
-      "id": "context",
-      "spec": "dsh-context@0.20.0",
-      "observerTargetId": "dsh-context",
-      "reason": "A context lifecycle plugin that exercises host, session and client integration boundaries."
-    },
-    {
-      "id": "cost-meter",
-      "spec": "dsh-cost-meter@1.5.31",
-      "observerTargetId": "dsh-cost-meter",
-      "reason": "A cost and budget plugin that reads DSH credential and home-path services."
-    },
-    {
-      "id": "dsh-market",
-      "spec": "dshmarket@1.17.1",
-      "observerTargetId": "dsh-market",
-      "reason": "The in-product plugin market is a high-leverage downstream consumer of DSH compatibility changes."
-    },
-    {
       "id": "sanqi-market",
       "spec": "@sanqi-normal/dsh-webui-market-plugin@0.5.5",
       "observerTargetId": "dsh-webui-market-plugin",
       "reason": "The first author-confirmed repair case proves that a new published artifact can resolve a previously broken DSH host dependency contract."
     },
     {
+      "id": "dsh-plugin-mall",
+      "spec": "@1e0zj/dsh-plugin-mall@0.4.7",
+      "observerTargetId": "dsh-plugin-mall",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4446 downloads and 2 GitHub stars to cover the market surface."
+    },
+    {
+      "id": "dsh-awiki",
+      "spec": "@awiki/dsh-plugin@0.3.2",
+      "observerTargetId": "dsh-awiki",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 1984 downloads and 10 GitHub stars to cover the identity surface."
+    },
+    {
+      "id": "dsh-auto-memory",
+      "spec": "@a9i5k4/dsh-auto-memory@0.1.29",
+      "observerTargetId": "dsh-auto-memory",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4699 downloads and 27 GitHub stars to cover the memory surface."
+    },
+    {
+      "id": "dsh-update-checker",
+      "spec": "dsh-update-checker@1.4.15",
+      "observerTargetId": "dsh-update-checker",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 5408 downloads and 8 GitHub stars to cover the dev surface."
+    },
+    {
+      "id": "dsh-agy-link",
+      "spec": "dsh-agy-link@0.4.13",
+      "observerTargetId": "dsh-agy-link",
+      "runtimeProfiles": [
+        "node24"
+      ],
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4001 downloads and 10 GitHub stars to cover the model surface."
+    },
+    {
+      "id": "dsh-vision-toolkit",
+      "spec": "@anionex/dsh-vision-toolkit@0.1.38",
+      "observerTargetId": "dsh-vision-toolkit",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 27048 downloads and 809 GitHub stars to cover the vision surface."
+    },
+    {
+      "id": "dsh-find-plugin",
+      "spec": "dsh-find-plugin@0.3.7",
+      "observerTargetId": "dsh-find-plugin",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 10503 downloads and 79 GitHub stars to cover the market surface."
+    },
+    {
+      "id": "dsh-remote-plugin",
+      "spec": "dsh-remote-plugin@0.6.10",
+      "observerTargetId": "dsh-remote-plugin",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4499 downloads and 18 GitHub stars to cover the remote surface."
+    },
+    {
+      "id": "context",
+      "spec": "dsh-context@0.25.3",
+      "observerTargetId": "dsh-context",
+      "reason": "A context lifecycle plugin that exercises host, session and client integration boundaries."
+    },
+    {
+      "id": "dsh-tui",
+      "spec": "@deepseek-harness-tui/dsh-tui@0.9.0",
+      "observerTargetId": "dsh-tui",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 29066 downloads and 2320 GitHub stars to cover the ui surface."
+    },
+    {
+      "id": "dsh-vibe-math",
+      "spec": "dsh-vibe-math@1.0.2",
+      "observerTargetId": "dsh-vibe-math",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4237 downloads and 5 GitHub stars to cover the workflow surface."
+    },
+    {
+      "id": "dsh-free-search",
+      "spec": "dsh-free-search@0.4.12",
+      "observerTargetId": "dsh-free-search",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4338 downloads and 48 GitHub stars to cover the browser surface."
+    },
+    {
+      "id": "dsh-market",
+      "spec": "dshmarket@1.19.0",
+      "observerTargetId": "dsh-market",
+      "reason": "The in-product plugin market is a high-leverage downstream consumer of DSH compatibility changes."
+    },
+    {
+      "id": "dsh-wallpaper-engine",
+      "spec": "dsh-plugin-wallpaper-engine@0.5.1",
+      "observerTargetId": "dsh-wallpaper-engine",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4132 downloads and 153 GitHub stars to cover the theme surface."
+    },
+    {
+      "id": "deepseek-harness-wallet",
+      "spec": "deepseek-harness-wallet@0.3.1",
+      "observerTargetId": "deepseek-harness-wallet",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 5374 downloads and 60 GitHub stars to cover the usage surface."
+    },
+    {
+      "id": "dsh-remote",
+      "spec": "dsh-remote@0.8.7",
+      "observerTargetId": "dsh-remote",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 5063 downloads and 32 GitHub stars to cover the tools surface."
+    },
+    {
+      "id": "dsh-codex-connect",
+      "spec": "dsh-codex-connect@0.1.0-alpha.4.14",
+      "observerTargetId": "dsh-codex-connect",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 5089 downloads and 40 GitHub stars to cover the model surface."
+    },
+    {
+      "id": "dsh-chatvoice",
+      "spec": "dsh-chatvoice@0.1.7",
+      "observerTargetId": "dsh-chatvoice",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 1567 downloads and 1 GitHub stars to cover the voice surface."
+    },
+    {
+      "id": "cost-meter",
+      "spec": "dsh-cost-meter@1.5.38",
+      "observerTargetId": "dsh-cost-meter",
+      "reason": "A cost and budget plugin that reads DSH credential and home-path services."
+    },
+    {
+      "id": "modsearch",
+      "spec": "@liustack/modsearch@5.9.0",
+      "observerTargetId": "modsearch",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 14253 downloads and 229 GitHub stars to cover the browser surface."
+    },
+    {
+      "id": "dsh-commandcode-provider",
+      "spec": "@mars-sea/dsh-commandcode-provider@0.8.0",
+      "observerTargetId": "dsh-commandcode-provider",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4193 downloads and 87 GitHub stars to cover the model surface."
+    },
+    {
+      "id": "dsh-agency-agents",
+      "spec": "@michengai/dsh-agency-agents@0.1.20",
+      "observerTargetId": "dsh-agency-agents",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 3961 downloads and 16 GitHub stars to cover the skill surface."
+    },
+    {
+      "id": "dsh-mneme",
+      "spec": "@modusensus/dsh-mneme@0.6.10",
+      "observerTargetId": "dsh-mneme",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 8624 downloads and 33 GitHub stars to cover the memory surface."
+    },
+    {
+      "id": "dsh-doctor",
+      "spec": "@moonquake2004/dsh-doctor@0.4.3",
+      "observerTargetId": "dsh-doctor",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 2802 downloads and 1 GitHub stars to cover the dev surface."
+    },
+    {
+      "id": "agent-teams",
+      "spec": "@nanmicoder/dsh-agent-teams@0.1.13",
+      "observerTargetId": "dsh-agent-teams",
+      "reason": "A popular multi-agent workflow plugin imported from the awesome-dsh-plugin maintained cohort."
+    },
+    {
+      "id": "dsh-chat-import",
+      "spec": "dsh-chat-import@0.6.2",
+      "observerTargetId": "dsh-chat-import",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 7662 downloads and 90 GitHub stars to cover the session surface."
+    },
+    {
+      "id": "better-sidebar",
+      "spec": "dsh-better-sidebar@0.15.2",
+      "observerTargetId": "dsh-better-sidebar",
+      "allowedBuilds": [
+        "node-pty"
+      ],
+      "reason": "A high-adoption UI workbench with a broad DSH peer surface and a native terminal dependency."
+    },
+    {
+      "id": "deepseek-harness-acp",
+      "spec": "@openma/deepseek-harness-acp@0.4.24",
+      "observerTargetId": "deepseek-harness-acp",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 6022 downloads and 14 GitHub stars to cover the notify surface."
+    },
+    {
+      "id": "dsh-pet",
+      "spec": "dsh-pet@0.1.7",
+      "observerTargetId": "dsh-pet",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4288 downloads and 332 GitHub stars to cover the fun surface."
+    },
+    {
+      "id": "dsh-extension-hub",
+      "spec": "dsh-extension-hub@0.2.19",
+      "observerTargetId": "dsh-extension-hub",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4202 downloads and 8 GitHub stars to cover the market surface."
+    },
+    {
+      "id": "dsh-dream-skin",
+      "spec": "dsh-dream-skin@0.4.10",
+      "observerTargetId": "dsh-dream-skin",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 8623 downloads and 84 GitHub stars to cover the theme surface."
+    },
+    {
+      "id": "dsh-mobile",
+      "spec": "dsh-mobile@0.1.4",
+      "observerTargetId": "dsh-mobile",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 6135 downloads and 120 GitHub stars to cover the remote surface."
+    },
+    {
+      "id": "dsh-pocket",
+      "spec": "dsh-pocket@1.12.3",
+      "observerTargetId": "dsh-pocket",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 15135 downloads and 463 GitHub stars to cover the notify surface."
+    },
+    {
+      "id": "dsh-auth-gate",
+      "spec": "dsh-auth-gate@0.7.2",
+      "observerTargetId": "dsh-auth-gate",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 3527 downloads and 4 GitHub stars to cover the security surface."
+    },
+    {
+      "id": "dsh-notifier",
+      "spec": "dsh-notifier@0.8.6",
+      "observerTargetId": "dsh-notifier",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 7331 downloads and 58 GitHub stars to cover the notify surface."
+    },
+    {
+      "id": "dsh-tool-lens",
+      "spec": "@trench-xinxin/dsh-tool-lens@2.0.5",
+      "observerTargetId": "dsh-tool-lens",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 5186 downloads and 2 GitHub stars to cover the tools surface."
+    },
+    {
+      "id": "archify-dsh",
+      "spec": "@tt-a1i/archify-dsh@0.1.0",
+      "observerTargetId": "archify-dsh",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 7046 downloads and 15069 GitHub stars to cover the docs surface."
+    },
+    {
+      "id": "hindsight-coding-agents",
+      "spec": "@vectorize-io/hindsight-coding-agents@0.4.1",
+      "observerTargetId": "hindsight-coding-agents",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 18785 downloads and 20935 GitHub stars to cover the memory surface."
+    },
+    {
+      "id": "dsh-git-worktree",
+      "spec": "dsh-git-worktree@0.4.0",
+      "observerTargetId": "dsh-git-worktree",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 1695 downloads and 3 GitHub stars to cover the git surface."
+    },
+    {
+      "id": "dsh-builtin-browser",
+      "spec": "dsh-builtin-browser@0.1.15",
+      "observerTargetId": "dsh-builtin-browser",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4077 downloads and 18 GitHub stars to cover the browser surface."
+    },
+    {
+      "id": "dsh-config-manager",
+      "spec": "dsh-config-manager@0.1.45",
+      "observerTargetId": "dsh-config-manager",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 7261 downloads and 12 GitHub stars to cover the tools surface."
+    },
+    {
+      "id": "dsh-im",
+      "spec": "@xmanrui/dsh-im@1.0.2",
+      "observerTargetId": "dsh-im",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 6895 downloads and 553 GitHub stars to cover the notify surface."
+    },
+    {
+      "id": "dsh-plugin-writing-guard",
+      "spec": "dsh-plugin-writing-guard@1.6.1",
+      "observerTargetId": "dsh-plugin-writing-guard",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 4492 downloads and 19 GitHub stars to cover the tools surface."
+    },
+    {
+      "id": "dsh-vision-router",
+      "spec": "dsh-vision-router@1.7.7",
+      "observerTargetId": "dsh-vision-router",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 34822 downloads and 938 GitHub stars to cover the vision surface."
+    },
+    {
+      "id": "dsh-web-ui-all",
+      "spec": "@linxin666/dsh-web-ui-all@0.2.9",
+      "observerTargetId": "dsh-web-ui-all",
+      "reason": "Identity-checked npm artifact from the 50-plugin catalog cohort; selected with 114128 downloads and 5612 GitHub stars to cover the ui surface."
+    },
+    {
       "id": "openpencil",
       "spec": "@zseven-w/dsh-openpencil@0.1.0-rc.1",
       "observerTargetId": "dsh-openpencil",
-      "runtimeProfiles": ["node24"],
+      "runtimeProfiles": [
+        "node24"
+      ],
       "reason": "A Node 24-targeted design plugin that exercises host tools and a broad web-client peer surface."
     }
   ]

--- a/examples/upstream-observer/targets.yml
+++ b/examples/upstream-observer/targets.yml
@@ -1,7 +1,6 @@
 schema: upstream-radar.observer-targets/v1alpha1
 targets:
-  # The upstream runtime itself. A new exact @deepseek-ai/dsh publication is
-  # the trigger for re-running the maintained install-observation corpus.
+  # The DSH runtime and four maintained repair/behavior cases.
   - id: deepseek-harness
     ecosystem: dsh
     repository: deepseek-ai/deepseek-harness
@@ -11,37 +10,29 @@ targets:
     packagePath: apps/cli/package.json
     lockfile: pnpm-lock.yaml
     lockfileType: pnpm
-
-  # A real public DSH/Feishu plugin. Replace it with the plugin repositories
-  # your team actually depends on.
   - id: dsh-feishu-bot
     ecosystem: dsh
     repository: PlutoKeating/dsh-lark-bot
     ref: main
-    package: dsh-feishu-bot
+    package: 'dsh-feishu-bot'
     packagePath: package.json
     lockfile: pnpm-lock.yaml
     lockfileType: pnpm
     dshVersions: ["0.1.0-rc.7", "0.1.0-rc.8"]
-
   - id: dsh-cloudflare-browser-run
     ecosystem: dsh
     repository: RealAlexandreAI/dsh-cloudflare-browser-run
     ref: main
-    package: dsh-cloudflare-browser-run
+    package: 'dsh-cloudflare-browser-run'
     packagePath: package.json
     lockfile: package-lock.json
     lockfileType: npm
-
   - id: dsh-wsl-workspace
     ecosystem: dsh
     repository: 6Mikao9/dsh-wsl-workspace
     ref: main
-    package: dsh-wsl-workspace
+    package: 'dsh-wsl-workspace'
     packagePath: package.json
-
-  # A real maintainer-repair case. This repository has no committed lockfile;
-  # the observer still watches the source manifest and the published npm release.
   - id: dsh-webui-market-plugin
     ecosystem: dsh
     repository: Sanqi-normal/dsh-webui-market-plugin
@@ -49,8 +40,162 @@ targets:
     package: '@sanqi-normal/dsh-webui-market-plugin'
     packagePath: package.json
 
-  # First maintained cohort imported from awesome-dsh-plugin at the immutable
-  # commit recorded in examples/dsh/awesome-observer/cohort.json.
+  # Adoption-stratified 50-plugin cohort imported from the immutable
+  # awesome-dsh-plugin commit recorded in the cohort manifest.
+  - id: dsh-plugin-mall
+    ecosystem: dsh
+    repository: 1e0zj/dsh-plugin-mall
+    ref: main
+    package: '@1e0zj/dsh-plugin-mall'
+    packagePath: package.json
+  - id: dsh-awiki
+    ecosystem: dsh
+    repository: AgentConnect/dsh-awiki
+    ref: main
+    package: '@awiki/dsh-plugin'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-auto-memory
+    ecosystem: dsh
+    repository: Aik358/dsh-auto-memory
+    ref: main
+    package: '@a9i5k4/dsh-auto-memory'
+    packagePath: package.json
+  - id: dsh-update-checker
+    ecosystem: dsh
+    repository: Airmetro/dsh-update-checker
+    ref: main
+    package: 'dsh-update-checker'
+    packagePath: package.json
+  - id: dsh-agy-link
+    ecosystem: dsh
+    repository: amlyczz/dsh-agy-link
+    ref: main
+    package: 'dsh-agy-link'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-vision-toolkit
+    ecosystem: dsh
+    repository: Anionex/dsh-vision-toolkit
+    ref: main
+    package: '@anionex/dsh-vision-toolkit'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-find-plugin
+    ecosystem: dsh
+    repository: awesome-dsh-plugin/dsh-find-plugin
+    ref: main
+    package: 'dsh-find-plugin'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-remote-plugin
+    ecosystem: dsh
+    repository: Blank-not-black/dsh-Remote
+    ref: main
+    package: 'dsh-remote-plugin'
+    packagePath: packages/plugin/package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-context
+    ecosystem: dsh
+    repository: bowenliang123/dsh-context
+    ref: main
+    package: 'dsh-context'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-tui
+    ecosystem: dsh
+    repository: ccch1mneyyy/dsh-TUI
+    ref: main
+    package: '@deepseek-harness-tui/dsh-tui'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-vibe-math
+    ecosystem: dsh
+    repository: ChongCyrus/Vibe-Mathematics
+    ref: main
+    package: 'dsh-vibe-math'
+    packagePath: package.json
+  - id: dsh-free-search
+    ecosystem: dsh
+    repository: DDDMUC/dsh-free-search
+    ref: master
+    package: 'dsh-free-search'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-market
+    ecosystem: dsh
+    repository: dsh-market/dsh-market
+    ref: main
+    package: 'dshmarket'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-wallpaper-engine
+    ecosystem: dsh
+    repository: elysia395/dsh-wallpaper-engine
+    ref: main
+    package: 'dsh-plugin-wallpaper-engine'
+    packagePath: package.json
+  - id: deepseek-harness-wallet
+    ecosystem: dsh
+    repository: feibi-mochi/deepseek-harness-control-center
+    ref: main
+    package: 'deepseek-harness-wallet'
+    packagePath: package.json
+  - id: dsh-remote
+    ecosystem: dsh
+    repository: flymysql/dsh-remote
+    ref: main
+    package: 'dsh-remote'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-codex-connect
+    ecosystem: dsh
+    repository: franksong2702/dsh-codex-connect
+    ref: main
+    package: 'dsh-codex-connect'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-chatvoice
+    ecosystem: dsh
+    repository: FuzzySoul/dsh-chatvoice
+    ref: main
+    package: 'dsh-chatvoice'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: aegis
+    ecosystem: dsh
+    repository: GanyuanRan/Aegis
+    ref: main
+    npm: false
+    packagePath: package.json
+  - id: dsh-cost-meter
+    ecosystem: dsh
+    repository: Han-1413141/dsh-cost-meter
+    ref: master
+    package: 'dsh-cost-meter'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: modsearch
+    ecosystem: dsh
+    repository: liustack/modsearch
+    ref: main
+    package: '@liustack/modsearch'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
   - id: dsh-browser
     ecosystem: dsh
     repository: Lum1104/dsh-browser
@@ -59,43 +204,34 @@ targets:
     packagePath: packages/browser/bridge-browser/package.json
     lockfile: pnpm-lock.yaml
     lockfileType: pnpm
-
-  - id: dsh-better-sidebar
+  - id: dsh-commandcode-provider
     ecosystem: dsh
-    repository: omdsh-dev/DSH-better-sidebar
+    repository: Mars-Sea/dsh-commandcode-provider
     ref: main
-    package: dsh-better-sidebar
+    package: '@mars-sea/dsh-commandcode-provider'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-agency-agents
+    ecosystem: dsh
+    repository: MichengAI/dsh-agency-agents
+    ref: main
+    package: '@michengai/dsh-agency-agents'
     packagePath: package.json
     lockfile: pnpm-lock.yaml
     lockfileType: pnpm
-
-  - id: dsh-market
+  - id: dsh-mneme
     ecosystem: dsh
-    repository: dsh-market/dsh-market
+    repository: modusensus/dsh-mneme
     ref: main
-    package: dshmarket
-    packagePath: package.json
-    lockfile: pnpm-lock.yaml
-    lockfileType: pnpm
-
-  - id: dsh-openpencil
+    package: '@modusensus/dsh-mneme'
+    packagePath: dsh-mneme/package.json
+  - id: dsh-doctor
     ecosystem: dsh
-    repository: ZSeven-W/dsh-openpencil
+    repository: moonquake2004/dsh-doctor
     ref: main
-    package: '@zseven-w/dsh-openpencil'
-    packagePath: package.json
-    lockfile: pnpm-lock.yaml
-    lockfileType: pnpm
-
-  - id: dsh-context
-    ecosystem: dsh
-    repository: bowenliang123/dsh-context
-    ref: main
-    package: dsh-context
-    packagePath: package.json
-    lockfile: pnpm-lock.yaml
-    lockfileType: pnpm
-
+    package: '@moonquake2004/dsh-doctor'
+    packagePath: plugin/package.json
   - id: dsh-agent-teams
     ecosystem: dsh
     repository: NanmiCoder/dsh-agent-teams
@@ -104,19 +240,171 @@ targets:
     packagePath: package.json
     lockfile: pnpm-lock.yaml
     lockfileType: pnpm
-
-  - id: dsh-cost-meter
+  - id: dsh-chat-import
     ecosystem: dsh
-    repository: Han-1413141/dsh-cost-meter
-    ref: master
-    package: dsh-cost-meter
+    repository: Nwflower/dsh-chat-import
+    ref: main
+    package: 'dsh-chat-import'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-better-sidebar
+    ecosystem: dsh
+    repository: omdsh-dev/DSH-better-sidebar
+    ref: main
+    package: 'dsh-better-sidebar'
     packagePath: package.json
     lockfile: pnpm-lock.yaml
     lockfileType: pnpm
-
-  - id: aegis
+  - id: deepseek-harness-acp
     ecosystem: dsh
-    repository: GanyuanRan/Aegis
+    repository: openma-ai/deepseek-harness-acp
+    ref: main
+    package: '@openma/deepseek-harness-acp'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-pet
+    ecosystem: dsh
+    repository: PC2005-cloud/dsh-pet
+    ref: main
+    package: 'dsh-pet'
+    packagePath: dsh-pet/package.json
+  - id: ouroboros-dsh-plugin
+    ecosystem: dsh
+    repository: Q00/ouroboros
     ref: main
     npm: false
+    packagePath: integrations/dsh-plugin/package.json
+  - id: dsh-extension-hub
+    ecosystem: dsh
+    repository: Relistencode/dsh-extension-hub
+    ref: main
+    package: 'dsh-extension-hub'
     packagePath: package.json
+  - id: dsh-dream-skin
+    ecosystem: dsh
+    repository: RevolutionLA/dsh-dream-skin
+    ref: main
+    package: 'dsh-dream-skin'
+    packagePath: package.json
+  - id: dsh-mobile
+    ecosystem: dsh
+    repository: saya-ch/dsh-mobile
+    ref: main
+    package: 'dsh-mobile'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-pocket
+    ecosystem: dsh
+    repository: shaobeichen/dsh-pocket
+    ref: main
+    package: 'dsh-pocket'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-auth-gate
+    ecosystem: dsh
+    repository: TecFancy/dsh-auth-gate
+    ref: main
+    package: 'dsh-auth-gate'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-notifier
+    ecosystem: dsh
+    repository: THEWOLFWALKER/dsh-notifier
+    ref: main
+    package: 'dsh-notifier'
+    packagePath: package.json
+  - id: api-relay-audit
+    ecosystem: dsh
+    repository: toby-bridges/api-relay-audit
+    ref: master
+    npm: false
+    packagePath: package.json
+  - id: dsh-tool-lens
+    ecosystem: dsh
+    repository: trench-xinxin/dsh-tool-lens
+    ref: main
+    package: '@trench-xinxin/dsh-tool-lens'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: archify-dsh
+    ecosystem: dsh
+    repository: tt-a1i/archify
+    ref: main
+    package: '@tt-a1i/archify-dsh'
+    packagePath: integrations/deepseek-harness/package.json
+  - id: hindsight-coding-agents
+    ecosystem: dsh
+    repository: vectorize-io/hindsight
+    ref: main
+    package: '@vectorize-io/hindsight-coding-agents'
+    packagePath: hindsight-integrations/coding-agents/package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-git-worktree
+    ecosystem: dsh
+    repository: wloops/dsh-git-worktree
+    ref: master
+    package: 'dsh-git-worktree'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-builtin-browser
+    ecosystem: dsh
+    repository: wqty123/dsh-browser
+    ref: master
+    package: 'dsh-builtin-browser'
+    packagePath: package.json
+  - id: dsh-config-manager
+    ecosystem: dsh
+    repository: xiajiajun516/dsh-config-manager
+    ref: main
+    package: 'dsh-config-manager'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-im
+    ecosystem: dsh
+    repository: xmanrui/dsh-im
+    ref: main
+    package: '@xmanrui/dsh-im'
+    packagePath: package.json
+    lockfile: package-lock.json
+    lockfileType: npm
+  - id: dsh-plugin-writing-guard
+    ecosystem: dsh
+    repository: xmutfyh/dsh-plugin-writing-guard
+    ref: master
+    package: 'dsh-plugin-writing-guard'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-vision-router
+    ecosystem: dsh
+    repository: ysr666/dsh-vision-router
+    ref: main
+    package: 'dsh-vision-router'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-web-ui-all
+    ecosystem: dsh
+    repository: zhu1090093659/dsh-web-ui
+    ref: main
+    package: '@linxin666/dsh-web-ui-all'
+    packagePath: packages/dsh-web-ui-all/package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm
+  - id: dsh-openpencil
+    ecosystem: dsh
+    repository: ZSeven-W/dsh-openpencil
+    ref: main
+    package: '@zseven-w/dsh-openpencil'
+    packagePath: package.json
+    lockfile: pnpm-lock.yaml
+    lockfileType: pnpm

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -1,6 +1,6 @@
 {
   "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha1",
-  "generatedAt": "2026-08-23T08:09:33.232Z",
+  "generatedAt": "2026-08-23T10:22:07.182Z",
   "producer": {
     "name": "upstream-radar",
     "version": "0.41.0",
@@ -9,10 +9,10 @@
   },
   "sourceCatalog": {
     "repository": "awesome-dsh-plugin/awesome-dsh-plugin",
-    "commit": "7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82",
-    "commitUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82",
+    "commit": "2e19b3c5bd42f2f688eba9df7933ace9e13e66ea",
+    "commitUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea",
     "entryDirectory": "data/plugins",
-    "entryCount": 1837,
+    "entryCount": 1884,
     "license": "CC0-1.0"
   },
   "boundary": {
@@ -24,25 +24,169 @@
     "refreshAfterHours": 168
   },
   "summary": {
-    "total": 8,
+    "total": 50,
     "observed-compatible": 4,
     "observed-incompatible": 0,
     "needs-review": 2,
-    "not-observed": 2
+    "not-observed": 44
   },
   "plugins": [
+    {
+      "id": "dsh-plugin-mall",
+      "repository": "1e0zj/dsh-plugin-mall",
+      "repositoryUrl": "https://github.com/1e0zj/dsh-plugin-mall",
+      "catalogUrl": "https://github.com/1e0zj/dsh-plugin-mall",
+      "catalogEntry": "data/plugins/1e0zj__dsh-plugin-mall.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/1e0zj__dsh-plugin-mall.yml",
+      "category": "market",
+      "distribution": {
+        "kind": "npm",
+        "name": "@1e0zj/dsh-plugin-mall",
+        "selectedVersion": "0.4.7",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-awiki",
+      "repository": "AgentConnect/dsh-awiki",
+      "repositoryUrl": "https://github.com/AgentConnect/dsh-awiki",
+      "catalogUrl": "https://github.com/AgentConnect/dsh-awiki",
+      "catalogEntry": "data/plugins/AgentConnect__dsh-awiki.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/AgentConnect__dsh-awiki.yml",
+      "category": "identity",
+      "distribution": {
+        "kind": "npm",
+        "name": "@awiki/dsh-plugin",
+        "selectedVersion": "0.3.2",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-auto-memory",
+      "repository": "Aik358/dsh-auto-memory",
+      "repositoryUrl": "https://github.com/Aik358/dsh-auto-memory",
+      "catalogUrl": "https://github.com/Aik358/dsh-auto-memory",
+      "catalogEntry": "data/plugins/Aik358__dsh-auto-memory.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Aik358__dsh-auto-memory.yml",
+      "category": "memory",
+      "distribution": {
+        "kind": "npm",
+        "name": "@a9i5k4/dsh-auto-memory",
+        "selectedVersion": "0.1.29",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-update-checker",
+      "repository": "Airmetro/dsh-update-checker",
+      "repositoryUrl": "https://github.com/Airmetro/dsh-update-checker",
+      "catalogUrl": "https://github.com/Airmetro/dsh-update-checker",
+      "catalogEntry": "data/plugins/Airmetro__dsh-update-checker.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Airmetro__dsh-update-checker.yml",
+      "category": "dev",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-update-checker",
+        "selectedVersion": "1.4.15",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-agy-link",
+      "repository": "amlyczz/dsh-agy-link",
+      "repositoryUrl": "https://github.com/amlyczz/dsh-agy-link",
+      "catalogUrl": "https://github.com/amlyczz/dsh-agy-link",
+      "catalogEntry": "data/plugins/amlyczz__dsh-agy-link.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/amlyczz__dsh-agy-link.yml",
+      "category": "model",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-agy-link",
+        "selectedVersion": "0.4.13",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-vision-toolkit",
+      "repository": "Anionex/dsh-vision-toolkit",
+      "repositoryUrl": "https://github.com/Anionex/dsh-vision-toolkit",
+      "catalogUrl": "https://github.com/Anionex/dsh-vision-toolkit",
+      "catalogEntry": "data/plugins/Anionex__dsh-vision-toolkit.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Anionex__dsh-vision-toolkit.yml",
+      "category": "vision",
+      "distribution": {
+        "kind": "npm",
+        "name": "@anionex/dsh-vision-toolkit",
+        "selectedVersion": "0.1.38",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-find-plugin",
+      "repository": "awesome-dsh-plugin/dsh-find-plugin",
+      "repositoryUrl": "https://github.com/awesome-dsh-plugin/dsh-find-plugin",
+      "catalogUrl": "https://github.com/awesome-dsh-plugin/dsh-find-plugin",
+      "catalogEntry": "data/plugins/awesome-dsh-plugin__dsh-find-plugin.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/awesome-dsh-plugin__dsh-find-plugin.yml",
+      "category": "market",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-find-plugin",
+        "selectedVersion": "0.3.7",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-remote-plugin",
+      "repository": "Blank-not-black/dsh-Remote",
+      "repositoryUrl": "https://github.com/Blank-not-black/dsh-Remote",
+      "catalogUrl": "https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin",
+      "catalogEntry": "data/plugins/Blank-not-black__dsh-Remote--packages-plugin.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Blank-not-black__dsh-Remote--packages-plugin.yml",
+      "category": "remote",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-remote-plugin",
+        "selectedVersion": "0.6.10",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
     {
       "id": "dsh-context",
       "repository": "bowenliang123/dsh-context",
       "repositoryUrl": "https://github.com/bowenliang123/dsh-context",
       "catalogUrl": "https://github.com/bowenliang123/dsh-context",
       "catalogEntry": "data/plugins/bowenliang123__dsh-context.yml",
-      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/bowenliang123__dsh-context.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/bowenliang123__dsh-context.yml",
       "category": "usage",
       "distribution": {
         "kind": "npm",
         "name": "dsh-context",
-        "selectedVersion": "0.20.0",
+        "selectedVersion": "0.25.3",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -75,17 +219,71 @@
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
     },
     {
+      "id": "dsh-tui",
+      "repository": "ccch1mneyyy/dsh-TUI",
+      "repositoryUrl": "https://github.com/ccch1mneyyy/dsh-TUI",
+      "catalogUrl": "https://github.com/ccch1mneyyy/dsh-TUI",
+      "catalogEntry": "data/plugins/ccch1mneyyy__dsh-TUI.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/ccch1mneyyy__dsh-TUI.yml",
+      "category": "ui",
+      "distribution": {
+        "kind": "npm",
+        "name": "@deepseek-harness-tui/dsh-tui",
+        "selectedVersion": "0.9.0",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-vibe-math",
+      "repository": "ChongCyrus/Vibe-Mathematics",
+      "repositoryUrl": "https://github.com/ChongCyrus/Vibe-Mathematics",
+      "catalogUrl": "https://github.com/ChongCyrus/Vibe-Mathematics",
+      "catalogEntry": "data/plugins/ChongCyrus__Vibe-Mathematics.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/ChongCyrus__Vibe-Mathematics.yml",
+      "category": "workflow",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-vibe-math",
+        "selectedVersion": "1.0.2",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-free-search",
+      "repository": "DDDMUC/dsh-free-search",
+      "repositoryUrl": "https://github.com/DDDMUC/dsh-free-search",
+      "catalogUrl": "https://github.com/DDDMUC/dsh-free-search",
+      "catalogEntry": "data/plugins/DDDMUC__dsh-free-search.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/DDDMUC__dsh-free-search.yml",
+      "category": "browser",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-free-search",
+        "selectedVersion": "0.4.12",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
       "id": "dsh-market",
       "repository": "dsh-market/dsh-market",
       "repositoryUrl": "https://github.com/dsh-market/dsh-market",
       "catalogUrl": "https://github.com/dsh-market/dsh-market",
       "catalogEntry": "data/plugins/dsh-market__dsh-market.yml",
-      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/dsh-market__dsh-market.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/dsh-market__dsh-market.yml",
       "category": "market",
       "distribution": {
         "kind": "npm",
         "name": "dshmarket",
-        "selectedVersion": "1.17.1",
+        "selectedVersion": "1.19.0",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -118,12 +316,102 @@
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
     },
     {
+      "id": "dsh-wallpaper-engine",
+      "repository": "elysia395/dsh-wallpaper-engine",
+      "repositoryUrl": "https://github.com/elysia395/dsh-wallpaper-engine",
+      "catalogUrl": "https://github.com/elysia395/dsh-wallpaper-engine",
+      "catalogEntry": "data/plugins/elysia395__dsh-wallpaper-engine.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/elysia395__dsh-wallpaper-engine.yml",
+      "category": "theme",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-plugin-wallpaper-engine",
+        "selectedVersion": "0.5.1",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "deepseek-harness-wallet",
+      "repository": "feibi-mochi/deepseek-harness-control-center",
+      "repositoryUrl": "https://github.com/feibi-mochi/deepseek-harness-control-center",
+      "catalogUrl": "https://github.com/feibi-mochi/deepseek-harness-control-center",
+      "catalogEntry": "data/plugins/feibi-mochi__deepseek-harness-control-center.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/feibi-mochi__deepseek-harness-control-center.yml",
+      "category": "usage",
+      "distribution": {
+        "kind": "npm",
+        "name": "deepseek-harness-wallet",
+        "selectedVersion": "0.3.1",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-remote",
+      "repository": "flymysql/dsh-remote",
+      "repositoryUrl": "https://github.com/flymysql/dsh-remote",
+      "catalogUrl": "https://github.com/flymysql/dsh-remote",
+      "catalogEntry": "data/plugins/flymysql__dsh-remote.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/flymysql__dsh-remote.yml",
+      "category": "tools",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-remote",
+        "selectedVersion": "0.8.7",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-codex-connect",
+      "repository": "franksong2702/dsh-codex-connect",
+      "repositoryUrl": "https://github.com/franksong2702/dsh-codex-connect",
+      "catalogUrl": "https://github.com/franksong2702/dsh-codex-connect",
+      "catalogEntry": "data/plugins/franksong2702__dsh-codex-connect.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/franksong2702__dsh-codex-connect.yml",
+      "category": "model",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-codex-connect",
+        "selectedVersion": "0.1.0-alpha.4.14",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-chatvoice",
+      "repository": "FuzzySoul/dsh-chatvoice",
+      "repositoryUrl": "https://github.com/FuzzySoul/dsh-chatvoice",
+      "catalogUrl": "https://github.com/FuzzySoul/dsh-chatvoice",
+      "catalogEntry": "data/plugins/FuzzySoul__dsh-chatvoice.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/FuzzySoul__dsh-chatvoice.yml",
+      "category": "voice",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-chatvoice",
+        "selectedVersion": "0.1.7",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
       "id": "aegis",
       "repository": "GanyuanRan/Aegis",
       "repositoryUrl": "https://github.com/GanyuanRan/Aegis",
       "catalogUrl": "https://github.com/GanyuanRan/Aegis",
       "catalogEntry": "data/plugins/GanyuanRan__Aegis.yml",
-      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/GanyuanRan__Aegis.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/GanyuanRan__Aegis.yml",
       "category": "skill",
       "distribution": {
         "kind": "github",
@@ -140,12 +428,12 @@
       "repositoryUrl": "https://github.com/Han-1413141/dsh-cost-meter",
       "catalogUrl": "https://github.com/Han-1413141/dsh-cost-meter",
       "catalogEntry": "data/plugins/Han-1413141__dsh-cost-meter.yml",
-      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/Han-1413141__dsh-cost-meter.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Han-1413141__dsh-cost-meter.yml",
       "category": "usage",
       "distribution": {
         "kind": "npm",
         "name": "dsh-cost-meter",
-        "selectedVersion": "1.5.31",
+        "selectedVersion": "1.5.38",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -178,16 +466,106 @@
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
     },
     {
+      "id": "modsearch",
+      "repository": "liustack/modsearch",
+      "repositoryUrl": "https://github.com/liustack/modsearch",
+      "catalogUrl": "https://github.com/liustack/modsearch",
+      "catalogEntry": "data/plugins/liustack__modsearch.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/liustack__modsearch.yml",
+      "category": "browser",
+      "distribution": {
+        "kind": "npm",
+        "name": "@liustack/modsearch",
+        "selectedVersion": "5.9.0",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
       "id": "dsh-browser",
       "repository": "Lum1104/dsh-browser",
       "repositoryUrl": "https://github.com/Lum1104/dsh-browser",
       "catalogUrl": "https://github.com/Lum1104/dsh-browser/tree/main/packages/browser/bridge-browser",
       "catalogEntry": "data/plugins/Lum1104__dsh-browser--packages-browser-bridge-browser.yml",
-      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/Lum1104__dsh-browser--packages-browser-bridge-browser.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Lum1104__dsh-browser--packages-browser-bridge-browser.yml",
       "category": "browser",
       "distribution": {
         "kind": "repository-installer",
         "reason": "The bridge package is private and its README uses the repository installer; the unrelated dsh-browser npm name must not be substituted."
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-commandcode-provider",
+      "repository": "Mars-Sea/dsh-commandcode-provider",
+      "repositoryUrl": "https://github.com/Mars-Sea/dsh-commandcode-provider",
+      "catalogUrl": "https://github.com/Mars-Sea/dsh-commandcode-provider",
+      "catalogEntry": "data/plugins/Mars-Sea__dsh-commandcode-provider.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Mars-Sea__dsh-commandcode-provider.yml",
+      "category": "model",
+      "distribution": {
+        "kind": "npm",
+        "name": "@mars-sea/dsh-commandcode-provider",
+        "selectedVersion": "0.8.0",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-agency-agents",
+      "repository": "MichengAI/dsh-agency-agents",
+      "repositoryUrl": "https://github.com/MichengAI/dsh-agency-agents",
+      "catalogUrl": "https://github.com/MichengAI/dsh-agency-agents",
+      "catalogEntry": "data/plugins/MichengAI__dsh-agency-agents.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/MichengAI__dsh-agency-agents.yml",
+      "category": "skill",
+      "distribution": {
+        "kind": "npm",
+        "name": "@michengai/dsh-agency-agents",
+        "selectedVersion": "0.1.20",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-mneme",
+      "repository": "modusensus/dsh-mneme",
+      "repositoryUrl": "https://github.com/modusensus/dsh-mneme",
+      "catalogUrl": "https://github.com/modusensus/dsh-mneme/tree/main/dsh-mneme",
+      "catalogEntry": "data/plugins/modusensus__dsh-mneme--dsh-mneme.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/modusensus__dsh-mneme--dsh-mneme.yml",
+      "category": "memory",
+      "distribution": {
+        "kind": "npm",
+        "name": "@modusensus/dsh-mneme",
+        "selectedVersion": "0.6.10",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-doctor",
+      "repository": "moonquake2004/dsh-doctor",
+      "repositoryUrl": "https://github.com/moonquake2004/dsh-doctor",
+      "catalogUrl": "https://github.com/moonquake2004/dsh-doctor/tree/main/plugin",
+      "catalogEntry": "data/plugins/moonquake2004__dsh-doctor--plugin.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/moonquake2004__dsh-doctor--plugin.yml",
+      "category": "dev",
+      "distribution": {
+        "kind": "npm",
+        "name": "@moonquake2004/dsh-doctor",
+        "selectedVersion": "0.4.3",
+        "distTag": "latest"
       },
       "status": "not-observed",
       "cells": [],
@@ -199,12 +577,12 @@
       "repositoryUrl": "https://github.com/NanmiCoder/dsh-agent-teams",
       "catalogUrl": "https://github.com/NanmiCoder/dsh-agent-teams",
       "catalogEntry": "data/plugins/NanmiCoder__dsh-agent-teams.yml",
-      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/NanmiCoder__dsh-agent-teams.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/NanmiCoder__dsh-agent-teams.yml",
       "category": "workflow",
       "distribution": {
         "kind": "npm",
         "name": "@nanmicoder/dsh-agent-teams",
-        "selectedVersion": "0.1.10",
+        "selectedVersion": "0.1.13",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -237,17 +615,35 @@
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
     },
     {
+      "id": "dsh-chat-import",
+      "repository": "Nwflower/dsh-chat-import",
+      "repositoryUrl": "https://github.com/Nwflower/dsh-chat-import",
+      "catalogUrl": "https://github.com/Nwflower/dsh-chat-import",
+      "catalogEntry": "data/plugins/Nwflower__dsh-chat-import.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Nwflower__dsh-chat-import.yml",
+      "category": "session",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-chat-import",
+        "selectedVersion": "0.6.2",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
       "id": "dsh-better-sidebar",
       "repository": "omdsh-dev/DSH-better-sidebar",
       "repositoryUrl": "https://github.com/omdsh-dev/DSH-better-sidebar",
       "catalogUrl": "https://github.com/omdsh-dev/DSH-better-sidebar",
       "catalogEntry": "data/plugins/omdsh-dev__DSH-better-sidebar.yml",
-      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/omdsh-dev__DSH-better-sidebar.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/omdsh-dev__DSH-better-sidebar.yml",
       "category": "ui",
       "distribution": {
         "kind": "npm",
         "name": "dsh-better-sidebar",
-        "selectedVersion": "0.14.0",
+        "selectedVersion": "0.15.2",
         "distTag": "latest"
       },
       "status": "needs-review",
@@ -280,12 +676,370 @@
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
     },
     {
+      "id": "deepseek-harness-acp",
+      "repository": "openma-ai/deepseek-harness-acp",
+      "repositoryUrl": "https://github.com/openma-ai/deepseek-harness-acp",
+      "catalogUrl": "https://github.com/openma-ai/deepseek-harness-acp",
+      "catalogEntry": "data/plugins/openma-ai__deepseek-harness-acp.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/openma-ai__deepseek-harness-acp.yml",
+      "category": "notify",
+      "distribution": {
+        "kind": "npm",
+        "name": "@openma/deepseek-harness-acp",
+        "selectedVersion": "0.4.24",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-pet",
+      "repository": "PC2005-cloud/dsh-pet",
+      "repositoryUrl": "https://github.com/PC2005-cloud/dsh-pet",
+      "catalogUrl": "https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet",
+      "catalogEntry": "data/plugins/PC2005-cloud__dsh-pet--dsh-pet.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/PC2005-cloud__dsh-pet--dsh-pet.yml",
+      "category": "fun",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-pet",
+        "selectedVersion": "0.1.7",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "ouroboros-dsh-plugin",
+      "repository": "Q00/ouroboros",
+      "repositoryUrl": "https://github.com/Q00/ouroboros",
+      "catalogUrl": "https://github.com/Q00/ouroboros/tree/main/integrations/dsh-plugin",
+      "catalogEntry": "data/plugins/Q00__ouroboros--integrations-dsh-plugin.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Q00__ouroboros--integrations-dsh-plugin.yml",
+      "category": "workflow",
+      "distribution": {
+        "kind": "github",
+        "reason": "The catalog install path is GitHub and no matching npm distribution is declared.",
+        "installSpec": "github:Q00/ouroboros#path:/integrations/dsh-plugin"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-extension-hub",
+      "repository": "Relistencode/dsh-extension-hub",
+      "repositoryUrl": "https://github.com/Relistencode/dsh-extension-hub",
+      "catalogUrl": "https://github.com/Relistencode/dsh-extension-hub",
+      "catalogEntry": "data/plugins/Relistencode__dsh-extension-hub.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/Relistencode__dsh-extension-hub.yml",
+      "category": "market",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-extension-hub",
+        "selectedVersion": "0.2.19",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-dream-skin",
+      "repository": "RevolutionLA/dsh-dream-skin",
+      "repositoryUrl": "https://github.com/RevolutionLA/dsh-dream-skin",
+      "catalogUrl": "https://github.com/RevolutionLA/dsh-dream-skin",
+      "catalogEntry": "data/plugins/RevolutionLA__dsh-dream-skin.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/RevolutionLA__dsh-dream-skin.yml",
+      "category": "theme",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-dream-skin",
+        "selectedVersion": "0.4.10",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-mobile",
+      "repository": "saya-ch/dsh-mobile",
+      "repositoryUrl": "https://github.com/saya-ch/dsh-mobile",
+      "catalogUrl": "https://github.com/saya-ch/dsh-mobile",
+      "catalogEntry": "data/plugins/saya-ch__dsh-mobile.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/saya-ch__dsh-mobile.yml",
+      "category": "remote",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-mobile",
+        "selectedVersion": "0.1.4",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-pocket",
+      "repository": "shaobeichen/dsh-pocket",
+      "repositoryUrl": "https://github.com/shaobeichen/dsh-pocket",
+      "catalogUrl": "https://github.com/shaobeichen/dsh-pocket",
+      "catalogEntry": "data/plugins/shaobeichen__dsh-pocket.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/shaobeichen__dsh-pocket.yml",
+      "category": "notify",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-pocket",
+        "selectedVersion": "1.12.3",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-auth-gate",
+      "repository": "TecFancy/dsh-auth-gate",
+      "repositoryUrl": "https://github.com/TecFancy/dsh-auth-gate",
+      "catalogUrl": "https://github.com/TecFancy/dsh-auth-gate",
+      "catalogEntry": "data/plugins/TecFancy__dsh-auth-gate.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/TecFancy__dsh-auth-gate.yml",
+      "category": "security",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-auth-gate",
+        "selectedVersion": "0.7.2",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-notifier",
+      "repository": "THEWOLFWALKER/dsh-notifier",
+      "repositoryUrl": "https://github.com/THEWOLFWALKER/dsh-notifier",
+      "catalogUrl": "https://github.com/THEWOLFWALKER/dsh-notifier",
+      "catalogEntry": "data/plugins/THEWOLFWALKER__dsh-notifier.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/THEWOLFWALKER__dsh-notifier.yml",
+      "category": "notify",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-notifier",
+        "selectedVersion": "0.8.6",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "api-relay-audit",
+      "repository": "toby-bridges/api-relay-audit",
+      "repositoryUrl": "https://github.com/toby-bridges/api-relay-audit",
+      "catalogUrl": "https://github.com/toby-bridges/api-relay-audit",
+      "catalogEntry": "data/plugins/toby-bridges__api-relay-audit.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/toby-bridges__api-relay-audit.yml",
+      "category": "security",
+      "distribution": {
+        "kind": "github",
+        "reason": "The catalog install path is GitHub and no matching npm distribution is declared.",
+        "installSpec": "github:toby-bridges/api-relay-audit"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-tool-lens",
+      "repository": "trench-xinxin/dsh-tool-lens",
+      "repositoryUrl": "https://github.com/trench-xinxin/dsh-tool-lens",
+      "catalogUrl": "https://github.com/trench-xinxin/dsh-tool-lens",
+      "catalogEntry": "data/plugins/trench-xinxin__dsh-tool-lens.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/trench-xinxin__dsh-tool-lens.yml",
+      "category": "tools",
+      "distribution": {
+        "kind": "npm",
+        "name": "@trench-xinxin/dsh-tool-lens",
+        "selectedVersion": "2.0.5",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "archify-dsh",
+      "repository": "tt-a1i/archify",
+      "repositoryUrl": "https://github.com/tt-a1i/archify",
+      "catalogUrl": "https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness",
+      "catalogEntry": "data/plugins/tt-a1i__archify--integrations-deepseek-harness.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/tt-a1i__archify--integrations-deepseek-harness.yml",
+      "category": "docs",
+      "distribution": {
+        "kind": "npm",
+        "name": "@tt-a1i/archify-dsh",
+        "selectedVersion": "0.1.0",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "hindsight-coding-agents",
+      "repository": "vectorize-io/hindsight",
+      "repositoryUrl": "https://github.com/vectorize-io/hindsight",
+      "catalogUrl": "https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/coding-agents",
+      "catalogEntry": "data/plugins/vectorize-io__hindsight--hindsight-integrations-coding-agents.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/vectorize-io__hindsight--hindsight-integrations-coding-agents.yml",
+      "category": "memory",
+      "distribution": {
+        "kind": "npm",
+        "name": "@vectorize-io/hindsight-coding-agents",
+        "selectedVersion": "0.4.1",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-git-worktree",
+      "repository": "wloops/dsh-git-worktree",
+      "repositoryUrl": "https://github.com/wloops/dsh-git-worktree",
+      "catalogUrl": "https://github.com/wloops/dsh-git-worktree",
+      "catalogEntry": "data/plugins/wloops__dsh-git-worktree.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/wloops__dsh-git-worktree.yml",
+      "category": "git",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-git-worktree",
+        "selectedVersion": "0.4.0",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-builtin-browser",
+      "repository": "wqty123/dsh-browser",
+      "repositoryUrl": "https://github.com/wqty123/dsh-browser",
+      "catalogUrl": "https://github.com/wqty123/dsh-browser",
+      "catalogEntry": "data/plugins/wqty123__dsh-browser.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/wqty123__dsh-browser.yml",
+      "category": "browser",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-builtin-browser",
+        "selectedVersion": "0.1.15",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-config-manager",
+      "repository": "xiajiajun516/dsh-config-manager",
+      "repositoryUrl": "https://github.com/xiajiajun516/dsh-config-manager",
+      "catalogUrl": "https://github.com/xiajiajun516/dsh-config-manager",
+      "catalogEntry": "data/plugins/xiajiajun516__dsh-config-manager.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/xiajiajun516__dsh-config-manager.yml",
+      "category": "tools",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-config-manager",
+        "selectedVersion": "0.1.45",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-im",
+      "repository": "xmanrui/dsh-im",
+      "repositoryUrl": "https://github.com/xmanrui/dsh-im",
+      "catalogUrl": "https://github.com/xmanrui/dsh-im",
+      "catalogEntry": "data/plugins/xmanrui__dsh-im.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/xmanrui__dsh-im.yml",
+      "category": "notify",
+      "distribution": {
+        "kind": "npm",
+        "name": "@xmanrui/dsh-im",
+        "selectedVersion": "1.0.2",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-plugin-writing-guard",
+      "repository": "xmutfyh/dsh-plugin-writing-guard",
+      "repositoryUrl": "https://github.com/xmutfyh/dsh-plugin-writing-guard",
+      "catalogUrl": "https://github.com/xmutfyh/dsh-plugin-writing-guard",
+      "catalogEntry": "data/plugins/xmutfyh__dsh-plugin-writing-guard.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/xmutfyh__dsh-plugin-writing-guard.yml",
+      "category": "tools",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-plugin-writing-guard",
+        "selectedVersion": "1.6.1",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-vision-router",
+      "repository": "ysr666/dsh-vision-router",
+      "repositoryUrl": "https://github.com/ysr666/dsh-vision-router",
+      "catalogUrl": "https://github.com/ysr666/dsh-vision-router",
+      "catalogEntry": "data/plugins/ysr666__dsh-vision-router.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/ysr666__dsh-vision-router.yml",
+      "category": "vision",
+      "distribution": {
+        "kind": "npm",
+        "name": "dsh-vision-router",
+        "selectedVersion": "1.7.7",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
+      "id": "dsh-web-ui-all",
+      "repository": "zhu1090093659/dsh-web-ui",
+      "repositoryUrl": "https://github.com/zhu1090093659/dsh-web-ui",
+      "catalogUrl": "https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-web-ui-all",
+      "catalogEntry": "data/plugins/zhu1090093659__dsh-web-ui--packages-dsh-web-ui-all.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/zhu1090093659__dsh-web-ui--packages-dsh-web-ui-all.yml",
+      "category": "ui",
+      "distribution": {
+        "kind": "npm",
+        "name": "@linxin666/dsh-web-ui-all",
+        "selectedVersion": "0.2.9",
+        "distTag": "latest"
+      },
+      "status": "not-observed",
+      "cells": [],
+      "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
+    },
+    {
       "id": "dsh-openpencil",
       "repository": "ZSeven-W/dsh-openpencil",
       "repositoryUrl": "https://github.com/ZSeven-W/dsh-openpencil",
       "catalogUrl": "https://github.com/ZSeven-W/dsh-openpencil",
       "catalogEntry": "data/plugins/ZSeven-W__dsh-openpencil.yml",
-      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82/data/plugins/ZSeven-W__dsh-openpencil.yml",
+      "catalogEntryUrl": "https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea/data/plugins/ZSeven-W__dsh-openpencil.yml",
       "category": "ui",
       "distribution": {
         "kind": "npm",

--- a/feeds/dsh-plugin-compatibility.md
+++ b/feeds/dsh-plugin-compatibility.md
@@ -1,18 +1,60 @@
 # DSH directory compatibility evidence
 
-Generated from catalog commit [`7f79f9c11b3c`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/7f79f9c11b3c655fe7656a00e54f0b6f8aa0bf82) at `2026-08-23T08:09:33.232Z`.
+Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-23T10:22:07.182Z`.
 
-**4 observed compatible · 0 observed incompatible · 2 needs review · 2 not observed**
+**4 observed compatible · 0 observed incompatible · 2 needs review · 44 not observed**
 
 | Catalog plugin | Exact artifact | Exact DSH / runtime | Evidence status | Observed |
 | --- | --- | --- | --- | --- |
+| [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) | — | — | `not-observed` | — |
+| [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) | — | — | `not-observed` | — |
+| [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) | — | — | `not-observed` | — |
+| [Airmetro/dsh-update-checker](https://github.com/Airmetro/dsh-update-checker) | — | — | `not-observed` | — |
+| [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) | — | — | `not-observed` | — |
+| [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | — | — | `not-observed` | — |
+| [awesome-dsh-plugin/dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) | — | — | `not-observed` | — |
+| [Blank-not-black/dsh-Remote](https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin) | — | — | `not-observed` | — |
 | [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) | `dsh-context@0.25.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:17.088Z |
+| [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | — | — | `not-observed` | — |
+| [ChongCyrus/Vibe-Mathematics](https://github.com/ChongCyrus/Vibe-Mathematics) | — | — | `not-observed` | — |
+| [DDDMUC/dsh-free-search](https://github.com/DDDMUC/dsh-free-search) | — | — | `not-observed` | — |
 | [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) | `dshmarket@1.19.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T07:09:16.954Z |
+| [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) | — | — | `not-observed` | — |
+| [feibi-mochi/deepseek-harness-control-center](https://github.com/feibi-mochi/deepseek-harness-control-center) | — | — | `not-observed` | — |
+| [flymysql/dsh-remote](https://github.com/flymysql/dsh-remote) | — | — | `not-observed` | — |
+| [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) | — | — | `not-observed` | — |
+| [FuzzySoul/dsh-chatvoice](https://github.com/FuzzySoul/dsh-chatvoice) | — | — | `not-observed` | — |
 | [GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis) | — | — | `not-observed` | — |
 | [Han-1413141/dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) | `dsh-cost-meter@1.5.38` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:18.405Z |
+| [liustack/modsearch](https://github.com/liustack/modsearch) | — | — | `not-observed` | — |
 | [Lum1104/dsh-browser](https://github.com/Lum1104/dsh-browser/tree/main/packages/browser/bridge-browser) | — | — | `not-observed` | — |
+| [Mars-Sea/dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) | — | — | `not-observed` | — |
+| [MichengAI/dsh-agency-agents](https://github.com/MichengAI/dsh-agency-agents) | — | — | `not-observed` | — |
+| [modusensus/dsh-mneme](https://github.com/modusensus/dsh-mneme/tree/main/dsh-mneme) | — | — | `not-observed` | — |
+| [moonquake2004/dsh-doctor](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) | — | — | `not-observed` | — |
 | [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | `@nanmicoder/dsh-agent-teams@0.1.13` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:29.383Z |
+| [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | — | — | `not-observed` | — |
 | [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | `dsh-better-sidebar@0.15.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T03:40:58.944Z |
+| [openma-ai/deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | — | — | `not-observed` | — |
+| [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) | — | — | `not-observed` | — |
+| [Q00/ouroboros](https://github.com/Q00/ouroboros/tree/main/integrations/dsh-plugin) | — | — | `not-observed` | — |
+| [Relistencode/dsh-extension-hub](https://github.com/Relistencode/dsh-extension-hub) | — | — | `not-observed` | — |
+| [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) | — | — | `not-observed` | — |
+| [saya-ch/dsh-mobile](https://github.com/saya-ch/dsh-mobile) | — | — | `not-observed` | — |
+| [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) | — | — | `not-observed` | — |
+| [TecFancy/dsh-auth-gate](https://github.com/TecFancy/dsh-auth-gate) | — | — | `not-observed` | — |
+| [THEWOLFWALKER/dsh-notifier](https://github.com/THEWOLFWALKER/dsh-notifier) | — | — | `not-observed` | — |
+| [toby-bridges/api-relay-audit](https://github.com/toby-bridges/api-relay-audit) | — | — | `not-observed` | — |
+| [trench-xinxin/dsh-tool-lens](https://github.com/trench-xinxin/dsh-tool-lens) | — | — | `not-observed` | — |
+| [tt-a1i/archify](https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness) | — | — | `not-observed` | — |
+| [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/coding-agents) | — | — | `not-observed` | — |
+| [wloops/dsh-git-worktree](https://github.com/wloops/dsh-git-worktree) | — | — | `not-observed` | — |
+| [wqty123/dsh-browser](https://github.com/wqty123/dsh-browser) | — | — | `not-observed` | — |
+| [xiajiajun516/dsh-config-manager](https://github.com/xiajiajun516/dsh-config-manager) | — | — | `not-observed` | — |
+| [xmanrui/dsh-im](https://github.com/xmanrui/dsh-im) | — | — | `not-observed` | — |
+| [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) | — | — | `not-observed` | — |
+| [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | — | — | `not-observed` | — |
+| [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-web-ui-all) | — | — | `not-observed` | — |
 | [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | `@zseven-w/dsh-openpencil@0.1.0-rc.1` | `0.1.1-rc.2` / Node 24 | `needs-review` | 2026-08-23T03:40:15.559Z |
 
 ## Reading the status

--- a/test/awesome-dsh-cohort.test.ts
+++ b/test/awesome-dsh-cohort.test.ts
@@ -6,6 +6,7 @@ import { parseObserverConfigText } from '../src/upstream-observer.js'
 
 interface CohortPlugin {
   id: string
+  category: string
   catalogUrl: string
   repository: string
   ref: string
@@ -34,8 +35,11 @@ describe('awesome-dsh-plugin monitored cohort', () => {
     assert.equal(cohort.schema, 'upstream-radar.awesome-dsh-cohort/v1alpha1')
     assert.match(cohort.source.commit, /^[0-9a-f]{40}$/)
     assert.ok(cohort.source.entryCount >= cohort.plugins.length)
-    assert.equal(cohort.plugins.length, 8)
+    assert.equal(cohort.plugins.length, 50)
     assert.equal(new Set(cohort.plugins.map(plugin => plugin.id)).size, cohort.plugins.length)
+    assert.equal(new Set(cohort.plugins.map(plugin => plugin.repository.toLowerCase())).size, cohort.plugins.length)
+    assert.equal(new Set(cohort.plugins.map(plugin => plugin.category)).size, 21)
+    assert.equal(installTargets.plugins.length, 50)
 
     const importedIds = new Set(cohort.plugins.map(plugin => plugin.id))
     const importedObserverTargets = observer.targets.filter(target => importedIds.has(target.id))
@@ -52,8 +56,11 @@ describe('awesome-dsh-plugin monitored cohort', () => {
 
     const npmPlugins = cohort.plugins.filter(plugin => plugin.distribution.kind === 'npm')
     const sourceOnlyPlugins = cohort.plugins.filter(plugin => plugin.distribution.kind !== 'npm')
-    assert.equal(npmPlugins.length, 6)
-    assert.deepEqual(sourceOnlyPlugins.map(plugin => plugin.id).sort(), ['aegis', 'dsh-browser'])
+    assert.equal(npmPlugins.length, 46)
+    assert.deepEqual(
+      sourceOnlyPlugins.map(plugin => plugin.id).sort(),
+      ['aegis', 'api-relay-audit', 'dsh-browser', 'ouroboros-dsh-plugin'],
+    )
     assert.equal(
       cohort.plugins.find(plugin => plugin.id === 'dsh-browser')?.catalogUrl,
       'https://github.com/Lum1104/dsh-browser/tree/main/packages/browser/bridge-browser',
@@ -79,5 +86,15 @@ describe('awesome-dsh-plugin monitored cohort', () => {
       installTargets.plugins.find(target => target.id === 'openpencil')?.runtimeProfiles,
       ['node24'],
     )
+    assert.deepEqual(
+      installTargets.plugins.find(target => target.id === 'dsh-agy-link')?.runtimeProfiles,
+      ['node24'],
+    )
+
+    const nonCohortTargets = installTargets.plugins
+      .filter(target => target.observerTargetId === undefined || !importedIds.has(target.observerTargetId))
+      .map(target => target.id)
+      .sort()
+    assert.deepEqual(nonCohortTargets, ['cloudflare-browser', 'feishu-bot', 'sanqi-market', 'wsl-workspace'])
   })
 })

--- a/test/dsh-directory-feed.test.ts
+++ b/test/dsh-directory-feed.test.ts
@@ -135,11 +135,13 @@ describe('DSH directory compatibility feed', () => {
       generatedAt: '2026-08-23T08:00:00.000Z',
     })
 
-    assert.equal(feed.plugins.length, 8)
+    assert.equal(feed.plugins.length, 50)
     assert.equal(feed.plugins.find(item => item.id === 'dsh-market')?.status, 'observed-compatible')
     assert.equal(feed.plugins.find(item => item.id === 'dsh-better-sidebar')?.status, 'needs-review')
     assert.equal(feed.plugins.find(item => item.id === 'dsh-openpencil')?.status, 'needs-review')
     assert.equal(feed.plugins.find(item => item.id === 'dsh-browser')?.status, 'not-observed')
+    assert.equal(feed.plugins.find(item => item.id === 'dsh-web-ui-all')?.status, 'not-observed')
+    assert.equal(feed.plugins.find(item => item.id === 'api-relay-audit')?.status, 'not-observed')
     assert.equal(
       feed.plugins.find(item => item.id === 'dsh-browser')?.catalogUrl,
       'https://github.com/Lum1104/dsh-browser/tree/main/packages/browser/bridge-browser',


### PR DESCRIPTION
## Summary

- expand the immutable awesome-dsh-plugin cohort from 8 to 50 repositories across all 21 catalog categories
- map 46 identity-checked npm artifacts into the isolated install/load matrix and retain four honest source-only entries
- expand the active dynamic corpus from 10 to 50 exact plugin targets
- refresh the directory feed and document the always-on reconciliation behavior

## Selection and trust boundary

Candidates were prioritized by catalog downloads and GitHub Stars, capped at four per category and one entry per repository. Each executable candidate was admitted only after its catalog URL, source package name, npm package name, DSH bundle metadata, and npm repository identity agreed. Catalog metadata remains discovery input, not compatibility evidence.

## Verification

- `pnpm test` (334/334)
- local reconciliation selects exactly 40 missing cells across 50 active cells against DSH 0.1.1-rc.2
- 55 static targets parse successfully: DSH, four maintained cases, and the 50-plugin cohort
