### PR TITLE
chore: reconcile DSH artifact observer rechecks

### DIFF
--- a/compatibility-ir.json
+++ b/compatibility-ir.json
@@ -176,14 +176,15 @@
       }
     },
     {
-      "id": "cell:df4d05cf659fc35bc26a1d4bef9de93450f2a47de6ccd5103361d91dc5fb88eb",
+      "id": "cell:b43b12f68aeba3a9d480d0d2c240ce281588eea030919765acc2b9f4fd0bb173",
       "caseId": "deepseek-harness-acp-node22",
       "targetId": "deepseek-harness-acp",
-      "observedAt": "2026-08-23T10:28:41.757Z",
-      "result": "unknown",
+      "observedAt": "2026-08-23T10:45:06.760Z",
+      "result": "compatible",
       "plugin": {
         "name": "@openma/deepseek-harness-acp",
         "version": "0.4.24",
+        "artifactSha256": "d1a95afe3d562df46c6b3a27919e8e5470d78e55f2f873188a22f2f53fb537c6",
         "staticFingerprint": "sha256:e94dbd7692477bdf438a3678e9113393f45ea215c66468cad6e4b00147baa4e3"
       },
       "runtime": {
@@ -195,7 +196,13 @@
         "pnpmVersion": "11.7.0",
         "contractFingerprint": "sha256:c24fd15b248b868f10faf7d7fbcdbd0ca6d969eb4bd499a190222c68b26245ac"
       },
-      "evidence": {}
+      "evidence": {
+        "runtimeGraphDigest": "sha256:9fc681b134ddb95014b186bf6ab9d985069746a9f70baebe2f9278c23c751c66",
+        "runtimeGraphNodes": 456,
+        "runtimeGraphEdges": 2041,
+        "requiredUnresolved": 0,
+        "declaredPeerContracts": 0
+      }
     },
     {
       "id": "cell:6525b79975ed807ffcbb588f7eeda3cf5b0dc2dc0ab26bd19106568d163695cd",
@@ -865,14 +872,15 @@
       }
     },
     {
-      "id": "cell:5c8498aed3af716b328889536a51988a9f341005a3e7fc335a35930e6add91bc",
+      "id": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
       "caseId": "dsh-pet-node22",
       "targetId": "dsh-pet",
-      "observedAt": "2026-08-23T10:28:39.649Z",
-      "result": "unknown",
+      "observedAt": "2026-08-23T10:45:08.504Z",
+      "result": "peer-contract-incompatible",
       "plugin": {
         "name": "dsh-pet",
         "version": "0.1.7",
+        "artifactSha256": "a1b0e87a5beca59d31fff6ac92b65df7743064055865f1a2e788f4c415ece001",
         "staticFingerprint": "sha256:2deaf09cffc00cf01350c9b68dca78f2881ff613e46fcd1f5b9ce3306110c091"
       },
       "runtime": {
@@ -884,7 +892,13 @@
         "pnpmVersion": "11.7.0",
         "contractFingerprint": "sha256:c8066f6abbf8e4cd313f1cd2019f6dd3dbb49483b6ad22cd1d5991708da99869"
       },
-      "evidence": {}
+      "evidence": {
+        "runtimeGraphDigest": "sha256:d70fbb66eaf7c135618ce00e6230bac31da9eaf1bfcd44dc3661924a09e0d367",
+        "runtimeGraphNodes": 448,
+        "runtimeGraphEdges": 2034,
+        "requiredUnresolved": 1,
+        "declaredPeerContracts": 6
+      }
     },
     {
       "id": "cell:9a1a897fab37a021c7b389c6e8f43a8cf42fd4f2dd372f5864e8b9e2b9497020",
@@ -1061,14 +1075,15 @@
       }
     },
     {
-      "id": "cell:819db38b1bbb54dbe19b7be3a2a39a7c6dfc70cbac80796884464afa59b4f9d8",
+      "id": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
       "caseId": "dsh-tui-node22",
       "targetId": "dsh-tui",
-      "observedAt": "2026-08-23T10:28:45.459Z",
-      "result": "unknown",
+      "observedAt": "2026-08-23T10:45:13.430Z",
+      "result": "compatible",
       "plugin": {
         "name": "@deepseek-harness-tui/dsh-tui",
         "version": "0.9.0",
+        "artifactSha256": "1604bf456c740743064bab07d91a1f083fb64dcc335d9b43dbddc0b96c1fe66e",
         "staticFingerprint": "sha256:2487532d41d57ff848a7d778081c7153b15e41954f685693abca10e479927937"
       },
       "runtime": {
@@ -1080,7 +1095,13 @@
         "pnpmVersion": "11.7.0",
         "contractFingerprint": "sha256:384bf76b47277a6fbb967b96f230fa8e637048ed572834d1c8ee10aba5220bcd"
       },
-      "evidence": {}
+      "evidence": {
+        "runtimeGraphDigest": "sha256:e07291b747343d2185b52a7d22b909c973961256428ccd3baeddab1d3172c700",
+        "runtimeGraphNodes": 520,
+        "runtimeGraphEdges": 2160,
+        "requiredUnresolved": 0,
+        "declaredPeerContracts": 26
+      }
     },
     {
       "id": "cell:c1e4e8a0dbdc07b9b81241b2eead957a73b24db0e05569e429b67e8505ff635f",
@@ -1112,14 +1133,15 @@
       }
     },
     {
-      "id": "cell:675e9c035b5e73fc78ba016249ac2e6e82d8f170b9a4650a6be438da5de64309",
+      "id": "cell:465cdc627306f61f0793b2bb57fbb0448acc8b93a064214e6571bc9bfa7c7322",
       "caseId": "dsh-vibe-math-node22",
       "targetId": "dsh-vibe-math",
-      "observedAt": "2026-08-23T10:28:56.405Z",
-      "result": "unknown",
+      "observedAt": "2026-08-23T10:45:04.817Z",
+      "result": "compatible",
       "plugin": {
         "name": "dsh-vibe-math",
         "version": "1.0.2",
+        "artifactSha256": "93ea96844b828c0845fc65059a858d41cc605cffdebc4f1298b478c50d06077c",
         "staticFingerprint": "sha256:4d613429f7edde8b2cb968c11cdaf659b672d0677a4a9b8c0ce9485a84499ef6"
       },
       "runtime": {
@@ -1131,7 +1153,13 @@
         "pnpmVersion": "11.7.0",
         "contractFingerprint": "sha256:de33af1c481b0c24bc433fb49ee7b965aca13377d1021df91ed39f179d18e949"
       },
-      "evidence": {}
+      "evidence": {
+        "runtimeGraphDigest": "sha256:ea5a6034ae6d201b24f7bcae3ae2b9b4c429d92a5bdb02b57fa6912a3a0583e3",
+        "runtimeGraphNodes": 448,
+        "runtimeGraphEdges": 2029,
+        "requiredUnresolved": 0,
+        "declaredPeerContracts": 0
+      }
     },
     {
       "id": "cell:cd0e3dd5ba91b3c4d6e2f0b8d276735f9a185314bfd5c73e345fd7594bd793b3",
@@ -2978,6 +3006,292 @@
       }
     },
     {
+      "id": "relation:fb92d5e2120330352b357616cc18111a96169d27acbbb5ea5f60f3e15a7dddca",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/cordis",
+        "required": "^4.0.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "4.0.1"
+      }
+    },
+    {
+      "id": "relation:dcfd82c88d936e3b899c30010ab1b009eb1bc133ff52ea1c0adcbcde9e73bc0c",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-agent",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:d30267527304742a8bb27f3dfa2468f0d85428d4cf385330ce2ac4ed8a1fa49e",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-agent-instructions",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:a74c01382cdb9584b1fea3c99f795eb4cf27055998c1fb02d67c4f004be725fc",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-agent-presets",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:433a886b8bb5a9b2d5e479b009c680b77dffc409b7c31c57e7f89f60d6fc99c4",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-atomic-write",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:c199fae7247ede10ba3cc375b1b00173c278d30af7091e1cfef9566ba6738448",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-commands",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:025a0205b3f29a500274cf61f1bf54a3215cd25c3077d38a26c7cad5dcb8a6c9",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-cordis-host-runner",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:b1ea51df2ad654c66dfa8163af0fc73324d479a11ecd3b5b4a5472d1c53829fe",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-invariants",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:6c4f68411435ed23625c17d11db272c4e5168c8c29dde9214680dacde1b8e588",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-llm",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:cb35307c53fa0d25ed4b60c01e86a6e9fa287ab52ffc43c1b06438bb936d8837",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-persona",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:40e4d72f93b5d6042ae50a877358d3fd2a2b1a7c76b8b199117ab7db2a617a9a",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-session",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:a00a10c47001deaf3457fa1db4e1a582f40af60b3da09a77176229d0b0133eb2",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-settings",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:1f572ccbd0e2bfee76c5e84dc30bf30d82c9c554a96e7bf985ddcd0e11098221",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-skill",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:31b044731cdabcae37139cc4d8606901afdda701a7d9ed6773d0f9eb0c32c18a",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-storage",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:813648f3aea1eef73a0525c4977e597af5a7612433fd4f399e939682dcdf5f0f",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-storage-domain",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:9f931aff82de1313d116a0961ae41817f9bbafd19910b55777db198a12ba11a7",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-storage-json",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:27cc6c32a52495b9856426b4141202342e8f6acda1b5eccbb020e845be08ac4f",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-system-prompt",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:a8ec4c3a3064225f47186742e53ae0db5a3f9e959d684df4f094cb0b98b48ae0",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-terminal",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:e6261807e9e1b55a3fe1f1e2e7c5e07cb0828774b3f57911583532c2adac3102",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-terminal-bash",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:13e5b6035ab8311fb2f7b5733f8e7dfeee10ee0c50787cc0c75d4e58ef7c5b6a",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-tool-ask-user",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:e6e420ae373f0cbca1705aad30fcb6c2bf49614f4ae1e3d89049e189e693e35f",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-tool-bash-persistent",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:a56dc26b048e1b09b3d715a6c477143735554c94b74bf22df3c2216948b37c39",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-tool-cordis",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:e645e20736e636e888872fbff404b510999212d93eb766b5cf0fb4a2f285ce09",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-user-approval",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:dd486e4db405b7010258c562fcc7bb2236fbc08ed3759226f74986cd3ac31d1f",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-user-questions",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:aac7e4771609b23fa9a563ed7af327f0cbe8e88afe1b4f3d9d49091ed48023b4",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-workspace",
+        "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:0f57ae5bea9467affd36c679c408fb3100d530ad0b65eed3f5ff6c05c7f85746",
+      "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+      "dependency": {
+        "name": "@deepseek-ai/schemastery",
+        "required": "^3.18.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "3.18.1"
+      }
+    },
+    {
       "id": "relation:10229a7845fa25645becd9eb62593301c2d866e9d12f2cbfff63e631dce15689",
       "cellId": "cell:a8fc384560fbd18b80d3f16499569cb9f4a6ab4639b71cfbbc03dce429ccd2a7",
       "dependency": {
@@ -3057,6 +3371,71 @@
     {
       "id": "relation:6d4f36ef98f8b3db63fb97256fc4e3efdea3a5ae70dec252df1e9c159864697d",
       "cellId": "cell:ae7ce4f5a5fed4457948fcc1660e5b3bfb13996726b34d6597d94f9c492ef524",
+      "dependency": {
+        "name": "react",
+        "required": "^18.2.0",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "18.3.1"
+      }
+    },
+    {
+      "id": "relation:85912375414bd0d996e18470f89679fe421d8c636e02afd7bde3ec3376216fef",
+      "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+      "dependency": {
+        "name": "@deepseek-ai/cordis",
+        "required": "^4.0.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "4.0.1"
+      }
+    },
+    {
+      "id": "relation:147132d0a2bcc64690e5e7b71ede6a606f116ca793466e3aa2ee7dfec4c848a1",
+      "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-client-runtime",
+        "required": "^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:38682b5fa4814e5825bb745685e66c2cef52eb9056b04ae5a7fc69d967a663e0",
+      "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-client-ui-slots",
+        "required": "^0.1.1-rc.1",
+        "status": "missing",
+        "staticUsage": "no-literal-reference-observed"
+      }
+    },
+    {
+      "id": "relation:442426ca6875c01a78a743fd848f49d45f86b1974f4ca15b068ba89d7721cbee",
+      "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-home-paths",
+        "required": "^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "runtime-import-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:04ab863f271fb50ca4e24351c79ebae27bd66f0890528d4b872de1e2cbf0a317",
+      "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+      "dependency": {
+        "name": "@deepseek-ai/dsh-host-webserver",
+        "required": "^0.1.1-rc.1",
+        "status": "satisfied",
+        "staticUsage": "type-only-reference-observed",
+        "resolvedVersion": "0.1.1-rc.2"
+      }
+    },
+    {
+      "id": "relation:84f49b1e3a673871d5bcc931371988dab334bef3af7a389e2947dd74279b4c52",
+      "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
       "dependency": {
         "name": "react",
         "required": "^18.2.0",

--- a/compatibility-ledger.json
+++ b/compatibility-ledger.json
@@ -2004,11 +2004,245 @@
       },
       "staticFingerprint": "sha256:e94dbd7692477bdf438a3678e9113393f45ea215c66468cad6e4b00147baa4e3",
       "contractFingerprint": "sha256:c24fd15b248b868f10faf7d7fbcdbd0ca6d969eb4bd499a190222c68b26245ac",
-      "observedAt": "2026-08-23T10:28:41.757Z",
-      "result": "unknown",
-      "reason": "the exact npm artifact could not be established before execution",
+      "observedAt": "2026-08-23T10:45:06.760Z",
+      "result": "compatible",
+      "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version",
       "artifact": {
-        "lifecycleScripts": []
+        "lifecycleScripts": [],
+        "sha256": "d1a95afe3d562df46c6b3a27919e8e5470d78e55f2f873188a22f2f53fb537c6",
+        "nodeEngine": ">=22.15"
+      },
+      "resolution": {
+        "profileLockfile": {
+          "sha256": "6b429edf46e6647b49e5eeeb5eec826028d3b0b891e5b1199ed01a8966888bc4",
+          "bytes": 2931,
+          "graphDigest": "sha256:74d526bd3665b5d30e3aae890f22a4edfb2906f514490c0913c8b5f690d29e11",
+          "nodes": 10,
+          "edges": 12,
+          "unresolved": 1,
+          "unresolvedDependencies": [
+            {
+              "from": "pnpm:@openma/deepseek-harness-acp@file:../../../artifact/openma-deepseek-harness-acp-0.4.24.tgz",
+              "name": "@deepseek-ai/dsh",
+              "spec": "*",
+              "kind": "optional"
+            }
+          ]
+        },
+        "runtimeGraph": {
+          "digest": "sha256:9fc681b134ddb95014b186bf6ab9d985069746a9f70baebe2f9278c23c751c66",
+          "nodes": 456,
+          "edges": 2041,
+          "unresolved": 0,
+          "optionalUnavailable": 59,
+          "optionalUnavailableDependencies": [
+            {
+              "from": "dsh-host/node_modules/.pnpm/@deepseek-ai+node-addon-landlock-run@0.1.1/node_modules/@deepseek-ai/node-addon-landlock-run",
+              "name": "@deepseek-ai/node-addon-landlock-run-linux-arm64",
+              "spec": "0.1.1",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@modelcontextprotocol+sdk@1.30.0_zod@4.4.3/node_modules/@modelcontextprotocol/sdk",
+              "name": "@cfworker/json-schema",
+              "spec": "^4.1.1",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-darwin-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-darwin-x64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-arm",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-ia32",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-ppc64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-riscv64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-s390x",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-ia32",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-x64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-darwin-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-darwin-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-loong64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-riscv64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-openbsd-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-openbsd-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-darwin-arm64",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-darwin-x64",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-linux-arm64-gnu",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-win32-arm64-msvc",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-win32-ia32-msvc",
+              "spec": "0.1.5",
+              "kind": "optional"
+            }
+          ],
+          "pluginPeerContracts": {
+            "declared": 0,
+            "satisfied": 0,
+            "mismatched": 0,
+            "indeterminate": 0,
+            "missing": 0,
+            "relations": []
+          },
+          "hostRuntime": {
+            "source": "dsh-process",
+            "resolvedNodes": 447,
+            "dshVersion": "0.1.1-rc.2"
+          }
+        }
       },
       "observer": {
         "schema": "upstream-radar.dsh-install-observation/v1alpha1",
@@ -9881,11 +10115,334 @@
       },
       "staticFingerprint": "sha256:2deaf09cffc00cf01350c9b68dca78f2881ff613e46fcd1f5b9ce3306110c091",
       "contractFingerprint": "sha256:c8066f6abbf8e4cd313f1cd2019f6dd3dbb49483b6ad22cd1d5991708da99869",
-      "observedAt": "2026-08-23T10:28:39.649Z",
-      "result": "unknown",
-      "reason": "the exact npm artifact could not be established before execution",
+      "observedAt": "2026-08-23T10:45:08.504Z",
+      "result": "peer-contract-incompatible",
+      "reason": "the exact artifact installed and loaded, but @deepseek-ai/dsh-client-ui-slots@^0.1.1-rc.1 was not resolved by the DSH runtime (no-literal-reference-observed)",
       "artifact": {
-        "lifecycleScripts": []
+        "lifecycleScripts": [
+          "prepare"
+        ],
+        "sha256": "a1b0e87a5beca59d31fff6ac92b65df7743064055865f1a2e788f4c415ece001"
+      },
+      "resolution": {
+        "profileLockfile": {
+          "sha256": "667e1af2459e6eca7ab9c7eb33fbc827de883071d7606763553216d362a25e4e",
+          "bytes": 912,
+          "graphDigest": "sha256:44fe91bd8b2aa829679b53431ea6f13a81073aaf7c7d4645f1603d62de799c90",
+          "nodes": 2,
+          "edges": 1,
+          "unresolved": 6,
+          "unresolvedDependencies": [
+            {
+              "from": "pnpm:dsh-pet@file:../../../artifact/dsh-pet-0.1.7.tgz",
+              "name": "@deepseek-ai/cordis",
+              "spec": "^4.0.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:dsh-pet@file:../../../artifact/dsh-pet-0.1.7.tgz",
+              "name": "@deepseek-ai/dsh-client-runtime",
+              "spec": "^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:dsh-pet@file:../../../artifact/dsh-pet-0.1.7.tgz",
+              "name": "@deepseek-ai/dsh-client-ui-slots",
+              "spec": "^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:dsh-pet@file:../../../artifact/dsh-pet-0.1.7.tgz",
+              "name": "@deepseek-ai/dsh-home-paths",
+              "spec": "^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:dsh-pet@file:../../../artifact/dsh-pet-0.1.7.tgz",
+              "name": "@deepseek-ai/dsh-host-webserver",
+              "spec": "^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:dsh-pet@file:../../../artifact/dsh-pet-0.1.7.tgz",
+              "name": "react",
+              "spec": "^18.2.0",
+              "kind": "peer"
+            }
+          ]
+        },
+        "runtimeGraph": {
+          "digest": "sha256:d70fbb66eaf7c135618ce00e6230bac31da9eaf1bfcd44dc3661924a09e0d367",
+          "nodes": 448,
+          "edges": 2034,
+          "unresolved": 1,
+          "unresolvedDependencies": [
+            {
+              "from": "node_modules/dsh-pet",
+              "name": "@deepseek-ai/dsh-client-ui-slots",
+              "spec": "^0.1.1-rc.1",
+              "kind": "peer"
+            }
+          ],
+          "optionalUnavailable": 59,
+          "optionalUnavailableDependencies": [
+            {
+              "from": "dsh-host/node_modules/.pnpm/@deepseek-ai+node-addon-landlock-run@0.1.1/node_modules/@deepseek-ai/node-addon-landlock-run",
+              "name": "@deepseek-ai/node-addon-landlock-run-linux-arm64",
+              "spec": "0.1.1",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@modelcontextprotocol+sdk@1.30.0_zod@4.4.3/node_modules/@modelcontextprotocol/sdk",
+              "name": "@cfworker/json-schema",
+              "spec": "^4.1.1",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-darwin-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-darwin-x64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-arm",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-ia32",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-ppc64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-riscv64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-s390x",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-ia32",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-x64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-darwin-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-darwin-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-loong64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-riscv64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-openbsd-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-openbsd-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-darwin-arm64",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-darwin-x64",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-linux-arm64-gnu",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-win32-arm64-msvc",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-win32-ia32-msvc",
+              "spec": "0.1.5",
+              "kind": "optional"
+            }
+          ],
+          "pluginPeerContracts": {
+            "declared": 6,
+            "satisfied": 5,
+            "mismatched": 0,
+            "indeterminate": 0,
+            "missing": 1,
+            "relations": [
+              {
+                "name": "@deepseek-ai/cordis",
+                "required": "^4.0.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "4.0.1"
+              },
+              {
+                "name": "@deepseek-ai/dsh-client-runtime",
+                "required": "^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-client-ui-slots",
+                "required": "^0.1.1-rc.1",
+                "status": "missing",
+                "staticUsage": "no-literal-reference-observed"
+              },
+              {
+                "name": "@deepseek-ai/dsh-home-paths",
+                "required": "^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-host-webserver",
+                "required": "^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "react",
+                "required": "^18.2.0",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "18.3.1"
+              }
+            ],
+            "issues": [
+              {
+                "name": "@deepseek-ai/dsh-client-ui-slots",
+                "required": "^0.1.1-rc.1",
+                "status": "missing",
+                "staticUsage": "no-literal-reference-observed"
+              }
+            ]
+          },
+          "hostRuntime": {
+            "source": "dsh-process",
+            "resolvedNodes": 447,
+            "dshVersion": "0.1.1-rc.2"
+          }
+        }
       },
       "observer": {
         "schema": "upstream-radar.dsh-install-observation/v1alpha1",
@@ -11764,11 +12321,580 @@
       },
       "staticFingerprint": "sha256:2487532d41d57ff848a7d778081c7153b15e41954f685693abca10e479927937",
       "contractFingerprint": "sha256:384bf76b47277a6fbb967b96f230fa8e637048ed572834d1c8ee10aba5220bcd",
-      "observedAt": "2026-08-23T10:28:45.459Z",
-      "result": "unknown",
-      "reason": "the exact npm artifact could not be established before execution",
+      "observedAt": "2026-08-23T10:45:13.430Z",
+      "result": "compatible",
+      "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version",
       "artifact": {
-        "lifecycleScripts": []
+        "lifecycleScripts": [
+          "prepare"
+        ],
+        "sha256": "1604bf456c740743064bab07d91a1f083fb64dcc335d9b43dbddc0b96c1fe66e",
+        "nodeEngine": "^22.19 || >=24"
+      },
+      "resolution": {
+        "profileLockfile": {
+          "sha256": "d8dc18a611ed6ade2a44c08386986f55632f5e1b7a06e8d15019f8d074ed7f8e",
+          "bytes": 19098,
+          "graphDigest": "sha256:b083c9d1dcb19fbf1bd0315ea31fb7d874f3bf141d13e02fbd26a033fea2c46b",
+          "nodes": 66,
+          "edges": 82,
+          "unresolved": 26,
+          "unresolvedDependencies": [
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/cordis",
+              "spec": "^4.0.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-agent",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-agent-instructions",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-agent-presets",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-atomic-write",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-commands",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-cordis-host-runner",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-invariants",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-llm",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-persona",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-session",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-settings",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-skill",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-storage",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-storage-domain",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-storage-json",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-system-prompt",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-terminal",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-terminal-bash",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-tool-ask-user",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-tool-bash-persistent",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-tool-cordis",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-user-approval",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-user-questions",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/dsh-workspace",
+              "spec": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+              "kind": "peer"
+            },
+            {
+              "from": "pnpm:@deepseek-harness-tui/dsh-tui@file:../../../artifact/deepseek-harness-tui-dsh-tui-0.9.0.tgz",
+              "name": "@deepseek-ai/schemastery",
+              "spec": "^3.18.1",
+              "kind": "peer"
+            }
+          ]
+        },
+        "runtimeGraph": {
+          "digest": "sha256:e07291b747343d2185b52a7d22b909c973961256428ccd3baeddab1d3172c700",
+          "nodes": 520,
+          "edges": 2160,
+          "unresolved": 0,
+          "optionalUnavailable": 62,
+          "optionalUnavailableDependencies": [
+            {
+              "from": "dsh-host/node_modules/.pnpm/@deepseek-ai+node-addon-landlock-run@0.1.1/node_modules/@deepseek-ai/node-addon-landlock-run",
+              "name": "@deepseek-ai/node-addon-landlock-run-linux-arm64",
+              "spec": "0.1.1",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@modelcontextprotocol+sdk@1.30.0_zod@4.4.3/node_modules/@modelcontextprotocol/sdk",
+              "name": "@cfworker/json-schema",
+              "spec": "^4.1.1",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-darwin-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-darwin-x64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-arm",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-ia32",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-ppc64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-riscv64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-s390x",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-ia32",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-x64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-darwin-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-darwin-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-loong64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-riscv64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-openbsd-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-openbsd-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-darwin-arm64",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-darwin-x64",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-linux-arm64-gnu",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-win32-arm64-msvc",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-win32-ia32-msvc",
+              "spec": "0.1.5",
+              "kind": "optional"
+            }
+          ],
+          "pluginPeerContracts": {
+            "declared": 26,
+            "satisfied": 26,
+            "mismatched": 0,
+            "indeterminate": 0,
+            "missing": 0,
+            "relations": [
+              {
+                "name": "@deepseek-ai/cordis",
+                "required": "^4.0.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "4.0.1"
+              },
+              {
+                "name": "@deepseek-ai/dsh-agent",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-agent-instructions",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-agent-presets",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-atomic-write",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-commands",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-cordis-host-runner",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-invariants",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-llm",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-persona",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-session",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-settings",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-skill",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-storage",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-storage-domain",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-storage-json",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-system-prompt",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-terminal",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-terminal-bash",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-tool-ask-user",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-tool-bash-persistent",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-tool-cordis",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-user-approval",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-user-questions",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/dsh-workspace",
+                "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+                "status": "satisfied",
+                "staticUsage": "type-only-reference-observed",
+                "resolvedVersion": "0.1.1-rc.2"
+              },
+              {
+                "name": "@deepseek-ai/schemastery",
+                "required": "^3.18.1",
+                "status": "satisfied",
+                "staticUsage": "runtime-import-observed",
+                "resolvedVersion": "3.18.1"
+              }
+            ]
+          },
+          "hostRuntime": {
+            "source": "dsh-process",
+            "resolvedNodes": 447,
+            "dshVersion": "0.1.1-rc.2"
+          }
+        }
       },
       "observer": {
         "schema": "upstream-radar.dsh-install-observation/v1alpha1",
@@ -12056,11 +13182,236 @@
       },
       "staticFingerprint": "sha256:4d613429f7edde8b2cb968c11cdaf659b672d0677a4a9b8c0ce9485a84499ef6",
       "contractFingerprint": "sha256:de33af1c481b0c24bc433fb49ee7b965aca13377d1021df91ed39f179d18e949",
-      "observedAt": "2026-08-23T10:28:56.405Z",
-      "result": "unknown",
-      "reason": "the exact npm artifact could not be established before execution",
+      "observedAt": "2026-08-23T10:45:04.817Z",
+      "result": "compatible",
+      "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version",
       "artifact": {
-        "lifecycleScripts": []
+        "lifecycleScripts": [],
+        "sha256": "93ea96844b828c0845fc65059a858d41cc605cffdebc4f1298b478c50d06077c"
+      },
+      "resolution": {
+        "profileLockfile": {
+          "sha256": "67798e56a0252d4d0b9695ddaa554c99fda7884dbfd99c21cabec87711237342",
+          "bytes": 672,
+          "graphDigest": "sha256:c81d36df6d43396d5982597218cf538551cd287fb49d9465e9a42c036fbe3969",
+          "nodes": 2,
+          "edges": 1,
+          "unresolved": 0
+        },
+        "runtimeGraph": {
+          "digest": "sha256:ea5a6034ae6d201b24f7bcae3ae2b9b4c429d92a5bdb02b57fa6912a3a0583e3",
+          "nodes": 448,
+          "edges": 2029,
+          "unresolved": 0,
+          "optionalUnavailable": 59,
+          "optionalUnavailableDependencies": [
+            {
+              "from": "dsh-host/node_modules/.pnpm/@deepseek-ai+node-addon-landlock-run@0.1.1/node_modules/@deepseek-ai/node-addon-landlock-run",
+              "name": "@deepseek-ai/node-addon-landlock-run-linux-arm64",
+              "spec": "0.1.1",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@modelcontextprotocol+sdk@1.30.0_zod@4.4.3/node_modules/@modelcontextprotocol/sdk",
+              "name": "@cfworker/json-schema",
+              "spec": "^4.1.1",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-darwin-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-darwin-x64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-arm",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-ia32",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-ppc64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-riscv64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-linux-s390x",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-arm64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-ia32",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/@vscode+ripgrep@1.18.0/node_modules/@vscode/ripgrep",
+              "name": "@vscode/ripgrep-win32-x64",
+              "spec": "1.18.0",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-darwin-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-darwin-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-freebsd-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-loong64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-linux-riscv64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-openbsd-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-openbsd-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-arm64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-ia32",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/koffi@3.1.6/node_modules/koffi",
+              "name": "@koromix/koffi-win32-x64",
+              "spec": "3.1.6",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-darwin-arm64",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-darwin-x64",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-linux-arm64-gnu",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-win32-arm64-msvc",
+              "spec": "0.1.5",
+              "kind": "optional"
+            },
+            {
+              "from": "dsh-host/node_modules/.pnpm/node-addon-require-builtin@0.1.5/node_modules/node-addon-require-builtin",
+              "name": "node-addon-require-builtin-win32-ia32-msvc",
+              "spec": "0.1.5",
+              "kind": "optional"
+            }
+          ],
+          "pluginPeerContracts": {
+            "declared": 0,
+            "satisfied": 0,
+            "mismatched": 0,
+            "indeterminate": 0,
+            "missing": 0,
+            "relations": []
+          },
+          "hostRuntime": {
+            "source": "dsh-process",
+            "resolvedNodes": 447,
+            "dshVersion": "0.1.1-rc.2"
+          }
+        }
       },
       "observer": {
         "schema": "upstream-radar.dsh-install-observation/v1alpha1",

--- a/compatibility-reverse-index.json
+++ b/compatibility-reverse-index.json
@@ -53,6 +53,18 @@
           "resolvedVersion": "4.0.1"
         },
         {
+          "relationId": "relation:fb92d5e2120330352b357616cc18111a96169d27acbbb5ea5f60f3e15a7dddca",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^4.0.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "4.0.1"
+        },
+        {
           "relationId": "relation:fe6b52e02db24d61cf0841976d28dcb3b45ee0ea0da117d2f7a4b41250ea34ba",
           "cellId": "cell:1d1e110d2659592a00c830bf2573998b9da3c472fc24c6cbf977497fa594b10f",
           "caseId": "dsh-commandcode-provider-node22",
@@ -245,6 +257,18 @@
           "resolvedVersion": "4.0.1"
         },
         {
+          "relationId": "relation:85912375414bd0d996e18470f89679fe421d8c636e02afd7bde3ec3376216fef",
+          "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+          "caseId": "dsh-pet-node22",
+          "plugin": "dsh-pet@0.1.7",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^4.0.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "4.0.1"
+        },
+        {
           "relationId": "relation:7bb811b58247f4b6805d01f4aa257e3ed00656a8a180e810a5c491d5fe3c9c9d",
           "cellId": "cell:f9e22175683cce9f4c1c204c3fd6524497e654000953e37bbfeff716e3d5ae2c",
           "caseId": "dsh-wallpaper-engine-node22",
@@ -346,6 +370,18 @@
           "resolvedVersion": "0.1.1-rc.2"
         },
         {
+          "relationId": "relation:dcfd82c88d936e3b899c30010ab1b009eb1bc133ff52ea1c0adcbcde9e73bc0c",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
           "relationId": "relation:d72c9f202bfaa3de4d181435957243331ed0501241f19e0b82fe3b30049c5671",
           "cellId": "cell:5f49817375df6ac68af35710fc58dcc1b71d1c1a44930c4367bc97f38b8baec9",
           "caseId": "better-sidebar-node22",
@@ -389,8 +425,37 @@
       ]
     },
     {
+      "name": "@deepseek-ai/dsh-agent-instructions",
+      "impacts": [
+        {
+          "relationId": "relation:d30267527304742a8bb27f3dfa2468f0d85428d4cf385330ce2ac4ed8a1fa49e",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
       "name": "@deepseek-ai/dsh-agent-presets",
       "impacts": [
+        {
+          "relationId": "relation:a74c01382cdb9584b1fea3c99f795eb4cf27055998c1fb02d67c4f004be725fc",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
         {
           "relationId": "relation:ab3bc3df4e6e9e55adb2122a5ed21b2d75e92a8b698c082ce9805afe23517ff5",
           "cellId": "cell:115214fe17453d43ae62804dfa43224bbd2a19fef9bf63186d4de2fbfe58e92c",
@@ -478,6 +543,18 @@
     {
       "name": "@deepseek-ai/dsh-atomic-write",
       "impacts": [
+        {
+          "relationId": "relation:433a886b8bb5a9b2d5e479b009c680b77dffc409b7c31c57e7f89f60d6fc99c4",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
         {
           "relationId": "relation:ea7c8d02281a2d9154aa16668294743ef42efc0be8d848344a6fc2a7546b13af",
           "cellId": "cell:7a238eec25721364f4e413ad93c70c63883644083d869915437d6ce25ff8548e",
@@ -825,6 +902,18 @@
           "required": "^0.1.0-rc.6",
           "status": "satisfied",
           "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
+          "relationId": "relation:147132d0a2bcc64690e5e7b71ede6a606f116ca793466e3aa2ee7dfec4c848a1",
+          "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+          "caseId": "dsh-pet-node22",
+          "plugin": "dsh-pet@0.1.7",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
           "resolvedVersion": "0.1.1-rc.2"
         },
         {
@@ -1227,6 +1316,17 @@
           "staticUsage": "runtime-import-observed"
         },
         {
+          "relationId": "relation:38682b5fa4814e5825bb745685e66c2cef52eb9056b04ae5a7fc69d967a663e0",
+          "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+          "caseId": "dsh-pet-node22",
+          "plugin": "dsh-pet@0.1.7",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.1-rc.1",
+          "status": "missing",
+          "staticUsage": "no-literal-reference-observed"
+        },
+        {
           "relationId": "relation:c2ced6043ecbfd88c6e79d02287a38ca69671e79c6efc2623028a3e0632654a6",
           "cellId": "cell:f9e22175683cce9f4c1c204c3fd6524497e654000953e37bbfeff716e3d5ae2c",
           "caseId": "dsh-wallpaper-engine-node22",
@@ -1330,6 +1430,18 @@
       "name": "@deepseek-ai/dsh-commands",
       "impacts": [
         {
+          "relationId": "relation:c199fae7247ede10ba3cc375b1b00173c278d30af7091e1cfef9566ba6738448",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
           "relationId": "relation:035683ef13fbe64847cbd4cb3269ac8141f03e785e6a398d5a7f84025853ebb5",
           "cellId": "cell:1d1e110d2659592a00c830bf2573998b9da3c472fc24c6cbf977497fa594b10f",
           "caseId": "dsh-commandcode-provider-node22",
@@ -1351,6 +1463,23 @@
           "required": "^0.1.0-rc.6",
           "status": "satisfied",
           "staticUsage": "scan-incomplete",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-cordis-host-runner",
+      "impacts": [
+        {
+          "relationId": "relation:025a0205b3f29a500274cf61f1bf54a3215cd25c3077d38a26c7cad5dcb8a6c9",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
           "resolvedVersion": "0.1.1-rc.2"
         }
       ]
@@ -1480,6 +1609,18 @@
           "status": "satisfied",
           "staticUsage": "runtime-import-observed",
           "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
+          "relationId": "relation:442426ca6875c01a78a743fd848f49d45f86b1974f4ca15b068ba89d7721cbee",
+          "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+          "caseId": "dsh-pet-node22",
+          "plugin": "dsh-pet@0.1.7",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
         }
       ]
     },
@@ -1564,6 +1705,18 @@
           "resolvedVersion": "0.1.1-rc.2"
         },
         {
+          "relationId": "relation:04ab863f271fb50ca4e24351c79ebae27bd66f0890528d4b872de1e2cbf0a317",
+          "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+          "caseId": "dsh-pet-node22",
+          "plugin": "dsh-pet@0.1.7",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
           "relationId": "relation:ab98db1ec1fd02d9b78028e580bd5eddddc8c3371659d3adeedd53407b5680b1",
           "cellId": "cell:a8fc384560fbd18b80d3f16499569cb9f4a6ab4639b71cfbbc03dce429ccd2a7",
           "caseId": "dsh-remote-node22",
@@ -1590,6 +1743,18 @@
           "required": "0.1.1-rc.2",
           "status": "satisfied",
           "staticUsage": "no-literal-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
+          "relationId": "relation:b1ea51df2ad654c66dfa8163af0fc73324d479a11ecd3b5b4a5472d1c53829fe",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
           "resolvedVersion": "0.1.1-rc.2"
         },
         {
@@ -1658,6 +1823,18 @@
           "dshVersion": "0.1.1-rc.2",
           "nodeMajor": 22,
           "required": "0.1.1-rc.2",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
+          "relationId": "relation:6c4f68411435ed23625c17d11db272c4e5168c8c29dde9214680dacde1b8e588",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
           "status": "satisfied",
           "staticUsage": "runtime-import-observed",
           "resolvedVersion": "0.1.1-rc.2"
@@ -1778,6 +1955,23 @@
       ]
     },
     {
+      "name": "@deepseek-ai/dsh-persona",
+      "impacts": [
+        {
+          "relationId": "relation:cb35307c53fa0d25ed4b60c01e86a6e9fa287ab52ffc43c1b06438bb936d8837",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
       "name": "@deepseek-ai/dsh-sandbox-policy",
       "impacts": [
         {
@@ -1817,6 +2011,18 @@
           "dshVersion": "0.1.1-rc.2",
           "nodeMajor": 22,
           "required": "0.1.1-rc.2",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
+          "relationId": "relation:40e4d72f93b5d6042ae50a877358d3fd2a2b1a7c76b8b199117ab7db2a617a9a",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
           "status": "satisfied",
           "staticUsage": "runtime-import-observed",
           "resolvedVersion": "0.1.1-rc.2"
@@ -1894,6 +2100,18 @@
           "dshVersion": "0.1.1-rc.2",
           "nodeMajor": 22,
           "required": "0.1.1-rc.2",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
+          "relationId": "relation:a00a10c47001deaf3457fa1db4e1a582f40af60b3da09a77176229d0b0133eb2",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
           "status": "satisfied",
           "staticUsage": "runtime-import-observed",
           "resolvedVersion": "0.1.1-rc.2"
@@ -2003,6 +2221,35 @@
           "status": "satisfied",
           "staticUsage": "type-only-reference-observed",
           "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
+          "relationId": "relation:1f572ccbd0e2bfee76c5e84dc30bf30d82c9c554a96e7bf985ddcd0e11098221",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-storage",
+      "impacts": [
+        {
+          "relationId": "relation:31b044731cdabcae37139cc4d8606901afdda701a7d9ed6773d0f9eb0c32c18a",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
         }
       ]
     },
@@ -2019,6 +2266,35 @@
           "required": "^0.1.0-rc.6",
           "status": "satisfied",
           "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
+          "relationId": "relation:813648f3aea1eef73a0525c4977e597af5a7612433fd4f399e939682dcdf5f0f",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-storage-json",
+      "impacts": [
+        {
+          "relationId": "relation:9f931aff82de1313d116a0961ae41817f9bbafd19910b55777db198a12ba11a7",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
           "resolvedVersion": "0.1.1-rc.2"
         }
       ]
@@ -2085,6 +2361,18 @@
       "name": "@deepseek-ai/dsh-system-prompt",
       "impacts": [
         {
+          "relationId": "relation:27cc6c32a52495b9856426b4141202342e8f6acda1b5eccbb020e845be08ac4f",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        },
+        {
           "relationId": "relation:cfe73e4181e658d99f70c1357cb4233f666944b541c4c13c69d93f828ec9dd43",
           "cellId": "cell:0de7f00b1bcc2e6ad33e10c690306e2527d1bb363c11fd428f795c23ba24a3bb",
           "caseId": "dsh-agency-agents-node22",
@@ -2147,6 +2435,40 @@
       ]
     },
     {
+      "name": "@deepseek-ai/dsh-terminal",
+      "impacts": [
+        {
+          "relationId": "relation:a8ec4c3a3064225f47186742e53ae0db5a3f9e959d684df4f094cb0b98b48ae0",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-terminal-bash",
+      "impacts": [
+        {
+          "relationId": "relation:e6261807e9e1b55a3fe1f1e2e7c5e07cb0828774b3f57911583532c2adac3102",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
       "name": "@deepseek-ai/dsh-timeout",
       "impacts": [
         {
@@ -2171,6 +2493,57 @@
           "required": "*",
           "status": "indeterminate",
           "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-tool-ask-user",
+      "impacts": [
+        {
+          "relationId": "relation:13e5b6035ab8311fb2f7b5733f8e7dfeee10ee0c50787cc0c75d4e58ef7c5b6a",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-tool-bash-persistent",
+      "impacts": [
+        {
+          "relationId": "relation:e6e420ae373f0cbca1705aad30fcb6c2bf49614f4ae1e3d89049e189e693e35f",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-tool-cordis",
+      "impacts": [
+        {
+          "relationId": "relation:a56dc26b048e1b09b3d715a6c477143735554c94b74bf22df3c2216948b37c39",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
           "resolvedVersion": "0.1.1-rc.2"
         }
       ]
@@ -2419,6 +2792,40 @@
       ]
     },
     {
+      "name": "@deepseek-ai/dsh-user-approval",
+      "impacts": [
+        {
+          "relationId": "relation:e645e20736e636e888872fbff404b510999212d93eb766b5cf0fb4a2f285ce09",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-user-questions",
+      "impacts": [
+        {
+          "relationId": "relation:dd486e4db405b7010258c562fcc7bb2236fbc08ed3759226f74986cd3ac31d1f",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
       "name": "@deepseek-ai/dsh-web",
       "impacts": [
         {
@@ -2431,6 +2838,23 @@
           "required": "0.1.0-rc.7",
           "status": "mismatched",
           "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "0.1.1-rc.2"
+        }
+      ]
+    },
+    {
+      "name": "@deepseek-ai/dsh-workspace",
+      "impacts": [
+        {
+          "relationId": "relation:aac7e4771609b23fa9a563ed7af327f0cbe8e88afe1b4f3d9d49091ed48023b4",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^0.1.0-rc.6 || ^0.1.1-rc.1",
+          "status": "satisfied",
+          "staticUsage": "type-only-reference-observed",
           "resolvedVersion": "0.1.1-rc.2"
         }
       ]
@@ -2455,6 +2879,18 @@
           "cellId": "cell:20edf253de6bb60c77cd89a01a6a2fdada89ae3b46de93db0a7219ad42b45544",
           "caseId": "dsh-vision-toolkit-node22",
           "plugin": "@anionex/dsh-vision-toolkit@0.1.38",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^3.18.1",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "3.18.1"
+        },
+        {
+          "relationId": "relation:0f57ae5bea9467affd36c679c408fb3100d530ad0b65eed3f5ff6c05c7f85746",
+          "cellId": "cell:a5b55da67f9e329d4cc061e7162f266a7f49731a962a1e2ed18ff17da35b2820",
+          "caseId": "dsh-tui-node22",
+          "plugin": "@deepseek-harness-tui/dsh-tui@0.9.0",
           "dshVersion": "0.1.1-rc.2",
           "nodeMajor": 22,
           "required": "^3.18.1",
@@ -2693,6 +3129,18 @@
           "cellId": "cell:ae7ce4f5a5fed4457948fcc1660e5b3bfb13996726b34d6597d94f9c492ef524",
           "caseId": "dsh-git-worktree-node22",
           "plugin": "dsh-git-worktree@0.4.0",
+          "dshVersion": "0.1.1-rc.2",
+          "nodeMajor": 22,
+          "required": "^18.2.0",
+          "status": "satisfied",
+          "staticUsage": "runtime-import-observed",
+          "resolvedVersion": "18.3.1"
+        },
+        {
+          "relationId": "relation:84f49b1e3a673871d5bcc931371988dab334bef3af7a389e2947dd74279b4c52",
+          "cellId": "cell:b0701baf0227e85409f56efa70277d743851ca414ac082e90627d76588e38e1d",
+          "caseId": "dsh-pet-node22",
+          "plugin": "dsh-pet@0.1.7",
           "dshVersion": "0.1.1-rc.2",
           "nodeMajor": 22,
           "required": "^18.2.0",

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -1,6 +1,6 @@
 {
   "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha1",
-  "generatedAt": "2026-08-23T10:30:09.077Z",
+  "generatedAt": "2026-08-23T10:48:50.129Z",
   "producer": {
     "name": "upstream-radar",
     "version": "0.41.0",
@@ -25,9 +25,9 @@
   },
   "summary": {
     "total": 50,
-    "observed-compatible": 29,
+    "observed-compatible": 32,
     "observed-incompatible": 4,
-    "needs-review": 13,
+    "needs-review": 10,
     "not-observed": 4
   },
   "plugins": [
@@ -432,12 +432,13 @@
         "selectedVersion": "0.9.0",
         "distTag": "latest"
       },
-      "status": "needs-review",
+      "status": "observed-compatible",
       "cells": [
         {
           "caseId": "dsh-tui-node22",
           "artifact": {
-            "spec": "@deepseek-harness-tui/dsh-tui@0.9.0"
+            "spec": "@deepseek-harness-tui/dsh-tui@0.9.0",
+            "sha256": "1604bf456c740743064bab07d91a1f083fb64dcc335d9b43dbddc0b96c1fe66e"
           },
           "dsh": {
             "package": "@deepseek-ai/dsh",
@@ -451,11 +452,11 @@
           },
           "executionPlane": "headless",
           "profile": "headless",
-          "status": "needs-review",
-          "radarResult": "unknown",
-          "observedAt": "2026-08-23T10:28:45.459Z",
-          "recheckDueAt": "2026-08-30T10:28:45.459Z",
-          "reason": "the exact npm artifact could not be established before execution"
+          "status": "observed-compatible",
+          "radarResult": "compatible",
+          "observedAt": "2026-08-23T10:45:13.430Z",
+          "recheckDueAt": "2026-08-30T10:45:13.430Z",
+          "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version"
         }
       ],
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
@@ -474,12 +475,13 @@
         "selectedVersion": "1.0.2",
         "distTag": "latest"
       },
-      "status": "needs-review",
+      "status": "observed-compatible",
       "cells": [
         {
           "caseId": "dsh-vibe-math-node22",
           "artifact": {
-            "spec": "dsh-vibe-math@1.0.2"
+            "spec": "dsh-vibe-math@1.0.2",
+            "sha256": "93ea96844b828c0845fc65059a858d41cc605cffdebc4f1298b478c50d06077c"
           },
           "dsh": {
             "package": "@deepseek-ai/dsh",
@@ -493,11 +495,11 @@
           },
           "executionPlane": "headless",
           "profile": "headless",
-          "status": "needs-review",
-          "radarResult": "unknown",
-          "observedAt": "2026-08-23T10:28:56.405Z",
-          "recheckDueAt": "2026-08-30T10:28:56.405Z",
-          "reason": "the exact npm artifact could not be established before execution"
+          "status": "observed-compatible",
+          "radarResult": "compatible",
+          "observedAt": "2026-08-23T10:45:04.817Z",
+          "recheckDueAt": "2026-08-30T10:45:04.817Z",
+          "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version"
         }
       ],
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
@@ -1237,12 +1239,13 @@
         "selectedVersion": "0.4.24",
         "distTag": "latest"
       },
-      "status": "needs-review",
+      "status": "observed-compatible",
       "cells": [
         {
           "caseId": "deepseek-harness-acp-node22",
           "artifact": {
-            "spec": "@openma/deepseek-harness-acp@0.4.24"
+            "spec": "@openma/deepseek-harness-acp@0.4.24",
+            "sha256": "d1a95afe3d562df46c6b3a27919e8e5470d78e55f2f873188a22f2f53fb537c6"
           },
           "dsh": {
             "package": "@deepseek-ai/dsh",
@@ -1256,11 +1259,11 @@
           },
           "executionPlane": "headless",
           "profile": "headless",
-          "status": "needs-review",
-          "radarResult": "unknown",
-          "observedAt": "2026-08-23T10:28:41.757Z",
-          "recheckDueAt": "2026-08-30T10:28:41.757Z",
-          "reason": "the exact npm artifact could not be established before execution"
+          "status": "observed-compatible",
+          "radarResult": "compatible",
+          "observedAt": "2026-08-23T10:45:06.760Z",
+          "recheckDueAt": "2026-08-30T10:45:06.760Z",
+          "reason": "the exact artifact installed, registered, loaded, and satisfied its direct peer contracts under the requested DSH version"
         }
       ],
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
@@ -1284,7 +1287,8 @@
         {
           "caseId": "dsh-pet-node22",
           "artifact": {
-            "spec": "dsh-pet@0.1.7"
+            "spec": "dsh-pet@0.1.7",
+            "sha256": "a1b0e87a5beca59d31fff6ac92b65df7743064055865f1a2e788f4c415ece001"
           },
           "dsh": {
             "package": "@deepseek-ai/dsh",
@@ -1299,10 +1303,10 @@
           "executionPlane": "headless",
           "profile": "headless",
           "status": "needs-review",
-          "radarResult": "unknown",
-          "observedAt": "2026-08-23T10:28:39.649Z",
-          "recheckDueAt": "2026-08-30T10:28:39.649Z",
-          "reason": "the exact npm artifact could not be established before execution"
+          "radarResult": "peer-contract-incompatible",
+          "observedAt": "2026-08-23T10:45:08.504Z",
+          "recheckDueAt": "2026-08-30T10:45:08.504Z",
+          "reason": "the exact artifact installed and loaded, but @deepseek-ai/dsh-client-ui-slots@^0.1.1-rc.1 was not resolved by the DSH runtime (no-literal-reference-observed)"
         }
       ],
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"

--- a/feeds/dsh-plugin-compatibility.md
+++ b/feeds/dsh-plugin-compatibility.md
@@ -1,8 +1,8 @@
 # DSH directory compatibility evidence
 
-Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-23T10:30:09.077Z`.
+Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-23T10:48:50.129Z`.
 
-**29 observed compatible · 4 observed incompatible · 13 needs review · 4 not observed**
+**32 observed compatible · 4 observed incompatible · 10 needs review · 4 not observed**
 
 | Catalog plugin | Exact artifact | Exact DSH / runtime | Evidence status | Observed |
 | --- | --- | --- | --- | --- |
@@ -15,8 +15,8 @@ Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-pl
 | [awesome-dsh-plugin/dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) | `dsh-find-plugin@0.3.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:07.055Z |
 | [Blank-not-black/dsh-Remote](https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin) | `dsh-remote-plugin@0.6.10` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:10.766Z |
 | [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) | `dsh-context@0.25.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:17.088Z |
-| [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | `@deepseek-harness-tui/dsh-tui@0.9.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:28:45.459Z |
-| [ChongCyrus/Vibe-Mathematics](https://github.com/ChongCyrus/Vibe-Mathematics) | `dsh-vibe-math@1.0.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:28:56.405Z |
+| [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | `@deepseek-harness-tui/dsh-tui@0.9.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:45:13.430Z |
+| [ChongCyrus/Vibe-Mathematics](https://github.com/ChongCyrus/Vibe-Mathematics) | `dsh-vibe-math@1.0.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:45:04.817Z |
 | [DDDMUC/dsh-free-search](https://github.com/DDDMUC/dsh-free-search) | `dsh-free-search@0.4.12` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:01.728Z |
 | [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) | `dshmarket@1.19.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T07:09:16.954Z |
 | [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) | `dsh-plugin-wallpaper-engine@0.5.1` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:29:07.481Z |
@@ -35,8 +35,8 @@ Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-pl
 | [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | `@nanmicoder/dsh-agent-teams@0.1.13` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:29.383Z |
 | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | `dsh-chat-import@0.6.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:28:59.740Z |
 | [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | `dsh-better-sidebar@0.15.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T03:40:58.944Z |
-| [openma-ai/deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | `@openma/deepseek-harness-acp@0.4.24` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:28:41.757Z |
-| [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) | `dsh-pet@0.1.7` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:28:39.649Z |
+| [openma-ai/deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | `@openma/deepseek-harness-acp@0.4.24` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:45:06.760Z |
+| [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) | `dsh-pet@0.1.7` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:45:08.504Z |
 | [Q00/ouroboros](https://github.com/Q00/ouroboros/tree/main/integrations/dsh-plugin) | — | — | `not-observed` | — |
 | [Relistencode/dsh-extension-hub](https://github.com/Relistencode/dsh-extension-hub) | `dsh-extension-hub@0.2.19` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:05.384Z |
 | [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) | `dsh-dream-skin@0.4.10` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:01.450Z |


### PR DESCRIPTION
## Result

Reconciles four isolated rechecks that were previously `unknown` because of observer artifact-parsing coverage gaps.

- `@openma/deepseek-harness-acp@0.4.24` → compatible
- `@deepseek-harness-tui/dsh-tui@0.9.0` → compatible
- `dsh-vibe-math@1.0.2` → compatible
- `dsh-pet@0.1.7` → needs execution-plane review for an unresolved UI-slots peer

Directory evidence moves from 29 to 32 observed-compatible entries and from 13 to 10 needs-review entries. The four observer workflows completed successfully and the merge accepted all four exact case reports with no missing or rejected evidence.

## Verification

- `pnpm test` — 336/336 passed