### PR TITLE
fix: accumulate Agent build approvals across retries

### DIFF
--- a/scripts/plan-dsh-headless-agent.mjs
+++ b/scripts/plan-dsh-headless-agent.mjs
@@ -232,12 +232,23 @@ const [targets, cohort, observations, ledger, existingPlans] = await Promise.all
   readPlans(plansPath),
 ])
 const targetById = new Map((Array.isArray(targets?.plugins) ? targets.plugins : []).map(target => [target.id, target]))
+const existingByCase = new Map(existingPlans.entries.map(entry => [entry.caseId, entry]))
 const reviewEntries = ledger.entries.filter(entry => (
   entry.result === 'build-approval-required' || entry.result === 'peer-contract-incompatible'
 )).slice(0, MAX_CANDIDATES)
 const candidates = await mapConcurrent(reviewEntries, async entry => {
   const target = targetById.get(entry.targetId)
   const source = sourceContext(target, observations, cohort)
+  const previous = existingByCase.get(entry.caseId)
+  const previouslyApprovedBuilds = previous?.action === 'retry-headless'
+    && previous.targetId === entry.targetId
+    && previous.plugin === entry.plugin
+    && previous.dshVersion === entry.dshVersion
+    && previous.nodeMajor === entry.runtime.nodeMajor
+    && previous.artifactSha256 !== undefined
+    && previous.artifactSha256 === entry.artifact.sha256
+      ? previous.allowedBuilds
+      : []
   return {
     caseId: entry.caseId,
     targetId: entry.targetId,
@@ -247,6 +258,7 @@ const candidates = await mapConcurrent(reviewEntries, async entry => {
     result: entry.result,
     reason: entry.reason,
     requiredDependencyBuilds: entry.requiredDependencyBuilds ?? [],
+    previouslyApprovedBuilds,
     ...(entry.artifact.sha256 === undefined ? {} : { artifactSha256: entry.artifact.sha256 }),
     ...(source.repository === undefined ? {} : { repository: source.repository }),
     ...(source.sourceCommit === undefined ? {} : { sourceCommit: source.sourceCommit }),
@@ -259,7 +271,6 @@ const baseUrl = process.env.ISSUE_LOCATOR_LLM_BASE_URL
 const apiKey = process.env.ISSUE_LOCATOR_LLM_API_KEY
 const model = process.env.ISSUE_LOCATOR_LLM_MODEL
 const config = baseUrl && apiKey && model ? { baseUrl, apiKey, model } : undefined
-const existingByCase = new Map(existingPlans.entries.map(entry => [entry.caseId, entry]))
 const pending = candidates.filter(candidate => {
   const previous = existingByCase.get(candidate.caseId)
   return previous?.inputFingerprint !== createDshHeadlessAgentInputFingerprint(candidate)
@@ -284,7 +295,10 @@ if (config === undefined && pending.length > 0) {
         dshVersion: candidate.dshVersion,
         nodeMajor: candidate.nodeMajor,
         result: candidate.result,
-        observedRequiredBuilds: candidate.requiredDependencyBuilds,
+        observedRequiredBuilds: [...new Set([
+          ...candidate.previouslyApprovedBuilds,
+          ...candidate.requiredDependencyBuilds,
+        ])].sort(),
         ...(candidate.artifactSha256 === undefined ? {} : { artifactSha256: candidate.artifactSha256 }),
         ...(candidate.repository === undefined ? {} : { repository: candidate.repository }),
         ...(candidate.sourceCommit === undefined ? {} : { sourceCommit: candidate.sourceCommit }),

--- a/src/dsh-headless-agent-plan.ts
+++ b/src/dsh-headless-agent-plan.ts
@@ -33,6 +33,7 @@ export interface DshHeadlessAgentCandidate {
   result: 'build-approval-required' | 'peer-contract-incompatible'
   reason: string
   requiredDependencyBuilds: string[]
+  previouslyApprovedBuilds: string[]
   artifactSha256?: string
   repository?: string
   sourceCommit?: string
@@ -143,10 +144,17 @@ export function parseDshHeadlessAgentDecision(
       throw new Error('a headless retry must be classified as build-approval')
     }
     if (decision.allowedBuilds.length === 0) throw new Error('a headless retry requires at least one approved dependency build')
-    const observed = new Set(candidate.requiredDependencyBuilds)
+    const observed = new Set([
+      ...candidate.previouslyApprovedBuilds,
+      ...candidate.requiredDependencyBuilds,
+    ])
     const invented = decision.allowedBuilds.filter(name => !observed.has(name))
     if (invented.length > 0) {
       throw new Error(`Agent requested dependency builds absent from the isolated observation: ${invented.join(', ')}`)
+    }
+    const dropped = candidate.previouslyApprovedBuilds.filter(name => !decision.allowedBuilds.includes(name))
+    if (dropped.length > 0) {
+      throw new Error(`Agent dropped dependency builds approved in an earlier retry: ${dropped.join(', ')}`)
     }
   } else if (decision.allowedBuilds.length > 0) {
     throw new Error('a stopped headless plan cannot approve dependency builds')
@@ -164,6 +172,7 @@ export function createDshHeadlessAgentInputFingerprint(candidate: DshHeadlessAge
     result: candidate.result,
     reason: candidate.reason,
     requiredDependencyBuilds: [...candidate.requiredDependencyBuilds].sort(),
+    previouslyApprovedBuilds: [...candidate.previouslyApprovedBuilds].sort(),
     artifactSha256: candidate.artifactSha256,
     repository: candidate.repository,
     sourceCommit: candidate.sourceCommit,
@@ -190,6 +199,7 @@ export function renderDshHeadlessAgentPrompt(candidate: DshHeadlessAgentCandidat
     'The only execution plane available in this milestone is the existing headless DSH profile.',
     'The runner may change only the explicit pnpm dependency-build approval list. It cannot add a Web/TUI plane, secrets, services, system packages, or arbitrary commands.',
     'Choose retry-headless only when the reproduced result is build-approval-required and repository evidence supports approving a subset of the exact observed build packages.',
+    'Build gates may appear in stages. A retry must keep every previously approved package and add any newly supported package; never drop an earlier approval.',
     'Otherwise choose stop-headless and classify the reason. Do not invent package names.',
     'Return exactly one JSON object with keys: action, classification, allowedBuilds, summary, evidence.',
     'Allowed action: retry-headless | stop-headless.',
@@ -202,7 +212,8 @@ export function renderDshHeadlessAgentPrompt(candidate: DshHeadlessAgentCandidat
     `Node major: ${candidate.nodeMajor}`,
     `Observed result: ${candidate.result}`,
     `Observed reason: ${candidate.reason}`,
-    `Observed build packages: ${candidate.requiredDependencyBuilds.join(', ') || '(none)'}`,
+    `Build packages required by the latest retry: ${candidate.requiredDependencyBuilds.join(', ') || '(none)'}`,
+    `Build packages approved in earlier retries: ${candidate.previouslyApprovedBuilds.join(', ') || '(none)'}`,
     `Repository: ${candidate.repository ?? '(unknown)'}`,
     `Source commit: ${candidate.sourceCommit ?? '(unknown)'}`,
     `Observed manifest: ${JSON.stringify(candidate.manifest ?? null).slice(0, 32 * 1024)}`,

--- a/test/dsh-headless-agent-plan.test.ts
+++ b/test/dsh-headless-agent-plan.test.ts
@@ -19,6 +19,7 @@ const candidate: DshHeadlessAgentCandidate = {
   result: 'build-approval-required',
   reason: 'the isolated install requires explicit approval for sharp',
   requiredDependencyBuilds: ['sharp'],
+  previouslyApprovedBuilds: [],
   artifactSha256: 'a'.repeat(64),
   repository: 'example/dsh-vision',
   sourceCommit: 'b'.repeat(40),
@@ -112,6 +113,32 @@ describe('DSH headless Agent planning', () => {
       summary: 'Wrong result type.',
       evidence: ['Existing peer evidence only.'],
     }, { ...candidate, result: 'peer-contract-incompatible', requiredDependencyBuilds: [] }), /only after a reproduced build-approval-required/)
+  })
+
+  it('requires the Agent to accumulate approvals across staged build gates', () => {
+    const stagedCandidate = {
+      ...candidate,
+      reason: 'the next isolated retry requires explicit approval for protobufjs',
+      requiredDependencyBuilds: ['protobufjs'],
+      previouslyApprovedBuilds: ['sharp'],
+    }
+    assert.throws(() => parseDshHeadlessAgentDecision({
+      action: 'retry-headless',
+      classification: 'build-approval',
+      allowedBuilds: ['protobufjs'],
+      summary: 'Approve only the newly visible gate.',
+      evidence: ['The latest isolated retry named protobufjs.'],
+    }, stagedCandidate), /dropped dependency builds approved in an earlier retry: sharp/)
+
+    const decision = parseDshHeadlessAgentDecision({
+      action: 'retry-headless',
+      classification: 'build-approval',
+      allowedBuilds: ['protobufjs', 'sharp'],
+      summary: 'Retain sharp and add protobufjs.',
+      evidence: ['Two consecutive isolated retries established both build gates.'],
+    }, stagedCandidate)
+    assert.deepEqual(decision.allowedBuilds, ['protobufjs', 'sharp'])
+    assert.match(renderDshHeadlessAgentPrompt(stagedCandidate), /never drop an earlier approval/)
   })
 
   it('overlays a retry only onto the exact artifact and runtime cell', () => {


### PR DESCRIPTION
## What changed

- carry exact prior Agent approvals into the next headless planning round
- require the Agent to retain earlier approvals while adding newly observed build gates
- bind accumulated state to the same case, artifact digest, DSH version and Node runtime
- reject invented or dropped approvals; there is still no static planning fallback

## Why

A real retry showed pnpm lifecycle gates in stages. Replacing the previous approval set with only the newest gate can oscillate forever. The headless loop now monotonically accumulates Agent-approved build packages until execution reaches a final result.

## Verification

Focused Agent-plan and install-observer tests pass, including a staged `sharp → protobufjs` regression case; TypeScript build passes.