### PR TITLE
fix: observe large npm plugin artifacts

### DIFF
--- a/src/dsh-install-observation.ts
+++ b/src/dsh-install-observation.ts
@@ -777,24 +777,34 @@ async function parsePackedArtifact(
   expectedVersion: string,
 ): Promise<ParsedArtifact> {
   if (commandStage(result).status !== 'passed') throw new Error(commandStage(result).detail ?? 'npm pack failed')
-  let output: unknown
-  try {
-    output = JSON.parse(result.stdout.trim()) as unknown
-  } catch {
-    throw new Error('npm pack did not return JSON')
+  const stdout = result.stdout.trim()
+  let filename: unknown
+  let integrity: string | undefined
+  if (stdout.startsWith('[')) {
+    let output: unknown
+    try {
+      output = JSON.parse(stdout) as unknown
+    } catch {
+      throw new Error('npm pack did not return valid JSON')
+    }
+    if (!Array.isArray(output) || output.length !== 1 || typeof output[0] !== 'object' || output[0] === null) {
+      throw new Error('npm pack returned an unexpected result')
+    }
+    const item = output[0] as Record<string, unknown>
+    filename = item.filename
+    integrity = typeof item.integrity === 'string' ? bounded(item.integrity, 1_024) : undefined
+  } else {
+    const lines = stdout.split(/\r?\n/)
+    if (lines.length !== 1) throw new Error('npm pack returned an unexpected result')
+    filename = lines[0]
   }
-  if (!Array.isArray(output) || output.length !== 1 || typeof output[0] !== 'object' || output[0] === null) {
-    throw new Error('npm pack returned an unexpected result')
-  }
-  const item = output[0] as Record<string, unknown>
-  const filename = item.filename
   if (typeof filename !== 'string' || filename === '' || filename !== basename(filename) || !filename.endsWith('.tgz')) {
     throw new Error('npm pack returned an unsafe artifact filename')
   }
   const path = resolve(artifactDirectory, filename)
   if (!path.startsWith(`${resolve(artifactDirectory)}${sep}`)) throw new Error('npm pack artifact escaped its directory')
   const compressed = await readRegularFileNoFollow(path, MAX_ARTIFACT_BYTES)
-  const parsed = parseNpmTarball(compressed)
+  const parsed = parseNpmTarball(compressed, { maxFileBytes: MAX_ARTIFACT_BYTES })
   const manifestEntry = parsed.entries.find(entry => entry.path === 'package.json' && entry.type === 'file')
   if (manifestEntry?.contents === undefined) throw new Error('packed artifact has no package.json')
   let manifest: Record<string, unknown>
@@ -835,7 +845,6 @@ async function parsePackedArtifact(
     throw new Error('packed artifact Node engine requirement exceeds 512 characters')
   }
   const nodeEngine = rawNodeEngine === undefined || rawNodeEngine === '' ? undefined : bounded(rawNodeEngine, 512)
-  const integrity = typeof item.integrity === 'string' ? bounded(item.integrity, 1_024) : undefined
   const peerRequirements = requiredPeerDependencies(manifest, parsed.entries)
   return {
     path,
@@ -1598,7 +1607,7 @@ export async function observeDshPluginInstall(options: DshInstallObservationOpti
     const artifactResult = await runSafely(runner, {
       phase: 'artifact',
       command: npmCommand,
-      args: ['pack', `${spec.name}@${spec.version}`, '--ignore-scripts', '--json', '--pack-destination', '.'],
+      args: ['pack', `${spec.name}@${spec.version}`, '--ignore-scripts', '--pack-destination', '.', '--silent'],
       cwd: artifactDirectory,
       env: noScriptsEnvironment,
       timeoutMs,

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -98,6 +98,13 @@ function parsePax(contents: Buffer): Record<string, string> {
   return values
 }
 
+function parsePaxSize(value: string): number {
+  if (!/^[0-9]+$/.test(value)) throw new Error('invalid PAX size override')
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < 0) throw new Error('invalid PAX size override')
+  return parsed
+}
+
 function pathIssue(rawPath: string): string | undefined {
   if (rawPath.includes('\0')) return 'contains a NUL byte'
   if (/[\u0001-\u001f\u007f-\u009f]/.test(rawPath)) return 'contains a control character'
@@ -247,17 +254,28 @@ export function parseNpmTarball(compressed: Buffer, options: TarOptions = {}): P
     verifyHeaderChecksum(header)
 
     const headerSize = readOctal(header, 124, 12, 'size')
-    if (headerSize > maxFileBytes) throw new Error('tar entry exceeds per-entry budget')
-    budgetBytes += headerSize
+    const typeFlag = String.fromCharCode(header[156] ?? 0)
+    const metadataRecord = typeFlag === 'x' || typeFlag === 'g' || typeFlag === 'L' || typeFlag === 'K'
+    const regularFile = typeFlag === '\0' || typeFlag === '0' || typeFlag === '7'
+    const pax = metadataRecord ? undefined : { ...globalPax, ...pendingPax }
+    let effectiveSize = headerSize
+    if (pax?.size !== undefined) {
+      const paxSize = parsePaxSize(pax.size)
+      if (!regularFile && paxSize !== headerSize) {
+        throw new Error('PAX size override is only supported for regular files')
+      }
+      effectiveSize = paxSize
+    }
+    if (effectiveSize > maxFileBytes) throw new Error('tar entry exceeds per-entry budget')
+    budgetBytes += effectiveSize
     if (budgetBytes > maxUnpackedBytes) throw new Error(`tar contents exceed ${maxUnpackedBytes} bytes`)
     const contentStart = offset + TAR_BLOCK
-    const contentEnd = contentStart + headerSize
+    const contentEnd = contentStart + effectiveSize
     if (contentEnd > archive.length) throw new Error('tar entry exceeds archive bounds')
-    const paddedSize = Math.ceil(headerSize / TAR_BLOCK) * TAR_BLOCK
+    const paddedSize = Math.ceil(effectiveSize / TAR_BLOCK) * TAR_BLOCK
     const nextOffset = contentStart + paddedSize
     if (nextOffset > archive.length) throw new Error('tar padding exceeds archive bounds')
 
-    const typeFlag = String.fromCharCode(header[156] ?? 0)
     const contents = archive.subarray(contentStart, contentEnd)
     const headerName = readString(header, 0, 100)
     const prefix = readString(header, 345, 155)
@@ -265,7 +283,6 @@ export function parseNpmTarball(compressed: Buffer, options: TarOptions = {}): P
 
     if (typeFlag === 'x' || typeFlag === 'g') {
       const parsed = parsePax(contents)
-      if (parsed.size !== undefined) throw new Error('unsupported PAX size override')
       if (typeFlag === 'g') globalPax = { ...globalPax, ...parsed }
       else pendingPax = parsed
       offset = nextOffset
@@ -279,9 +296,8 @@ export function parseNpmTarball(compressed: Buffer, options: TarOptions = {}): P
       continue
     }
 
-    const pax = { ...globalPax, ...pendingPax }
-    const rawPath = pax.path ?? pendingLongName ?? combinedHeaderName
-    const rawLink = pax.linkpath ?? pendingLongLink ?? readString(header, 157, 100)
+    const rawPath = pax?.path ?? pendingLongName ?? combinedHeaderName
+    const rawLink = pax?.linkpath ?? pendingLongLink ?? readString(header, 157, 100)
     pendingPax = {}
     pendingLongName = undefined
     pendingLongLink = undefined
@@ -331,11 +347,10 @@ export function parseNpmTarball(compressed: Buffer, options: TarOptions = {}): P
     portablePaths.set(portableKey, entryPath)
 
     const mode = readOctal(header, 100, 8, 'mode')
-    const regularFile = typeFlag === '\0' || typeFlag === '0' || typeFlag === '7'
     if (regularFile) {
-      fileBytes += headerSize
+      fileBytes += effectiveSize
       const digest = createHash('sha256').update(contents).digest('hex')
-      entries.push({ path: entryPath, type: 'file', mode, size: headerSize, digest, contents: Buffer.from(contents) })
+      entries.push({ path: entryPath, type: 'file', mode, size: effectiveSize, digest, contents: Buffer.from(contents) })
     } else if (typeFlag === '5') {
       const digest = createHash('sha256').update('directory').digest('hex')
       entries.push({ path: entryPath, type: 'directory', mode, size: 0, digest })

--- a/test/dsh-directory-feed.test.ts
+++ b/test/dsh-directory-feed.test.ts
@@ -128,24 +128,22 @@ describe('DSH directory compatibility feed', () => {
     const cohort = JSON.parse(await readFile('examples/dsh/awesome-observer/cohort.json', 'utf8')) as unknown
     const installTargets = JSON.parse(await readFile('examples/dsh/install-observer/targets.json', 'utf8')) as unknown
     const ledger = JSON.parse(await readFile('compatibility-ledger.json', 'utf8')) as unknown
+    const checkedInFeed = JSON.parse(await readFile('feeds/dsh-plugin-compatibility.json', 'utf8')) as { generatedAt: string }
     const feed = buildDshDirectoryCompatibilityFeed({
       cohort,
       installTargets,
       ledger,
-      generatedAt: '2026-08-23T08:00:00.000Z',
+      generatedAt: checkedInFeed.generatedAt,
     })
 
+    assert.deepEqual(feed, checkedInFeed)
     assert.equal(feed.plugins.length, 50)
-    assert.equal(feed.plugins.find(item => item.id === 'dsh-market')?.status, 'observed-compatible')
-    assert.equal(feed.plugins.find(item => item.id === 'dsh-better-sidebar')?.status, 'needs-review')
-    assert.equal(feed.plugins.find(item => item.id === 'dsh-openpencil')?.status, 'needs-review')
     assert.equal(feed.plugins.find(item => item.id === 'dsh-browser')?.status, 'not-observed')
-    assert.equal(feed.plugins.find(item => item.id === 'dsh-web-ui-all')?.status, 'not-observed')
     assert.equal(feed.plugins.find(item => item.id === 'api-relay-audit')?.status, 'not-observed')
     assert.equal(
       feed.plugins.find(item => item.id === 'dsh-browser')?.catalogUrl,
       'https://github.com/Lum1104/dsh-browser/tree/main/packages/browser/bridge-browser',
     )
-    assert.equal(feed.plugins.filter(item => item.status === 'observed-incompatible').length, 0)
+    assert.equal(Object.values(feed.summary).slice(1).reduce((sum, count) => sum + count, 0), feed.summary.total)
   })
 })

--- a/test/dsh-install-observation.test.ts
+++ b/test/dsh-install-observation.test.ts
@@ -84,6 +84,7 @@ describe('DSH install observation', () => {
 
   it('stops before DSH or plugin execution when the exact artifact excludes the isolated Node runtime', async () => {
     const phases: InstallObservationCommand['phase'][] = []
+    let artifactArgs: string[] = []
     const report = await observeDshPluginInstall({
       packageSpec: 'future-plugin@1.0.0',
       dshVersion: '0.1.1-rc.1',
@@ -93,6 +94,7 @@ describe('DSH install observation', () => {
         phases.push(command.phase)
         if (command.phase === 'runtime') return passed({ stdout: '11.7.0\n' })
         if (command.phase === 'artifact') {
+          artifactArgs = command.args
           await writeFile(join(command.cwd, 'future-plugin-1.0.0.tgz'), makeTarball([
             { path: 'package/package.json', contents: JSON.stringify({
               name: 'future-plugin',
@@ -101,8 +103,9 @@ describe('DSH install observation', () => {
               dsh: { bundle: { patch: 'cordis.patch.yml' } },
             }) },
             { path: 'package/cordis.patch.yml', contents: '[]\n' },
+            { path: 'package/vendor/dsh-runtime.tgz', contents: Buffer.alloc(17 * 1024 * 1024) },
           ]))
-          return passed({ stdout: JSON.stringify([{ filename: 'future-plugin-1.0.0.tgz' }]) })
+          return passed({ stdout: 'future-plugin-1.0.0.tgz\n' })
         }
         throw new Error(`unexpected execution phase: ${command.phase}`)
       },
@@ -115,6 +118,8 @@ describe('DSH install observation', () => {
     assert.equal(report.stages.install.status, 'skipped')
     assert.equal(report.stages.load.status, 'skipped')
     assert.deepEqual(phases, ['runtime', 'artifact'])
+    assert.equal(artifactArgs.includes('--silent'), true)
+    assert.equal(artifactArgs.includes('--json'), false)
     assert.match(report.reason, /declares Node >=999\.0\.0/)
     assert.match(renderDshInstallObservation(report), /RUNTIME-INCOMPATIBLE/)
   })

--- a/test/helpers/tar.ts
+++ b/test/helpers/tar.ts
@@ -8,6 +8,7 @@ export interface TestTarEntry {
   type?: 'file' | 'directory' | 'symlink' | 'hardlink' | 'pax'
   linkTarget?: string
   mode?: number
+  headerSize?: number
 }
 
 function writeText(target: Buffer, offset: number, length: number, value: string): void {
@@ -48,7 +49,7 @@ export function makeTarball(entries: readonly TestTarEntry[]): Buffer {
     const contents = type === 'file' || type === 'pax'
       ? Buffer.isBuffer(entry.contents) ? entry.contents : Buffer.from(entry.contents ?? '')
       : Buffer.alloc(0)
-    parts.push(headerFor(entry, contents.length), contents)
+    parts.push(headerFor(entry, entry.headerSize ?? contents.length), contents)
     const padding = (BLOCK - (contents.length % BLOCK)) % BLOCK
     if (padding > 0) parts.push(Buffer.alloc(padding))
   }

--- a/test/tar.test.ts
+++ b/test/tar.test.ts
@@ -118,12 +118,33 @@ describe('npm tarball parser', () => {
     assert.throws(() => parseNpmTarball(tarball, { maxFileBytes: 8 }), /per-entry budget/)
   })
 
-  it('rejects PAX size overrides the parser cannot account for safely', () => {
+  it('uses a validated PAX size override to find the next tar header', () => {
     const tarball = makeTarball([
       { path: 'pax-header', contents: '10 size=1\n', type: 'pax' },
-      { path: 'package/a.js', contents: 'x' },
+      { path: 'package/a.js', contents: 'x', headerSize: 0 },
     ])
 
-    assert.throws(() => parseNpmTarball(tarball), /unsupported PAX size override/)
+    const parsed = parseNpmTarball(tarball)
+    assert.equal(parsed.entries[0]?.path, 'a.js')
+    assert.equal(parsed.entries[0]?.size, 1)
+    assert.equal(parsed.entries[0]?.contents?.toString('utf8'), 'x')
+  })
+
+  it('rejects malformed PAX size overrides', () => {
+    const tarball = makeTarball([
+      { path: 'pax-header', contents: '11 size=-1\n', type: 'pax' },
+      { path: 'package/a.js', contents: 'x', headerSize: 0 },
+    ])
+
+    assert.throws(() => parseNpmTarball(tarball), /invalid PAX size override/)
+  })
+
+  it('applies the per-entry byte budget to the effective PAX size', () => {
+    const tarball = makeTarball([
+      { path: 'pax-header', contents: '11 size=12\n', type: 'pax' },
+      { path: 'package/a.js', contents: 'twelve-bytes', headerSize: 0 },
+    ])
+
+    assert.throws(() => parseNpmTarball(tarball, { maxFileBytes: 11 }), /per-entry budget/)
   })
 })


### PR DESCRIPTION
## What changed

- consume bounded `npm pack --silent` output instead of an unbounded JSON file listing
- support validated POSIX PAX size overrides while retaining entry, decompression, and archive limits
- allow a single plugin artifact entry up to the existing 64 MiB total artifact budget
- make the checked-in directory-feed test follow reconciled evidence instead of stale hard-coded statuses

## Why

The first 50-plugin DSH compatibility run left four cells unknown because the observer could not parse two valid PAX archives, one large vendored runtime entry, and one package whose JSON file listing exceeded the command-output budget. These were observer coverage gaps, not plugin incompatibilities.

## Verification

- `pnpm test` — 336/336 passed
- focused PAX, large-entry, and silent-output regression tests included