### PR TITLE
fix: distinguish dependency build approval gates

### DIFF
--- a/.github/workflows/observe-dsh-plugin-install.yml
+++ b/.github/workflows/observe-dsh-plugin-install.yml
@@ -233,6 +233,7 @@ jobs:
                 `- Plugin Node requirement: \`${inline(report.artifact?.nodeEngine ?? 'not declared')}\``,
                 `- Resolved profile graph: \`${inline(report.resolution?.profileLockfile?.graphDigest ?? 'not established')}\``,
                 `- Approved dependency builds: \`${inline(report.boundary?.approvedDependencyBuilds?.join(', ') || 'none')}\``,
+                `- Additional dependency builds required: \`${inline(report.boundary?.requiredDependencyBuilds?.join(', ') || 'none')}\``,
                 `- Declared lifecycle scripts: \`${inline(report.artifact?.lifecycleScripts?.join(', ') || 'none')}\``,
                 `- Install behavior: ${count(report.observations?.install?.processes)} process exec(s), ${count(report.observations?.install?.network)} network attempt(s), ${count(report.observations?.install?.fileWrites)} file-write syscall(s)`,
                 `- Load behavior: ${count(report.observations?.load?.processes)} process exec(s), ${count(report.observations?.load?.network)} network attempt(s), ${count(report.observations?.load?.fileWrites)} file-write syscall(s)`,
@@ -292,6 +293,7 @@ jobs:
             'compatible',
             'runtime-incompatible',
             'peer-contract-incompatible',
+            'build-approval-required',
             'install-failed',
             'load-failed',
           ])

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,7 +160,8 @@ desired plugin × DSH × runtime-policy cell
 ```
 
 The result vocabulary separates `install-failed`, `load-failed`,
-`peer-contract-incompatible`, `compatible`, and `unknown`; missing or truncated tracing never becomes a clean result. A
+`peer-contract-incompatible`, `build-approval-required`, `compatible`, and
+`unknown`; missing or truncated tracing never becomes a clean result. A
 static Node-engine mismatch is recorded before plugin execution and may open a
 configured alternate runtime cell, so a Node 22 failure is not prematurely
 called a global plugin failure. The ledger accepts a dynamic report only if its
@@ -183,12 +184,21 @@ index, so a later DSH host dependency change can be routed directly to exact
 plugin cells. This backend is useful compatibility and behavior evidence, not
 hostile-code proof.
 
+pnpm's explicit dependency-build gate is not classified as a plugin failure.
+When `ERR_PNPM_IGNORED_BUILDS` provides an exact bounded package list, Radar
+records `build-approval-required` and retains those package names. A separately
+configured cell can approve that exact set and continue through registration
+and load. Malformed or unbounded output remains an ordinary failed/unknown
+observation rather than being guessed into this category.
+
 Issue reconciliation is part of the same scheduled transaction as the ledger
-merge. An actionable result (`runtime-incompatible`,
-`peer-contract-incompatible`, `install-failed`, or `load-failed`) owns one
-issue in Radar's repository through a stable target/runtime case id. A later
-failure updates or reopens that issue; a complete `compatible` observation adds
-the exact retest evidence and closes it. `unknown` never opens a plugin issue.
+merge. An actionable reproduced result (`runtime-incompatible`,
+`install-failed`, or `load-failed`) owns one issue in Radar's repository through
+a stable target/runtime case id. `peer-contract-incompatible` from the headless
+plane and `build-approval-required` stay as review evidence; they do not blame
+the plugin author. A later failure updates or reopens an issue; a complete
+`compatible` observation adds the exact retest evidence and closes it. `unknown`
+never opens a plugin issue.
 If GitHub issue reconciliation fails, the new ledger is not persisted, so the
 next schedule retries the delivery instead of silently marking it handled.
 Docker shares the hosted VM kernel, and code in the same container may attempt

--- a/examples/dsh/install-observer/README.md
+++ b/examples/dsh/install-observer/README.md
@@ -98,6 +98,7 @@ blocked script into a global “allow all” policy.
 | `compatible` | The exact tarball installed, registered, and loaded under the exact DSH release and recorded build-approval set, with readable bounded traces. |
 | `runtime-incompatible` | The exact tarball requires a Node version that excludes the isolated runtime. No plugin or dependency code is executed. |
 | `peer-contract-incompatible` | Install and load passed, but a declared required peer is missing from the actual DSH profile or its resolved version is outside the declared range. This is not by itself proof that every UI/business path fails. |
+| `build-approval-required` | pnpm stopped before registration and supplied an exact list of dependency packages whose lifecycle builds need explicit approval. This is a trust-policy gate, not proof that the plugin is incompatible. |
 | `install-failed` | The traced install failed or DSH did not register the plugin. |
 | `load-failed` | Installation and registration passed, but the traced profile load failed. |
 | `unknown` | The artifact, DSH bootstrap, timeout/output bound, tracer, or collector could not establish a reliable result. |

--- a/schemas/dsh-compatibility-ir.schema.json
+++ b/schemas/dsh-compatibility-ir.schema.json
@@ -20,7 +20,7 @@
           "caseId": { "type": "string", "minLength": 1, "maxLength": 64 },
           "targetId": { "type": "string", "minLength": 1, "maxLength": 64 },
           "observedAt": { "type": "string", "format": "date-time" },
-          "result": { "enum": ["compatible", "runtime-incompatible", "peer-contract-incompatible", "install-failed", "load-failed", "unknown"] },
+          "result": { "enum": ["compatible", "runtime-incompatible", "peer-contract-incompatible", "build-approval-required", "install-failed", "load-failed", "unknown"] },
           "plugin": {
             "type": "object",
             "additionalProperties": false,
@@ -54,7 +54,14 @@
               "runtimeGraphNodes": { "type": "integer", "minimum": 0, "maximum": 100000 },
               "runtimeGraphEdges": { "type": "integer", "minimum": 0, "maximum": 250000 },
               "requiredUnresolved": { "type": "integer", "minimum": 0, "maximum": 250000 },
-              "declaredPeerContracts": { "type": "integer", "minimum": 0, "maximum": 64 }
+              "declaredPeerContracts": { "type": "integer", "minimum": 0, "maximum": 64 },
+              "requiredDependencyBuilds": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 16,
+                "uniqueItems": true,
+                "items": { "type": "string", "pattern": "^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$", "maxLength": 214 }
+              }
             }
           }
         }

--- a/schemas/dsh-install-observation.schema.json
+++ b/schemas/dsh-install-observation.schema.json
@@ -75,7 +75,7 @@
       }
     },
     "resolution": { "$ref": "#/$defs/resolution" },
-    "result": { "enum": ["compatible", "runtime-incompatible", "peer-contract-incompatible", "install-failed", "load-failed", "unknown"] },
+    "result": { "enum": ["compatible", "runtime-incompatible", "peer-contract-incompatible", "build-approval-required", "install-failed", "load-failed", "unknown"] },
     "reason": { "type": "string", "maxLength": 4096 },
     "boundary": {
       "type": "object",
@@ -89,6 +89,12 @@
         "pluginCodeMayExecuteDuringLoad": { "const": true },
         "inheritedHostSecrets": { "const": false },
         "approvedDependencyBuilds": {
+          "type": "array",
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$", "maxLength": 214 }
+        },
+        "requiredDependencyBuilds": {
           "type": "array",
           "maxItems": 16,
           "uniqueItems": true,

--- a/src/dsh-compatibility-ir.ts
+++ b/src/dsh-compatibility-ir.ts
@@ -56,6 +56,7 @@ export interface DshCompatibilityIrCell {
     runtimeGraphEdges?: number
     requiredUnresolved?: number
     declaredPeerContracts?: number
+    requiredDependencyBuilds?: string[]
   }
 }
 
@@ -148,7 +149,8 @@ function peerStaticUsage(value: unknown, label: string): DshCompatibilityPeerCon
 function result(value: unknown, label: string): DshCompatibilityLedgerEntry['result'] {
   const parsed = boundedString(value, label, 64)
   if (parsed !== 'compatible' && parsed !== 'runtime-incompatible' && parsed !== 'peer-contract-incompatible'
-    && parsed !== 'install-failed' && parsed !== 'load-failed' && parsed !== 'unknown') {
+    && parsed !== 'build-approval-required' && parsed !== 'install-failed'
+    && parsed !== 'load-failed' && parsed !== 'unknown') {
     throw new Error(`${label} is unsupported`)
   }
   return parsed
@@ -256,6 +258,7 @@ export function buildDshCompatibilityIR(ledgerInput: DshCompatibilityLedger | un
         ...(runtimeGraph?.edges === undefined ? {} : { runtimeGraphEdges: runtimeGraph.edges }),
         ...(runtimeGraph?.unresolved === undefined ? {} : { requiredUnresolved: runtimeGraph.unresolved }),
         ...(contracts === undefined ? {} : { declaredPeerContracts: contracts.declared }),
+        ...(entry.requiredDependencyBuilds === undefined ? {} : { requiredDependencyBuilds: entry.requiredDependencyBuilds }),
       },
     })
     for (const relation of contracts?.relations ?? []) {
@@ -332,12 +335,28 @@ function parseCell(value: unknown, index: number): DshCompatibilityIrCell {
   const runtimeGraphEdges = evidence.runtimeGraphEdges === undefined ? undefined : boundedInteger(evidence.runtimeGraphEdges, `cells[${index}].evidence.runtimeGraphEdges`, 250_000)
   const requiredUnresolved = evidence.requiredUnresolved === undefined ? undefined : boundedInteger(evidence.requiredUnresolved, `cells[${index}].evidence.requiredUnresolved`, 250_000)
   const declaredPeerContracts = evidence.declaredPeerContracts === undefined ? undefined : boundedInteger(evidence.declaredPeerContracts, `cells[${index}].evidence.declaredPeerContracts`, MAX_RELATIONS_PER_CELL)
+  let requiredDependencyBuilds: string[] | undefined
+  if (evidence.requiredDependencyBuilds !== undefined) {
+    if (!Array.isArray(evidence.requiredDependencyBuilds) || evidence.requiredDependencyBuilds.length === 0 || evidence.requiredDependencyBuilds.length > 16) {
+      throw new Error(`cells[${index}].evidence.requiredDependencyBuilds must contain between one and 16 package names`)
+    }
+    requiredDependencyBuilds = evidence.requiredDependencyBuilds
+      .map((name, dependencyIndex) => packageName(name, `cells[${index}].evidence.requiredDependencyBuilds[${dependencyIndex}]`))
+      .sort()
+    if (new Set(requiredDependencyBuilds).size !== requiredDependencyBuilds.length) {
+      throw new Error(`cells[${index}].evidence.requiredDependencyBuilds must not contain duplicates`)
+    }
+  }
+  const parsedResult = result(item.result, `cells[${index}].result`)
+  if ((parsedResult === 'build-approval-required') !== (requiredDependencyBuilds !== undefined)) {
+    throw new Error(`cells[${index}] must bind build-approval-required to requiredDependencyBuilds evidence`)
+  }
   const cell: DshCompatibilityIrCell = {
     id: boundedString(item.id, `cells[${index}].id`, 80),
     caseId: boundedString(item.caseId, `cells[${index}].caseId`, 64),
     targetId: boundedString(item.targetId, `cells[${index}].targetId`, 64),
     observedAt,
-    result: result(item.result, `cells[${index}].result`),
+    result: parsedResult,
     plugin: {
       name: parsedPlugin.name,
       version: parsedPlugin.version,
@@ -359,6 +378,7 @@ function parseCell(value: unknown, index: number): DshCompatibilityIrCell {
       ...(runtimeGraphEdges === undefined ? {} : { runtimeGraphEdges }),
       ...(requiredUnresolved === undefined ? {} : { requiredUnresolved }),
       ...(declaredPeerContracts === undefined ? {} : { declaredPeerContracts }),
+      ...(requiredDependencyBuilds === undefined ? {} : { requiredDependencyBuilds }),
     },
   }
   return cell

--- a/src/dsh-compatibility-issues.ts
+++ b/src/dsh-compatibility-issues.ts
@@ -179,6 +179,17 @@ export function renderDshCompatibilityResolution(entry: DshCompatibilityLedgerEn
 }
 
 export function renderDshCompatibilityReviewReclassification(entry: DshCompatibilityLedgerEntry): string {
+  const explanation = entry.result === 'build-approval-required'
+    ? [
+        `pnpm stopped before DSH registration because these dependency builds require an explicit trust decision: ${(entry.requiredDependencyBuilds ?? []).map(name => `\`${inline(name, 214)}\``).join(', ')}.`,
+        '',
+        'That gate is important operational evidence, but it does not prove the plugin artifact is incompatible. The exact requirement remains visible as `needs-review`; a separately configured cell may approve those packages and test registration and load.',
+      ]
+    : [
+        'This cell used the headless profile. A missing or mismatched web-client peer from that Node resolution anchor does not prove the plugin fails in its intended browser execution plane. The evidence remains visible as `needs-review`; it will become author-actionable only after the intended plane reproduces an install, registration or load failure.',
+        '',
+        'Execution-plane coverage is tracked in #75.',
+      ]
   return [
     `<!-- upstream-radar:dsh-compatibility-review=${entry.caseId}:${entry.contractFingerprint} -->`,
     '',
@@ -189,9 +200,7 @@ export function renderDshCompatibilityReviewReclassification(entry: DshCompatibi
     `- Raw result retained in the ledger: \`${entry.result}\``,
     `- Evidence gap: ${inline(entry.reason, 4_096)}`,
     '',
-    'This cell used the headless profile. A missing or mismatched web-client peer from that Node resolution anchor does not prove the plugin fails in its intended browser execution plane. The evidence remains visible as `needs-review`; it will become author-actionable only after the intended plane reproduces an install, registration or load failure.',
-    '',
-    'Execution-plane coverage is tracked in #75.',
+    ...explanation,
   ].join('\n')
 }
 
@@ -228,7 +237,7 @@ export function buildDshCompatibilityIssuePlan(input: {
       ignoredUnknownCaseIds.push(entry.caseId)
       continue
     }
-    if (entry.result === 'peer-contract-incompatible') {
+    if (entry.result === 'peer-contract-incompatible' || entry.result === 'build-approval-required') {
       reviewOnlyCaseIds.push(entry.caseId)
       if (issue?.state === 'open') {
         actions.push({

--- a/src/dsh-compatibility-ledger.ts
+++ b/src/dsh-compatibility-ledger.ts
@@ -13,7 +13,7 @@ export const DSH_COMPATIBILITY_LEDGER_SCHEMA = 'upstream-radar.dsh-compatibility
 const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 const CASE_ID = /^[a-z0-9][a-z0-9._-]{0,63}$/
 const FINGERPRINT = /^sha256:[a-f0-9]{64}$/
-const RESULTS = new Set<DshInstallObservationResult>(['compatible', 'runtime-incompatible', 'peer-contract-incompatible', 'install-failed', 'load-failed', 'unknown'])
+const RESULTS = new Set<DshInstallObservationResult>(['compatible', 'runtime-incompatible', 'peer-contract-incompatible', 'build-approval-required', 'install-failed', 'load-failed', 'unknown'])
 const MAX_ENTRIES = 500
 const MAX_REPORTS = 100
 
@@ -95,6 +95,8 @@ export interface DshCompatibilityLedgerEntry {
   observedAt: string
   result: DshInstallObservationResult
   reason: string
+  /** Exact dependency packages pnpm refused to build without explicit approval. */
+  requiredDependencyBuilds?: string[]
   artifact: {
     lifecycleScripts: string[]
     sha256?: string
@@ -441,6 +443,12 @@ function parseEntry(value: unknown, index: number): DshCompatibilityLedgerEntry 
   const integrity = optionalBoundedString(artifact.integrity, `entries[${index}].artifact.integrity`, 1_024)
   const nodeEngine = optionalBoundedString(artifact.nodeEngine, `entries[${index}].artifact.nodeEngine`, 512)
   const pnpmVersion = runtime.pnpmVersion === undefined ? undefined : exactVersion(runtime.pnpmVersion, `entries[${index}].runtime.pnpmVersion`)
+  const requiredDependencyBuilds = item.requiredDependencyBuilds === undefined
+    ? []
+    : parseLifecycleBuilds(item.requiredDependencyBuilds, `entries[${index}].requiredDependencyBuilds`)
+  if ((result === 'build-approval-required') !== (requiredDependencyBuilds.length > 0)) {
+    throw new Error(`entries[${index}] must bind build-approval-required to a non-empty requiredDependencyBuilds list`)
+  }
   return {
     caseId: caseId(item.caseId, `entries[${index}].caseId`),
     targetId: caseId(item.targetId, `entries[${index}].targetId`),
@@ -458,6 +466,7 @@ function parseEntry(value: unknown, index: number): DshCompatibilityLedgerEntry 
     observedAt,
     result,
     reason: boundedString(item.reason, `entries[${index}].reason`, 4_096),
+    ...(requiredDependencyBuilds.length === 0 ? {} : { requiredDependencyBuilds }),
     artifact: {
       lifecycleScripts: parseLifecycleScripts(artifact.lifecycleScripts, `entries[${index}].artifact.lifecycleScripts`),
       ...(sha256 === undefined ? {} : { sha256 }),
@@ -605,6 +614,12 @@ function parseObservationReport(value: unknown, expected: DshCompatibilityExpect
   if (approved.join(',') !== expected.allowedBuilds) throw new Error('report approved dependency builds do not match the scheduled policy')
   const result = reportString(report.result, 'report result', 64) as DshInstallObservationResult
   if (!RESULTS.has(result)) throw new Error('report result is unsupported')
+  const requiredDependencyBuilds = boundary.requiredDependencyBuilds === undefined
+    ? []
+    : parseLifecycleBuilds(boundary.requiredDependencyBuilds, 'report boundary.requiredDependencyBuilds')
+  if ((result === 'build-approval-required') !== (requiredDependencyBuilds.length > 0)) {
+    throw new Error('report must bind build-approval-required to a non-empty requiredDependencyBuilds list')
+  }
   const lifecycleScripts = parseLifecycleScripts(artifact.lifecycleScripts, 'report artifact.lifecycleScripts')
   const sha256 = optionalBareSha256(artifact.sha256, 'report artifact.sha256')
   const integrity = optionalBoundedString(artifact.integrity, 'report artifact.integrity', 1_024)
@@ -633,6 +648,7 @@ function parseObservationReport(value: unknown, expected: DshCompatibilityExpect
     observedAt,
     result,
     reason: reportString(report.reason, 'report reason', 4_096),
+    ...(requiredDependencyBuilds.length === 0 ? {} : { requiredDependencyBuilds }),
     artifact: {
       lifecycleScripts,
       ...(sha256 === undefined ? {} : { sha256 }),

--- a/src/dsh-directory-feed.ts
+++ b/src/dsh-directory-feed.ts
@@ -62,6 +62,7 @@ export interface DshDirectoryEvidenceCell {
   profile: 'headless'
   status: Exclude<DshDirectoryEvidenceStatus, 'not-observed'>
   radarResult: DshCompatibilityLedgerEntry['result']
+  requiredDependencyBuilds?: string[]
   observedAt: string
   recheckDueAt: string
   reason: string
@@ -287,6 +288,7 @@ export function buildDshDirectoryCompatibilityFeed(input: {
       profile: 'headless',
       status: cellStatus(entry.result),
       radarResult: entry.result,
+      ...(entry.requiredDependencyBuilds === undefined ? {} : { requiredDependencyBuilds: entry.requiredDependencyBuilds }),
       observedAt: entry.observedAt,
       recheckDueAt: dueAt(entry.observedAt, installTargets.refreshAfterHours),
       reason: entry.reason,
@@ -372,7 +374,7 @@ export function renderDshDirectoryCompatibilityFeed(feed: DshDirectoryCompatibil
     '',
     '- `observed-compatible`: the exact artifact installed, registered and loaded in the stated headless cell.',
     '- `observed-incompatible`: the exact cell reproduced a runtime gate, install, registration or load failure.',
-    '- `needs-review`: evidence exists, but Radar cannot yet separate a plugin defect from an uncovered execution plane or environment condition.',
+    '- `needs-review`: evidence exists, but Radar cannot yet separate a plugin defect from an uncovered execution plane, environment condition, or explicit dependency-build approval gate.',
     '- `not-observed`: the catalog entry is monitored statically but has no matching executable npm artifact in this cohort.',
     '',
     `A cell expires at its \`recheckDueAt\` value (${feed.boundary.refreshAfterHours} hours after observation). Consumers must then show it as stale. This is exact compatibility evidence, not a security review or endorsement.`,

--- a/src/dsh-install-observation.ts
+++ b/src/dsh-install-observation.ts
@@ -45,7 +45,14 @@ const PROFILE_LOCKFILE_CANDIDATES = [
 ] as const
 const SYNTHETIC_PROFILE_GRAPH_ROOT = { name: 'dsh-profile-headless', version: '0.0.0' } as const
 
-export type DshInstallObservationResult = 'compatible' | 'runtime-incompatible' | 'peer-contract-incompatible' | 'install-failed' | 'load-failed' | 'unknown'
+export type DshInstallObservationResult =
+  | 'compatible'
+  | 'runtime-incompatible'
+  | 'peer-contract-incompatible'
+  | 'build-approval-required'
+  | 'install-failed'
+  | 'load-failed'
+  | 'unknown'
 export type InstallObservationPhase = 'runtime' | 'artifact' | 'profile' | 'install' | 'load'
 export type InstallObservationIsolationProvider = 'github-actions-hosted-runner' | 'firecracker' | 'other'
 
@@ -282,6 +289,7 @@ export interface DshInstallObservationReport {
     pluginCodeMayExecuteDuringLoad: true
     inheritedHostSecrets: false
     approvedDependencyBuilds: string[]
+    requiredDependencyBuilds: string[]
     note: string
   }
 }
@@ -339,6 +347,38 @@ interface ParsedArtifact {
 
 function isNpmPackageName(value: string): boolean {
   return /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)$/.test(value)
+}
+
+/**
+ * pnpm 10+ deliberately stops before running dependency lifecycle scripts
+ * unless each package is approved. Keep that policy gate distinct from a
+ * plugin install defect, but only when pnpm supplied a bounded, exact list.
+ */
+function requiredDependencyBuilds(output: string): string[] {
+  const normalized = output.replace(/\r\n?/g, '\n')
+  const marker = '[ERR_PNPM_IGNORED_BUILDS]'
+  const markerIndex = normalized.indexOf(marker)
+  if (markerIndex < 0) return []
+  const tail = normalized.slice(markerIndex, markerIndex + MAX_COMMAND_OUTPUT_BYTES)
+  const prefix = 'Ignored build scripts:'
+  const prefixIndex = tail.indexOf(prefix)
+  if (prefixIndex < marker.length || prefixIndex > 256) return []
+  let list = tail.slice(prefixIndex + prefix.length)
+  const terminator = list.search(/\n\s*\n|\n\s*Run\s+["']pnpm approve-builds["']/)
+  if (terminator >= 0) list = list.slice(0, terminator)
+  const coordinates = list.split(',').map(value => value.trim()).filter(Boolean)
+  if (coordinates.length === 0 || coordinates.length > MAX_ALLOWED_BUILDS) return []
+  const names = new Set<string>()
+  for (const coordinate of coordinates) {
+    try {
+      const parsed = parseNpmSpec(coordinate)
+      if (!EXACT_VERSION.test(parsed.version) || !isNpmPackageName(parsed.name)) return []
+      names.add(parsed.name)
+    } catch {
+      return []
+    }
+  }
+  return [...names].sort()
 }
 
 function staticPeerUsage(entries: readonly TarEntry[], requirements: readonly { name: string, required: string }[]): DshInstallPeerStaticUsage[] {
@@ -1554,6 +1594,7 @@ export async function observeDshPluginInstall(options: DshInstallObservationOpti
       pluginCodeMayExecuteDuringLoad: true,
       inheritedHostSecrets: false,
       approvedDependencyBuilds: allowedBuilds,
+      requiredDependencyBuilds: [],
       note: 'Radar scrubs the child environment and records Linux system-call evidence, but the caller provides and must verify the disposable isolation boundary. Same-container traces are best-effort evidence, not a malicious-code safety certificate.',
     },
   }
@@ -1700,6 +1741,15 @@ export async function observeDshPluginInstall(options: DshInstallObservationOpti
         return finishReport(report, 'unknown', 'the install command ran without readable trace evidence')
       }
       if (installResult.code !== 0) {
+        const requiredBuilds = requiredDependencyBuilds(`${installResult.stderr}\n${installResult.stdout}`)
+        if (requiredBuilds.length > 0) {
+          report.boundary.requiredDependencyBuilds = requiredBuilds
+          return finishReport(
+            report,
+            'build-approval-required',
+            `the DSH plugin install requires explicit approval for dependency builds: ${requiredBuilds.join(', ')}`,
+          )
+        }
         return finishReport(report, 'install-failed', 'the traced DSH plugin install command failed')
       }
 
@@ -1780,6 +1830,7 @@ export function renderDshInstallObservation(report: DshInstallObservationReport)
     `Plugin Node requirement: ${report.artifact.nodeEngine ?? 'not declared'}`,
     `Isolation claim: ${report.boundary.isolationProviderClaim} (provided externally; not verified by Radar)`,
     `Approved dependency builds: ${report.boundary.approvedDependencyBuilds.length === 0 ? 'none' : report.boundary.approvedDependencyBuilds.join(', ')}`,
+    `Additional dependency builds required: ${report.boundary.requiredDependencyBuilds.length === 0 ? 'none' : report.boundary.requiredDependencyBuilds.join(', ')}`,
     '',
     `Result: ${report.result.toUpperCase()} — ${report.reason}`,
     `Lifecycle scripts declared: ${lifecycle}`,

--- a/test/dsh-compatibility-ir.test.ts
+++ b/test/dsh-compatibility-ir.test.ts
@@ -141,4 +141,20 @@ describe('DSH compatibility IR', () => {
     }
     assert.throws(() => parseDshCompatibilityIR(incomplete), /relation count does not match declared peer contracts/)
   })
+
+  it('keeps an exact dependency build-approval gate in the normalized evidence', () => {
+    const value = ledger()
+    const first = value.entries[0]
+    assert.notEqual(first, undefined)
+    if (first === undefined) return
+    first.result = 'build-approval-required'
+    first.reason = 'pnpm requires an explicit dependency-build approval'
+    first.requiredDependencyBuilds = ['protobufjs', 'sharp']
+    delete first.resolution
+
+    const ir = buildDshCompatibilityIR(value)
+
+    assert.deepEqual(ir.cells[0]?.evidence.requiredDependencyBuilds, ['protobufjs', 'sharp'])
+    assert.deepEqual(parseDshCompatibilityIR(ir), ir)
+  })
 })

--- a/test/dsh-compatibility-issues.test.ts
+++ b/test/dsh-compatibility-issues.test.ts
@@ -169,6 +169,24 @@ describe('DSH compatibility issue reconciliation', () => {
     assert.deepEqual(plan.reviewOnlyCaseIds, ['openpencil-node24'])
   })
 
+  it('keeps a dependency build-approval gate as review evidence instead of blaming the plugin', () => {
+    const review = {
+      ...entry('unknown'),
+      result: 'build-approval-required' as DshCompatibilityLedgerEntry['result'],
+      reason: 'the install requires explicit approval for protobufjs',
+      requiredDependencyBuilds: ['protobufjs'],
+    }
+    const plan = buildDshCompatibilityIssuePlan({
+      ledger: ledger(review),
+      existingIssues: [issue(review)],
+    })
+
+    assert.equal(plan.actions[0]?.kind, 'close')
+    assert.match(plan.actions[0]?.kind === 'close' ? plan.actions[0].comment : '', /protobufjs.*does not prove the plugin artifact is incompatible/s)
+    assert.deepEqual(plan.openCaseIds, [])
+    assert.deepEqual(plan.reviewOnlyCaseIds, ['openpencil-node24'])
+  })
+
   it('closes an old peer-contract incident after the evidence is reclassified', () => {
     const review = entry('peer-contract-incompatible')
     const plan = buildDshCompatibilityIssuePlan({

--- a/test/dsh-compatibility-ledger.test.ts
+++ b/test/dsh-compatibility-ledger.test.ts
@@ -155,6 +155,29 @@ describe('DSH compatibility ledger', () => {
     assert.equal(resolved.transitions[0]?.status, 'resolved-incompatibility')
   })
 
+  it('retains an exact build-approval requirement as review evidence', () => {
+    const merged = mergeDshCompatibilityLedger({
+      ledger: emptyDshCompatibilityLedger(),
+      expected: [expected],
+      reports: [report({
+        result: 'build-approval-required',
+        reason: 'the install requires explicit approval for protobufjs',
+        boundary: {
+          approvedDependencyBuilds: [],
+          requiredDependencyBuilds: ['protobufjs'],
+        },
+      })],
+    })
+
+    assert.deepEqual(merged.acceptedCaseIds, ['openpencil-node24'])
+    assert.deepEqual(
+      (merged.ledger.entries[0] as typeof merged.ledger.entries[number] & { requiredDependencyBuilds?: string[] })
+        ?.requiredDependencyBuilds,
+      ['protobufjs'],
+    )
+    assert.equal(parseDshCompatibilityLedger(merged.ledger).entries[0]?.result, 'build-approval-required')
+  })
+
   it('surfaces a newly resolved dependency graph even when install/load still succeeds', () => {
     const first = mergeDshCompatibilityLedger({
       ledger: emptyDshCompatibilityLedger(),

--- a/test/dsh-directory-feed.test.ts
+++ b/test/dsh-directory-feed.test.ts
@@ -27,6 +27,7 @@ function ledgerEntry(targetId: string, result: DshCompatibilityLedgerEntry['resu
     observedAt: '2026-08-23T00:00:00.000Z',
     result,
     reason: `${result} evidence`,
+    ...(result === 'build-approval-required' ? { requiredDependencyBuilds: ['protobufjs'] } : {}),
     artifact: { lifecycleScripts: [], sha256: 'c'.repeat(64) },
     observer: {
       schema: 'upstream-radar.dsh-install-observation/v1alpha1',
@@ -36,7 +37,7 @@ function ledgerEntry(targetId: string, result: DshCompatibilityLedgerEntry['resu
 }
 
 function fixture() {
-  const ids = ['clean', 'broken', 'peer-gap', 'unknown']
+  const ids = ['clean', 'broken', 'peer-gap', 'approval', 'unknown']
   return {
     cohort: {
       schema: AWESOME_DSH_COHORT_SCHEMA,
@@ -79,6 +80,7 @@ function fixture() {
         ledgerEntry('clean', 'compatible'),
         ledgerEntry('broken', 'load-failed'),
         ledgerEntry('peer-gap', 'peer-contract-incompatible'),
+        ledgerEntry('approval', 'build-approval-required' as DshCompatibilityLedgerEntry['result']),
         ledgerEntry('unknown', 'unknown'),
       ],
     },
@@ -94,15 +96,17 @@ describe('DSH directory compatibility feed', () => {
     })
 
     assert.deepEqual(feed.summary, {
-      total: 5,
+      total: 6,
       'observed-compatible': 1,
       'observed-incompatible': 1,
-      'needs-review': 2,
+      'needs-review': 3,
       'not-observed': 1,
     })
     assert.equal(feed.plugins.find(item => item.id === 'clean')?.status, 'observed-compatible')
     assert.equal(feed.plugins.find(item => item.id === 'broken')?.status, 'observed-incompatible')
     assert.equal(feed.plugins.find(item => item.id === 'peer-gap')?.status, 'needs-review')
+    assert.equal(feed.plugins.find(item => item.id === 'approval')?.status, 'needs-review')
+    assert.deepEqual(feed.plugins.find(item => item.id === 'approval')?.cells[0]?.requiredDependencyBuilds, ['protobufjs'])
     assert.equal(feed.plugins.find(item => item.id === 'unknown')?.status, 'needs-review')
     assert.equal(feed.plugins.find(item => item.id === 'source-only')?.status, 'not-observed')
     assert.equal(
@@ -119,7 +123,7 @@ describe('DSH directory compatibility feed', () => {
       generatedAt: '2026-08-23T01:00:00.000Z',
     })
     const markdown = renderDshDirectoryCompatibilityFeed(feed)
-    assert.match(markdown, /1 observed compatible · 1 observed incompatible · 2 needs review · 1 not observed/)
+    assert.match(markdown, /1 observed compatible · 1 observed incompatible · 3 needs review · 1 not observed/)
     assert.match(markdown, /must then show it as stale/)
     assert.match(markdown, /not a security review or endorsement/)
   })

--- a/test/dsh-install-observation.test.ts
+++ b/test/dsh-install-observation.test.ts
@@ -418,6 +418,49 @@ snapshots:
     assert.match(report.reason, /install command failed/)
   })
 
+  it('separates a pnpm build-approval gate from a plugin incompatibility', async () => {
+    const artifact = makeTarball([
+      { path: 'package/package.json', contents: JSON.stringify({
+        name: 'approval-plugin',
+        version: '1.0.0',
+        dsh: { bundle: { patch: 'cordis.patch.yml' } },
+      }) },
+      { path: 'package/cordis.patch.yml', contents: '[]\n' },
+    ])
+    const runner = async (command: InstallObservationCommand): Promise<InstallObservationCommandResult> => {
+      if (command.phase === 'runtime') return passed({ stdout: '11.7.0\n' })
+      if (command.phase === 'artifact') {
+        await writeFile(join(command.cwd, 'approval-plugin-1.0.0.tgz'), artifact)
+        return passed({ stdout: 'approval-plugin-1.0.0.tgz\n' })
+      }
+      if (command.phase === 'install') {
+        if (command.tracePath !== undefined) await writeFile(command.tracePath, TRACE)
+        return passed({
+          code: 1,
+          stderr: '[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5, @scope/native@1.2.3, protobufjs@7.6.5\n\nRun "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.\n',
+        })
+      }
+      return passed()
+    }
+
+    const report = await observeDshPluginInstall({
+      packageSpec: 'approval-plugin@1.0.0',
+      dshVersion: '0.1.1-rc.2',
+      allowExecution: true,
+      isolationProvider: 'other',
+      runner,
+    })
+
+    assert.equal(report.result, 'build-approval-required')
+    assert.deepEqual(
+      (report.boundary as typeof report.boundary & { requiredDependencyBuilds?: string[] }).requiredDependencyBuilds,
+      ['@scope/native', 'protobufjs', 'sharp'],
+    )
+    assert.match(report.reason, /requires explicit approval.*@scope\/native, protobufjs, sharp/)
+    assert.equal(report.stages.registration.status, 'skipped')
+    assert.equal(report.stages.load.status, 'skipped')
+  })
+
   it('passes only explicit validated dependency build approvals to pnpm', async () => {
     let installArgs: string[] = []
     const runner = async (command: InstallObservationCommand): Promise<InstallObservationCommandResult> => {


### PR DESCRIPTION
## What changed

- classify exact pnpm `ERR_PNPM_IGNORED_BUILDS` evidence as `build-approval-required` instead of a plugin install failure
- retain the exact dependency package names through the observation report, durable ledger, compatibility IR, and directory feed
- keep build-approval gates in review-only status and close any previously opened managed incompatibility incident
- expose the result in the isolated observer summary and accept it as trustworthy bounded evidence

## Why

The first 50-plugin run produced four apparent install failures. Paired isolated reruns showed all four installs proceed when the exact dependency builds are explicitly approved. Treating the policy gate as an author-caused incompatibility would create misleading issues as coverage grows.

## Verification

- `pnpm test`
- 340 tests passing