### PR TITLE
fix: bind Agent approval to the exact plugin tarball

### DIFF
--- a/src/dsh-install-observation.ts
+++ b/src/dsh-install-observation.ts
@@ -389,6 +389,23 @@ function requiredDependencyBuilds(output: string, artifactName: string): string[
   return [...names].sort()
 }
 
+/**
+ * pnpm keys registry dependency build approvals by package name, but keys a
+ * tarball dependency by its full package id. DSH installs the already-pinned
+ * artifact from a local tarball, so an Agent approval for the root package
+ * must be bound back to that exact file coordinate before it reaches pnpm.
+ */
+function pnpmBuildApproval(
+  approvedPackage: string,
+  artifact: ParsedArtifact,
+  artifactName: string,
+  profileDirectory: string,
+): string {
+  if (approvedPackage !== artifactName) return approvedPackage
+  const artifactPath = relative(profileDirectory, artifact.path).split(sep).join('/')
+  return `${artifactName}@file:${artifactPath}`
+}
+
 function staticPeerUsage(entries: readonly TarEntry[], requirements: readonly { name: string, required: string }[]): DshInstallPeerStaticUsage[] {
   const state = new Map(requirements.map(requirement => [requirement.name, 'no-literal-reference-observed' as DshInstallPeerStaticUsage]))
   let scanned = 0
@@ -1725,7 +1742,12 @@ export async function observeDshPluginInstall(options: DshInstallObservationOpti
         command: pnpmCommand,
         args: dshArgs(options.dshVersion, [
           'plugin', '--profile', PROFILE, 'add', join(artifactDirectory, artifact.filename),
-          ...allowedBuilds.map(name => `--allow-build=${name}`),
+          ...allowedBuilds.map(name => `--allow-build=${pnpmBuildApproval(
+            name,
+            artifact,
+            spec.name,
+            join(environment.DSH_HOME as string, 'profiles', PROFILE),
+          )}`),
         ]),
         cwd: artifactDirectory,
         env: scriptsEnvironment,

--- a/test/dsh-install-observation.test.ts
+++ b/test/dsh-install-observation.test.ts
@@ -492,12 +492,13 @@ snapshots:
       dshVersion: '0.1.1-rc.1',
       allowExecution: true,
       isolationProvider: 'other',
-      allowedBuilds: ['protobufjs', 'protobufjs'],
+      allowedBuilds: ['approved-plugin', 'protobufjs', 'protobufjs'],
       runner,
     })
 
+    assert.equal(installArgs.includes('--allow-build=approved-plugin@file:../../../artifact/approved-plugin-1.0.0.tgz'), true)
     assert.equal(installArgs.includes('--allow-build=protobufjs'), true)
-    assert.deepEqual(report.boundary.approvedDependencyBuilds, ['protobufjs'])
+    assert.deepEqual(report.boundary.approvedDependencyBuilds, ['approved-plugin', 'protobufjs'])
     await assert.rejects(observeDshPluginInstall({
       packageSpec: 'approved-plugin@1.0.0',
       dshVersion: '0.1.1-rc.1',


### PR DESCRIPTION
## What changed

- translate an Agent-approved root package into pnpm’s exact local-tarball build key
- keep transitive approvals as bounded package names
- retain the exact artifact and disposable-runner boundary

## Why

The first real Agent retry cleared transitive build gates for three plugins, but pnpm continued to block each root tarball lifecycle script. pnpm keys non-registry artifacts by the full package id, so `--allow-build=<package>` cannot approve `<package>@file:...`.

## Verification

- focused install-observer and Agent-plan tests pass
- TypeScript build passes
- after merge, the fast `headless-agent` workflow will rerun the three live cases