### PR TITLE
fix: test the actual DSH bundle contract

### DIFF
--- a/src/dsh-compatibility-ledger.ts
+++ b/src/dsh-compatibility-ledger.ts
@@ -540,7 +540,9 @@ export function createDshCompatibilityContractFingerprint(value: {
   allowedBuilds: readonly string[]
 }): string {
   return fingerprint({
-    probe: 'dsh-install/v1alpha1',
+    // v1alpha2 boots the composed DSH profile instead of imposing a package-
+    // root ESM export that the DSH bundle contract does not require.
+    probe: 'dsh-install/v1alpha2',
     platform: 'linux',
     architecture: 'x64',
     packageManager: 'pnpm@11.7.0',

--- a/src/dsh-install-observation.ts
+++ b/src/dsh-install-observation.ts
@@ -23,6 +23,7 @@ export const DSH_INSTALL_OBSERVATION_SCHEMA = 'upstream-radar.dsh-install-observ
 const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 const DEFAULT_TIMEOUT_MS = 180_000
 const MAX_ARTIFACT_BYTES = 64 * 1024 * 1024
+const MAX_ARTIFACT_UNPACKED_BYTES = 192 * 1024 * 1024
 const MAX_COMMAND_OUTPUT_BYTES = 64 * 1024
 const MAX_REPORT_DETAIL_BYTES = 4 * 1024
 const MAX_TRACE_BYTES = 16 * 1024 * 1024
@@ -354,7 +355,7 @@ function isNpmPackageName(value: string): boolean {
  * unless each package is approved. Keep that policy gate distinct from a
  * plugin install defect, but only when pnpm supplied a bounded, exact list.
  */
-function requiredDependencyBuilds(output: string): string[] {
+function requiredDependencyBuilds(output: string, artifactName: string): string[] {
   const normalized = output.replace(/\r\n?/g, '\n')
   const marker = '[ERR_PNPM_IGNORED_BUILDS]'
   const markerIndex = normalized.indexOf(marker)
@@ -375,7 +376,14 @@ function requiredDependencyBuilds(output: string): string[] {
       if (!EXACT_VERSION.test(parsed.version) || !isNpmPackageName(parsed.name)) return []
       names.add(parsed.name)
     } catch {
-      return []
+      // When the exact reviewed tarball itself has a lifecycle script, pnpm
+      // prints its profile-relative file: coordinate alongside registry
+      // dependencies. Accept only the already-established artifact identity;
+      // an arbitrary local coordinate must not become an approval suggestion.
+      const prefix = `${artifactName}@file:`
+      const localPath = coordinate.startsWith(prefix) ? coordinate.slice(prefix.length) : ''
+      if (localPath === '' || localPath.length > 4_096 || /[\u0000-\u0020\u007f]/.test(localPath)) return []
+      names.add(artifactName)
     }
   }
   return [...names].sort()
@@ -844,7 +852,10 @@ async function parsePackedArtifact(
   const path = resolve(artifactDirectory, filename)
   if (!path.startsWith(`${resolve(artifactDirectory)}${sep}`)) throw new Error('npm pack artifact escaped its directory')
   const compressed = await readRegularFileNoFollow(path, MAX_ARTIFACT_BYTES)
-  const parsed = parseNpmTarball(compressed, { maxFileBytes: MAX_ARTIFACT_BYTES })
+  const parsed = parseNpmTarball(compressed, {
+    maxFileBytes: MAX_ARTIFACT_BYTES,
+    maxUnpackedBytes: MAX_ARTIFACT_UNPACKED_BYTES,
+  })
   const manifestEntry = parsed.entries.find(entry => entry.path === 'package.json' && entry.type === 'file')
   if (manifestEntry?.contents === undefined) throw new Error('packed artifact has no package.json')
   let manifest: Record<string, unknown>
@@ -1251,14 +1262,13 @@ async function readProfilePeerContracts(
 }
 
 /**
- * Run the plugin's real ESM entry from the profile resolution anchor, then
- * boot DSH. The config dumper intentionally skips `!!js` and module imports;
- * this tiny trusted wrapper proves that the installed plugin can resolve its
- * own direct imports before the DSH headless app exits through `--help`.
+ * Resolve direct peer contracts from the profile anchor, then boot the actual
+ * composed DSH profile. A DSH bundle does not have to export its package root:
+ * its patch may load one or more package subpaths (or a command adapter).
+ * Importing the root here would therefore test a contract DSH never declared.
  */
 async function writeProfileLoadProbe(
   dshHome: string,
-  pluginName: string,
   dshVersion: string,
   pnpmCommand: string,
   peerRequirements: readonly ProfilePeerRequirement[],
@@ -1285,7 +1295,6 @@ async function writeProfileLoadProbe(
     '  catch { peers.push({ name: peer.name, status: \'missing\' }) }',
     '}',
     `await writeFile(${JSON.stringify(peerResolutionPath)}, JSON.stringify({ schema: ${JSON.stringify(PROFILE_PEER_RESOLUTION_SCHEMA)}, peers }), { encoding: 'utf8', mode: 0o600, flag: 'wx' })`,
-    `await import(${JSON.stringify(pluginName)})`,
     `const child = spawn(${JSON.stringify(pnpmCommand)}, ${JSON.stringify(dshBootArgs)}, { cwd: process.cwd(), env: process.env, stdio: 'inherit' })`,
     "const exitCode = await new Promise(resolve => {",
     "  child.once('error', error => { console.error(error.message); resolve(1) })",
@@ -1741,7 +1750,7 @@ export async function observeDshPluginInstall(options: DshInstallObservationOpti
         return finishReport(report, 'unknown', 'the install command ran without readable trace evidence')
       }
       if (installResult.code !== 0) {
-        const requiredBuilds = requiredDependencyBuilds(`${installResult.stderr}\n${installResult.stdout}`)
+        const requiredBuilds = requiredDependencyBuilds(`${installResult.stderr}\n${installResult.stdout}`, spec.name)
         if (requiredBuilds.length > 0) {
           report.boundary.requiredDependencyBuilds = requiredBuilds
           return finishReport(
@@ -1761,7 +1770,6 @@ export async function observeDshPluginInstall(options: DshInstallObservationOpti
 
       const loadProbe = await writeProfileLoadProbe(
         environment.DSH_HOME as string,
-        spec.name,
         options.dshVersion,
         pnpmCommand,
         artifact.requiredPeerDependencies,

--- a/test/dsh-install-observation.test.ts
+++ b/test/dsh-install-observation.test.ts
@@ -82,7 +82,7 @@ describe('DSH install observation', () => {
     assert.deepEqual(phases, ['runtime'])
   })
 
-  it('stops before DSH or plugin execution when the exact artifact excludes the isolated Node runtime', async () => {
+  it('preflights a bounded large bundle before stopping on an incompatible Node runtime', async () => {
     const phases: InstallObservationCommand['phase'][] = []
     let artifactArgs: string[] = []
     const report = await observeDshPluginInstall({
@@ -103,7 +103,10 @@ describe('DSH install observation', () => {
               dsh: { bundle: { patch: 'cordis.patch.yml' } },
             }) },
             { path: 'package/cordis.patch.yml', contents: '[]\n' },
-            { path: 'package/vendor/dsh-runtime.tgz', contents: Buffer.alloc(17 * 1024 * 1024) },
+            ...Array.from({ length: 4 }, (_, index) => ({
+              path: `package/vendor/runtime-${index}.bin`,
+              contents: Buffer.alloc(17 * 1024 * 1024),
+            })),
           ]))
           return passed({ stdout: 'future-plugin-1.0.0.tgz\n' })
         }
@@ -209,7 +212,7 @@ snapshots:
       if (command.phase === 'load') {
         assert.equal(command.command, process.execPath)
         const probe = await readFile(command.args[0] as string, 'utf8')
-        assert.match(probe, /await import\("example-plugin"\)/)
+        assert.doesNotMatch(probe, /await import\("example-plugin"\)/)
         assert.match(probe, /"--profile","headless","--help"/)
         assert.notEqual(hostRuntimeEntry, undefined)
         await writeFile(join(command.cwd, '.upstream-radar-peer-resolution.json'), JSON.stringify({
@@ -437,7 +440,7 @@ snapshots:
         if (command.tracePath !== undefined) await writeFile(command.tracePath, TRACE)
         return passed({
           code: 1,
-          stderr: '[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: sharp@0.34.5, @scope/native@1.2.3, protobufjs@7.6.5\n\nRun "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.\n',
+          stderr: '[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: approval-plugin@file:../../../artifact/approval-plugin-1.0.0.tgz, sharp@0.34.5, @scope/native@1.2.3, protobufjs@7.6.5\n\nRun "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.\n',
         })
       }
       return passed()
@@ -454,9 +457,9 @@ snapshots:
     assert.equal(report.result, 'build-approval-required')
     assert.deepEqual(
       (report.boundary as typeof report.boundary & { requiredDependencyBuilds?: string[] }).requiredDependencyBuilds,
-      ['@scope/native', 'protobufjs', 'sharp'],
+      ['@scope/native', 'approval-plugin', 'protobufjs', 'sharp'],
     )
-    assert.match(report.reason, /requires explicit approval.*@scope\/native, protobufjs, sharp/)
+    assert.match(report.reason, /requires explicit approval.*@scope\/native, approval-plugin, protobufjs, sharp/)
     assert.equal(report.stages.registration.status, 'skipped')
     assert.equal(report.stages.load.status, 'skipped')
   })


### PR DESCRIPTION
## Why

The first 100-target run produced five red cells. Reviewing the raw evidence showed that all five needed observer-side triage before any author outreach:

- three pnpm build-approval gates were misclassified because the ignored-build list included the exact plugin tarball as a `file:` coordinate
- two root-import failures imposed an ESM package-root contract that DSH bundles do not declare; DSH actually loads names from the bundle patch
- one valid 34 MB npm package expands to 157 MB and exceeded the previous aggregate preflight budget

## What changed

- recognize the reviewed local artifact in pnpm ignored-build output while rejecting arbitrary local coordinates
- resolve peer contracts, then boot the actual composed DSH profile without importing the package root
- raise only the bounded aggregate unpacked-artifact budget to 192 MiB; compressed and per-file caps remain 64 MiB
- bump the execution-contract fingerprint to `dsh-install/v1alpha2`, which deliberately schedules all 100 maintained cells for re-observation

## Verification

- `pnpm test` (341 tests)
- real `dsh-univer-office@0.2.9` artifact preflight: 35,613,705 compressed bytes, 156,845,396 unpacked bytes, 241 entries, no archive findings
- reconciliation dry run selects exactly 100 cells, all for `execution-contract-changed`

The next observer run will determine which findings survive the corrected DSH contract.