### PR TITLE
data: reclassify four dependency build gates

### DIFF
--- a/compatibility-ir.json
+++ b/compatibility-ir.json
@@ -788,8 +788,8 @@
       "id": "cell:1af50ea8f9b1667789eee8f015d073aba5e03f582e7c736a050d3ca16775181e",
       "caseId": "dsh-mneme-node22",
       "targetId": "dsh-mneme",
-      "observedAt": "2026-08-23T10:29:03.439Z",
-      "result": "install-failed",
+      "observedAt": "2026-08-23T11:12:37.676Z",
+      "result": "build-approval-required",
       "plugin": {
         "name": "@modusensus/dsh-mneme",
         "version": "0.6.10",
@@ -810,7 +810,12 @@
         "runtimeGraphNodes": 498,
         "runtimeGraphEdges": 2092,
         "requiredUnresolved": 0,
-        "declaredPeerContracts": 6
+        "declaredPeerContracts": 6,
+        "requiredDependencyBuilds": [
+          "onnxruntime-node",
+          "protobufjs",
+          "sharp"
+        ]
       }
     },
     {
@@ -846,8 +851,8 @@
       "id": "cell:7fa5cc5d190bd7f572bc56eea27f213c974963c05b94c7535a9a7be58adabb05",
       "caseId": "dsh-notifier-node22",
       "targetId": "dsh-notifier",
-      "observedAt": "2026-08-23T10:28:57.196Z",
-      "result": "install-failed",
+      "observedAt": "2026-08-23T11:12:24.826Z",
+      "result": "build-approval-required",
       "plugin": {
         "name": "dsh-notifier",
         "version": "0.8.6",
@@ -868,7 +873,10 @@
         "runtimeGraphNodes": 502,
         "runtimeGraphEdges": 2113,
         "requiredUnresolved": 0,
-        "declaredPeerContracts": 1
+        "declaredPeerContracts": 1,
+        "requiredDependencyBuilds": [
+          "protobufjs"
+        ]
       }
     },
     {
@@ -991,8 +999,8 @@
       "id": "cell:a8fc384560fbd18b80d3f16499569cb9f4a6ab4639b71cfbbc03dce429ccd2a7",
       "caseId": "dsh-remote-node22",
       "targetId": "dsh-remote",
-      "observedAt": "2026-08-23T10:29:13.306Z",
-      "result": "install-failed",
+      "observedAt": "2026-08-23T11:12:31.567Z",
+      "result": "build-approval-required",
       "plugin": {
         "name": "dsh-remote",
         "version": "0.8.7",
@@ -1013,7 +1021,12 @@
         "runtimeGraphNodes": 622,
         "runtimeGraphEdges": 2398,
         "requiredUnresolved": 2,
-        "declaredPeerContracts": 7
+        "declaredPeerContracts": 7,
+        "requiredDependencyBuilds": [
+          "cpu-features",
+          "node-pty",
+          "ssh2"
+        ]
       }
     },
     {
@@ -1252,8 +1265,8 @@
       "id": "cell:44193cf8cdd59c418cc794381f7924f5e750d467c0d059d5a572cf1d757a8c06",
       "caseId": "dsh-web-ui-all-node22",
       "targetId": "dsh-web-ui-all",
-      "observedAt": "2026-08-23T10:29:14.718Z",
-      "result": "install-failed",
+      "observedAt": "2026-08-23T11:12:43.381Z",
+      "result": "build-approval-required",
       "plugin": {
         "name": "@linxin666/dsh-web-ui-all",
         "version": "0.2.9",
@@ -1274,7 +1287,13 @@
         "runtimeGraphNodes": 651,
         "runtimeGraphEdges": 2458,
         "requiredUnresolved": 3,
-        "declaredPeerContracts": 0
+        "declaredPeerContracts": 0,
+        "requiredDependencyBuilds": [
+          "cloudflared",
+          "cpu-features",
+          "node-pty",
+          "ssh2"
+        ]
       }
     },
     {

--- a/compatibility-ledger.json
+++ b/compatibility-ledger.json
@@ -9207,17 +9207,21 @@
       },
       "staticFingerprint": "sha256:625d67dfb6a97e74123b023f8502234d38a87de66c6390986e8d9998c09da0dc",
       "contractFingerprint": "sha256:1d785808a544dc72cfe8cd7039c87e24113142e3c05312ec31f0f05258f7df11",
-      "observedAt": "2026-08-23T10:29:03.439Z",
-      "result": "install-failed",
-      "reason": "the traced DSH plugin install command failed",
+      "observedAt": "2026-08-23T11:12:37.676Z",
+      "result": "build-approval-required",
+      "reason": "the DSH plugin install requires explicit approval for dependency builds: onnxruntime-node, protobufjs, sharp",
+      "requiredDependencyBuilds": [
+        "onnxruntime-node",
+        "protobufjs",
+        "sharp"
+      ],
       "artifact": {
         "lifecycleScripts": [],
-        "sha256": "e60755fea5e92b72a3abe900a5dae11b6064de3d53746e3259bf8a6411c8b669",
-        "integrity": "sha512-eUUMrPkEOdA2wBXB3lcU17KUpKxmpaHJHjEqG9h1u7nf0Lija0YGNhx2IlCnmRxRPk1091/x+J6E2fCDIVK7cA=="
+        "sha256": "e60755fea5e92b72a3abe900a5dae11b6064de3d53746e3259bf8a6411c8b669"
       },
       "resolution": {
         "profileLockfile": {
-          "sha256": "deee5a1173c653ca827ee891a28b1278487d6cf16b7822a4dd81539605ca05d4",
+          "sha256": "ee1006bc7a447946a431fa944497edcc9108bbc9347ebc67cba00c6d2b886e58",
           "bytes": 21631,
           "graphDigest": "sha256:87250c4530790d396659f51478a6f75860b1b2f586c0851e70daae067760420e",
           "nodes": 76,
@@ -9823,18 +9827,20 @@
       },
       "staticFingerprint": "sha256:fee6a3bbe9ce6177cf03fcca60375c66f07183dc51c3a7460782eb2af87532fa",
       "contractFingerprint": "sha256:349d18abf4e5fa26ff8985280bbae6c107df261e699749855f3a205d971b24ed",
-      "observedAt": "2026-08-23T10:28:57.196Z",
-      "result": "install-failed",
-      "reason": "the traced DSH plugin install command failed",
+      "observedAt": "2026-08-23T11:12:24.826Z",
+      "result": "build-approval-required",
+      "reason": "the DSH plugin install requires explicit approval for dependency builds: protobufjs",
+      "requiredDependencyBuilds": [
+        "protobufjs"
+      ],
       "artifact": {
         "lifecycleScripts": [],
         "sha256": "31df82786797f1bbf26eed3e4573db55d0d15bb59584324478d2268512776cca",
-        "integrity": "sha512-V7KGTjBXC4YBYd9K/L67nDOzGousIE5tx0wY4JlFiLVjCFvcB5FrxZpXTMoKsdE3kFaYCZwO33BIfZDf5tJ0UA==",
         "nodeEngine": ">=22"
       },
       "resolution": {
         "profileLockfile": {
-          "sha256": "59468f9030f2f7dd018c82afd9af35127839f299cf4287ff49b2ae7feb02764b",
+          "sha256": "e72a955417bc8453a275958a3bcc9fa2c7760c7064f0b2df35ce70d5058ffbcc",
           "bytes": 15797,
           "graphDigest": "sha256:33cda90c380df28951669a5750cdb7205a37358846b3c7c63199c81a3ef0a57e",
           "nodes": 56,
@@ -11331,17 +11337,21 @@
       },
       "staticFingerprint": "sha256:14e286ee6a925d9539e15ad9478e32f40349514d96b79c588416ff0e710bbb2c",
       "contractFingerprint": "sha256:3235db0f7c200a2e425c5819da5ce23334837df92ff7b820353365f652c0a8b5",
-      "observedAt": "2026-08-23T10:29:13.306Z",
-      "result": "install-failed",
-      "reason": "the traced DSH plugin install command failed",
+      "observedAt": "2026-08-23T11:12:31.567Z",
+      "result": "build-approval-required",
+      "reason": "the DSH plugin install requires explicit approval for dependency builds: cpu-features, node-pty, ssh2",
+      "requiredDependencyBuilds": [
+        "cpu-features",
+        "node-pty",
+        "ssh2"
+      ],
       "artifact": {
         "lifecycleScripts": [],
-        "sha256": "0c3b171a83069ed67b1a75a19333cceb05c16939dd4c216c934f2c1fac7046d1",
-        "integrity": "sha512-5LdgS9nXoKCrnIt2Z+navrEjruJyv1Gch6dA7tlYR2qmb37+NLTEb1RPg1d11+D9ekgmNyuv19HCSHcy+13qFQ=="
+        "sha256": "0c3b171a83069ed67b1a75a19333cceb05c16939dd4c216c934f2c1fac7046d1"
       },
       "resolution": {
         "profileLockfile": {
-          "sha256": "ea226b8190daf9cdf7ca2ed1ccc7004401a338488f787f7412a6e72c27f3fbf8",
+          "sha256": "0c5d4972086ab81cbe6a6bf5d02053649e80740d5407d0390b8949a4e36acc2d",
           "bytes": 47010,
           "graphDigest": "sha256:7a3a5db5c6633594c52bf157a8801b4ea1e6d9a679304a88d7711bb77854c22b",
           "nodes": 176,
@@ -14636,17 +14646,22 @@
       },
       "staticFingerprint": "sha256:84687c1df225fa808858f5a6a3949e98e1dacea47ea8f36a0887b5f068b98827",
       "contractFingerprint": "sha256:a3265261d6a6599b2c40e3f18ca3b1b5475b9acc0b13f1f2b9b0c30c85fbe792",
-      "observedAt": "2026-08-23T10:29:14.718Z",
-      "result": "install-failed",
-      "reason": "the traced DSH plugin install command failed",
+      "observedAt": "2026-08-23T11:12:43.381Z",
+      "result": "build-approval-required",
+      "reason": "the DSH plugin install requires explicit approval for dependency builds: cloudflared, cpu-features, node-pty, ssh2",
+      "requiredDependencyBuilds": [
+        "cloudflared",
+        "cpu-features",
+        "node-pty",
+        "ssh2"
+      ],
       "artifact": {
         "lifecycleScripts": [],
-        "sha256": "1e18c7538682931593cda66395b571dd1c53bbefc5698c4f18fa236adee6c9a3",
-        "integrity": "sha512-0Iu1EVXvOQvHZAg82izxKGzXBhGhUhjbx6C+mdYACo0kYkitncm/U/iWKbINN8BQghlVgL1BUExmB3a7uI6rpQ=="
+        "sha256": "1e18c7538682931593cda66395b571dd1c53bbefc5698c4f18fa236adee6c9a3"
       },
       "resolution": {
         "profileLockfile": {
-          "sha256": "ebe7ca1b90501b5d2b70856dde4b94d10613f3226522e4a47036a88006bf7fb0",
+          "sha256": "1f07c05491272026142477b19514bd685f3a1c9ddec085e330042e6cb8bacadd",
           "bytes": 59585,
           "graphDigest": "sha256:207edfe6239b14663d7313570338277431c3f6b9887812cfe248b392a84d6a74",
           "nodes": 215,

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -1,6 +1,6 @@
 {
   "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha1",
-  "generatedAt": "2026-08-23T10:48:50.129Z",
+  "generatedAt": "2026-08-23T11:13:55.704Z",
   "producer": {
     "name": "upstream-radar",
     "version": "0.41.0",
@@ -26,8 +26,8 @@
   "summary": {
     "total": 50,
     "observed-compatible": 32,
-    "observed-incompatible": 4,
-    "needs-review": 10,
+    "observed-incompatible": 0,
+    "needs-review": 14,
     "not-observed": 4
   },
   "plugins": [
@@ -690,7 +690,7 @@
         "selectedVersion": "0.8.7",
         "distTag": "latest"
       },
-      "status": "observed-incompatible",
+      "status": "needs-review",
       "cells": [
         {
           "caseId": "dsh-remote-node22",
@@ -710,11 +710,16 @@
           },
           "executionPlane": "headless",
           "profile": "headless",
-          "status": "observed-incompatible",
-          "radarResult": "install-failed",
-          "observedAt": "2026-08-23T10:29:13.306Z",
-          "recheckDueAt": "2026-08-30T10:29:13.306Z",
-          "reason": "the traced DSH plugin install command failed"
+          "status": "needs-review",
+          "radarResult": "build-approval-required",
+          "requiredDependencyBuilds": [
+            "cpu-features",
+            "node-pty",
+            "ssh2"
+          ],
+          "observedAt": "2026-08-23T11:12:31.567Z",
+          "recheckDueAt": "2026-08-30T11:12:31.567Z",
+          "reason": "the DSH plugin install requires explicit approval for dependency builds: cpu-features, node-pty, ssh2"
         }
       ],
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
@@ -1024,7 +1029,7 @@
         "selectedVersion": "0.6.10",
         "distTag": "latest"
       },
-      "status": "observed-incompatible",
+      "status": "needs-review",
       "cells": [
         {
           "caseId": "dsh-mneme-node22",
@@ -1044,11 +1049,16 @@
           },
           "executionPlane": "headless",
           "profile": "headless",
-          "status": "observed-incompatible",
-          "radarResult": "install-failed",
-          "observedAt": "2026-08-23T10:29:03.439Z",
-          "recheckDueAt": "2026-08-30T10:29:03.439Z",
-          "reason": "the traced DSH plugin install command failed"
+          "status": "needs-review",
+          "radarResult": "build-approval-required",
+          "requiredDependencyBuilds": [
+            "onnxruntime-node",
+            "protobufjs",
+            "sharp"
+          ],
+          "observedAt": "2026-08-23T11:12:37.676Z",
+          "recheckDueAt": "2026-08-30T11:12:37.676Z",
+          "reason": "the DSH plugin install requires explicit approval for dependency builds: onnxruntime-node, protobufjs, sharp"
         }
       ],
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
@@ -1557,7 +1567,7 @@
         "selectedVersion": "0.8.6",
         "distTag": "latest"
       },
-      "status": "observed-incompatible",
+      "status": "needs-review",
       "cells": [
         {
           "caseId": "dsh-notifier-node22",
@@ -1577,11 +1587,14 @@
           },
           "executionPlane": "headless",
           "profile": "headless",
-          "status": "observed-incompatible",
-          "radarResult": "install-failed",
-          "observedAt": "2026-08-23T10:28:57.196Z",
-          "recheckDueAt": "2026-08-30T10:28:57.196Z",
-          "reason": "the traced DSH plugin install command failed"
+          "status": "needs-review",
+          "radarResult": "build-approval-required",
+          "requiredDependencyBuilds": [
+            "protobufjs"
+          ],
+          "observedAt": "2026-08-23T11:12:24.826Z",
+          "recheckDueAt": "2026-08-30T11:12:24.826Z",
+          "reason": "the DSH plugin install requires explicit approval for dependency builds: protobufjs"
         }
       ],
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"
@@ -2004,7 +2017,7 @@
         "selectedVersion": "0.2.9",
         "distTag": "latest"
       },
-      "status": "observed-incompatible",
+      "status": "needs-review",
       "cells": [
         {
           "caseId": "dsh-web-ui-all-node22",
@@ -2024,11 +2037,17 @@
           },
           "executionPlane": "headless",
           "profile": "headless",
-          "status": "observed-incompatible",
-          "radarResult": "install-failed",
-          "observedAt": "2026-08-23T10:29:14.718Z",
-          "recheckDueAt": "2026-08-30T10:29:14.718Z",
-          "reason": "the traced DSH plugin install command failed"
+          "status": "needs-review",
+          "radarResult": "build-approval-required",
+          "requiredDependencyBuilds": [
+            "cloudflared",
+            "cpu-features",
+            "node-pty",
+            "ssh2"
+          ],
+          "observedAt": "2026-08-23T11:12:43.381Z",
+          "recheckDueAt": "2026-08-30T11:12:43.381Z",
+          "reason": "the DSH plugin install requires explicit approval for dependency builds: cloudflared, cpu-features, node-pty, ssh2"
         }
       ],
       "evidenceUrl": "https://github.com/MicroMilo/upstream-radar/blob/main/compatibility-ledger.json"

--- a/feeds/dsh-plugin-compatibility.md
+++ b/feeds/dsh-plugin-compatibility.md
@@ -1,8 +1,8 @@
 # DSH directory compatibility evidence
 
-Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-23T10:48:50.129Z`.
+Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-23T11:13:55.704Z`.
 
-**32 observed compatible · 4 observed incompatible · 10 needs review · 4 not observed**
+**32 observed compatible · 0 observed incompatible · 14 needs review · 4 not observed**
 
 | Catalog plugin | Exact artifact | Exact DSH / runtime | Evidence status | Observed |
 | --- | --- | --- | --- | --- |
@@ -21,7 +21,7 @@ Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-pl
 | [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) | `dshmarket@1.19.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T07:09:16.954Z |
 | [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) | `dsh-plugin-wallpaper-engine@0.5.1` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:29:07.481Z |
 | [feibi-mochi/deepseek-harness-control-center](https://github.com/feibi-mochi/deepseek-harness-control-center) | `deepseek-harness-wallet@0.3.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:39.842Z |
-| [flymysql/dsh-remote](https://github.com/flymysql/dsh-remote) | `dsh-remote@0.8.7` | `0.1.1-rc.2` / Node 22 | `observed-incompatible` | 2026-08-23T10:29:13.306Z |
+| [flymysql/dsh-remote](https://github.com/flymysql/dsh-remote) | `dsh-remote@0.8.7` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:12:31.567Z |
 | [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) | `dsh-codex-connect@0.1.0-alpha.4.14` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:29:11.415Z |
 | [FuzzySoul/dsh-chatvoice](https://github.com/FuzzySoul/dsh-chatvoice) | `dsh-chatvoice@0.1.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:10.309Z |
 | [GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis) | — | — | `not-observed` | — |
@@ -30,7 +30,7 @@ Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-pl
 | [Lum1104/dsh-browser](https://github.com/Lum1104/dsh-browser/tree/main/packages/browser/bridge-browser) | — | — | `not-observed` | — |
 | [Mars-Sea/dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) | `@mars-sea/dsh-commandcode-provider@0.8.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:29:06.719Z |
 | [MichengAI/dsh-agency-agents](https://github.com/MichengAI/dsh-agency-agents) | `@michengai/dsh-agency-agents@0.1.20` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T10:29:05.828Z |
-| [modusensus/dsh-mneme](https://github.com/modusensus/dsh-mneme/tree/main/dsh-mneme) | `@modusensus/dsh-mneme@0.6.10` | `0.1.1-rc.2` / Node 22 | `observed-incompatible` | 2026-08-23T10:29:03.439Z |
+| [modusensus/dsh-mneme](https://github.com/modusensus/dsh-mneme/tree/main/dsh-mneme) | `@modusensus/dsh-mneme@0.6.10` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:12:37.676Z |
 | [moonquake2004/dsh-doctor](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) | `@moonquake2004/dsh-doctor@0.4.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:28:59.744Z |
 | [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | `@nanmicoder/dsh-agent-teams@0.1.13` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T03:40:29.383Z |
 | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | `dsh-chat-import@0.6.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:28:59.740Z |
@@ -43,7 +43,7 @@ Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-pl
 | [saya-ch/dsh-mobile](https://github.com/saya-ch/dsh-mobile) | `dsh-mobile@0.1.4` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:06.821Z |
 | [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) | `dsh-pocket@1.12.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:08.417Z |
 | [TecFancy/dsh-auth-gate](https://github.com/TecFancy/dsh-auth-gate) | `dsh-auth-gate@0.7.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:07.792Z |
-| [THEWOLFWALKER/dsh-notifier](https://github.com/THEWOLFWALKER/dsh-notifier) | `dsh-notifier@0.8.6` | `0.1.1-rc.2` / Node 22 | `observed-incompatible` | 2026-08-23T10:28:57.196Z |
+| [THEWOLFWALKER/dsh-notifier](https://github.com/THEWOLFWALKER/dsh-notifier) | `dsh-notifier@0.8.6` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:12:24.826Z |
 | [toby-bridges/api-relay-audit](https://github.com/toby-bridges/api-relay-audit) | — | — | `not-observed` | — |
 | [trench-xinxin/dsh-tool-lens](https://github.com/trench-xinxin/dsh-tool-lens) | `@trench-xinxin/dsh-tool-lens@2.0.5` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:10.665Z |
 | [tt-a1i/archify](https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness) | `@tt-a1i/archify-dsh@0.1.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:07.782Z |
@@ -54,14 +54,14 @@ Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-pl
 | [xmanrui/dsh-im](https://github.com/xmanrui/dsh-im) | `@xmanrui/dsh-im@1.0.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:09.549Z |
 | [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) | `dsh-plugin-writing-guard@1.6.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:05.560Z |
 | [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | `dsh-vision-router@1.7.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T10:29:10.312Z |
-| [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-web-ui-all) | `@linxin666/dsh-web-ui-all@0.2.9` | `0.1.1-rc.2` / Node 22 | `observed-incompatible` | 2026-08-23T10:29:14.718Z |
+| [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-web-ui-all) | `@linxin666/dsh-web-ui-all@0.2.9` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:12:43.381Z |
 | [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | `@zseven-w/dsh-openpencil@0.1.0-rc.1` | `0.1.1-rc.2` / Node 24 | `needs-review` | 2026-08-23T03:40:15.559Z |
 
 ## Reading the status
 
 - `observed-compatible`: the exact artifact installed, registered and loaded in the stated headless cell.
 - `observed-incompatible`: the exact cell reproduced a runtime gate, install, registration or load failure.
-- `needs-review`: evidence exists, but Radar cannot yet separate a plugin defect from an uncovered execution plane or environment condition.
+- `needs-review`: evidence exists, but Radar cannot yet separate a plugin defect from an uncovered execution plane, environment condition, or explicit dependency-build approval gate.
 - `not-observed`: the catalog entry is monitored statically but has no matching executable npm artifact in this cohort.
 
 A cell expires at its `recheckDueAt` value (168 hours after observation). Consumers must then show it as stale. This is exact compatibility evidence, not a security review or endorsement.

--- a/scripts/merge-dsh-compatibility-ledger.mjs
+++ b/scripts/merge-dsh-compatibility-ledger.mjs
@@ -100,6 +100,7 @@ await writeFile(resolve(reverseIndexPath), `${JSON.stringify(reverseIndex, null,
 
 const actionable = merged.transitions.filter(item => (
   item.status !== 'compatible' && item.status !== 'persisting-incompatibility'
+    && item.status !== 'persisting-review-signal'
 )).length
 const summary = {
   accepted: merged.acceptedCaseIds.length,

--- a/src/dsh-compatibility-ledger.ts
+++ b/src/dsh-compatibility-ledger.ts
@@ -139,6 +139,11 @@ export type DshCompatibilityTransitionStatus =
   | 'changed-incompatibility'
   | 'resolved-incompatibility'
   | 'persisting-incompatibility'
+  | 'new-review-signal'
+  | 'changed-review-signal'
+  | 'persisting-review-signal'
+  | 'reclassified-for-review'
+  | 'resolved-review-signal'
 
 export interface DshCompatibilityTransition {
   caseId: string
@@ -679,7 +684,11 @@ function parseLifecycleBuilds(value: unknown, label: string): string[] {
 }
 
 function isIncompatible(result: DshInstallObservationResult): boolean {
-  return result !== 'compatible'
+  return result !== 'compatible' && result !== 'build-approval-required'
+}
+
+function isReviewSignal(result: DshInstallObservationResult): boolean {
+  return result === 'build-approval-required'
 }
 
 function sameResolution(
@@ -707,8 +716,16 @@ function sameResolution(
 function transition(previous: DshCompatibilityLedgerEntry | undefined, current: DshCompatibilityLedgerEntry): DshCompatibilityTransition {
   const previousIncompatible = previous !== undefined && isIncompatible(previous.result)
   const currentIncompatible = isIncompatible(current.result)
+  const previousReview = previous !== undefined && isReviewSignal(previous.result)
+  const currentReview = isReviewSignal(current.result)
   let status: DshCompatibilityTransitionStatus
-  if (previous === undefined) status = currentIncompatible ? 'new-incompatibility' : 'compatible'
+  if (previous === undefined) status = currentReview ? 'new-review-signal' : currentIncompatible ? 'new-incompatibility' : 'compatible'
+  else if (currentReview && previousReview) {
+    status = previous.reason === current.reason ? 'persisting-review-signal' : 'changed-review-signal'
+  } else if (currentReview && previousIncompatible) status = 'reclassified-for-review'
+  else if (currentReview) status = 'new-review-signal'
+  else if (previousReview && !currentIncompatible) status = 'resolved-review-signal'
+  else if (previousReview && currentIncompatible) status = 'new-incompatibility'
   else if (previousIncompatible && !currentIncompatible) status = 'resolved-incompatibility'
   else if (!previousIncompatible && currentIncompatible) status = 'new-incompatibility'
   else if (previousIncompatible && currentIncompatible && (previous.result !== current.result || previous.reason !== current.reason)) status = 'changed-incompatibility'
@@ -787,7 +804,8 @@ export function renderDshCompatibilityLedgerMerge(merge: DshCompatibilityLedgerM
     `- Rejected reports: **${merge.rejectedReports.length}**`,
     `- Current active cells: **${merge.ledger.entries.length}**`,
   ]
-  const actionable = merge.transitions.filter(item => item.status !== 'compatible' && item.status !== 'persisting-incompatibility')
+  const actionable = merge.transitions.filter(item => item.status !== 'compatible'
+    && item.status !== 'persisting-incompatibility' && item.status !== 'persisting-review-signal')
   if (actionable.length > 0) {
     lines.push('', '### New or changed evidence', '')
     for (const item of actionable) {

--- a/test/dsh-compatibility-ledger.test.ts
+++ b/test/dsh-compatibility-ledger.test.ts
@@ -170,12 +170,35 @@ describe('DSH compatibility ledger', () => {
     })
 
     assert.deepEqual(merged.acceptedCaseIds, ['openpencil-node24'])
+    assert.equal(merged.transitions[0]?.status, 'new-review-signal')
     assert.deepEqual(
       (merged.ledger.entries[0] as typeof merged.ledger.entries[number] & { requiredDependencyBuilds?: string[] })
         ?.requiredDependencyBuilds,
       ['protobufjs'],
     )
     assert.equal(parseDshCompatibilityLedger(merged.ledger).entries[0]?.result, 'build-approval-required')
+  })
+
+  it('calls an install failure reclassified as a build gate review evidence, not a changed incompatibility', () => {
+    const failed = mergeDshCompatibilityLedger({
+      ledger: emptyDshCompatibilityLedger(),
+      expected: [expected],
+      reports: [report({ result: 'install-failed', reason: 'the traced install failed' })],
+    })
+    const reviewed = mergeDshCompatibilityLedger({
+      ledger: failed.ledger,
+      expected: [expected],
+      reports: [report({
+        result: 'build-approval-required',
+        reason: 'the install requires explicit approval for protobufjs',
+        boundary: {
+          approvedDependencyBuilds: [],
+          requiredDependencyBuilds: ['protobufjs'],
+        },
+      })],
+    })
+
+    assert.equal(reviewed.transitions[0]?.status, 'reclassified-for-review')
   })
 
   it('surfaces a newly resolved dependency graph even when install/load still succeeds', () => {


### PR DESCRIPTION
## Outcome

Four exact catalog cells were re-observed in fresh secret-free GitHub runners with no dependency-build approvals. All four now produce bounded `build-approval-required` evidence instead of `install-failed`:

- `@modusensus/dsh-mneme@0.6.10`: `onnxruntime-node`, `protobufjs`, `sharp`
- `dsh-notifier@0.8.6`: `protobufjs`
- `dsh-remote@0.8.7`: `cpu-features`, `node-pty`, `ssh2`
- `@linxin666/dsh-web-ui-all@0.2.9`: `cloudflared`, `cpu-features`, `node-pty`, `ssh2`

The maintained directory snapshot is now 32 observed compatible, 0 reproduced incompatible, 14 needs review, and 4 source-only/not observed. Managed incidents #80–#83 were closed with an English reclassification note.

This also gives review evidence its own transition vocabulary, so always-on summaries no longer call a build-policy gate a changed incompatibility.

## Evidence

- https://github.com/MicroMilo/upstream-radar/actions/runs/32635844512
- https://github.com/MicroMilo/upstream-radar/actions/runs/32635844427
- https://github.com/MicroMilo/upstream-radar/actions/runs/32635844293
- https://github.com/MicroMilo/upstream-radar/actions/runs/32635844352

## Verification

- 4 reports accepted, 0 missing, 0 rejected
- `pnpm test`: 341 passing