### PR TITLE
release: prepare v0.43.0

### DIFF
--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.42.0
+      - uses: MicroMilo/upstream-radar@v0.43.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/.github/workflows/review-dsh-plugin.yml
+++ b/.github/workflows/review-dsh-plugin.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.42.0
+        uses: MicroMilo/upstream-radar@v0.43.0
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Upstream Radar are documented here.
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-08-24
+
+### Agent-driven headless closure
+
+- Let the configured DSH Agent read bounded repository instructions plus the
+  latest isolated result and choose either a constrained headless retry or an
+  explicit stop. There is no static environment-planning fallback.
+- Add a fast `headless-agent` GitHub Actions mode that reuses current exact
+  observations instead of waiting for the full upstream refresh before every
+  follow-up.
+- Bind every Agent plan to the exact plugin artifact digest, DSH version and
+  Node runtime. The model key stays in the planning job; the target package
+  executes later in a separate secret-free disposable runner.
+- Translate an Agent-approved root package to pnpm's exact local-tarball build
+  key, and accumulate approvals across staged lifecycle gates instead of
+  replacing the previous set and oscillating.
+- Complete the first live loop over the 29 catalog review cells: the Agent
+  selected nine bounded retries, seven became compatible, and two stopped at a
+  Web-client dependency boundary. The maintained fleet now records 74
+  compatible, 22 review-only, zero reproduced-incompatible and four
+  source-only catalog entries.
+
 ## [0.42.0] - 2026-08-23
 
 ### 100-plugin maintained fleet

--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ issue; when the author ships a fix, it retests and closes the loop.
 
 **100 maintained install/load targets · 100 catalog entries across all 21 categories · 4 upstream reports closed**
 
-[Latest full fleet run](https://github.com/MicroMilo/upstream-radar/actions/runs/32637649422):
-**96 executable catalog cells observed · 67 compatible · 29 need review · 0 reproduced incompatibilities · 4 source-only**.
+[Latest Agent-driven headless run](https://github.com/MicroMilo/upstream-radar/actions/runs/32684879130):
+**96 executable catalog cells observed · 74 compatible · 22 need review · 0 reproduced incompatibilities · 4 source-only**.
 Review signals are never advertised as plugin failures.
+
+The first live loop started with 29 review cells. The Agent selected nine
+bounded retries; seven became compatible, while two stopped at an explicit Web
+client dependency boundary instead of being mislabeled as broken.
 
 ## Why it exists
 
@@ -40,26 +44,28 @@ maintained plugins stopped passing after the ecosystem changed?”
 ```mermaid
 flowchart TB
   Schedule["Scheduled GitHub Action"] --> Watch["Watch DSH + plugin releases"]
-  Watch --> Matrix["Exact plugin × DSH matrix"]
-  Matrix --> Static["Static contract checks"]
-  Matrix --> Runtime["Disposable runner: install → register → load"]
-  Static --> Evidence["Reproducible compatibility evidence"]
-  Runtime --> Evidence
-  Evidence --> Issue["One fixable issue"]
+  Watch --> Evidence["Current exact headless evidence"]
+  Evidence --> Agent["Agent chooses the next bounded retry"]
+  Agent --> Runtime["Disposable VM: install → register → load"]
+  Runtime -->|"next observed gate"| Agent
+  Runtime -->|"compatible"| Ledger["Persist exact result"]
+  Runtime -->|"outside headless"| Hold["Keep as review evidence"]
+  Runtime -->|"reproduced failure"| Issue["One fixable issue"]
   Issue --> Fix["Author publishes a fix"]
   Fix --> Watch
 ```
 
-Radar establishes the result with deterministic evidence. An optional DSH
-Agent can explain impact and suggest the next action, but a model never turns
-missing evidence into a pass.
+The Agent interprets repository instructions and the latest runtime evidence,
+then chooses whether and how headless should retry. The disposable runner—not
+the model—establishes the result. A model cannot invent a build package, execute
+inside the target VM, or turn missing evidence into a pass.
 
 ## What you get
 
 - An exact result for `plugin version × DSH version × Node/profile`, not a
   timeless “compatible” badge.
-- Static dependency and peer-contract checks joined with real
-  install/register/load evidence from the published artifact.
+- Agent-planned follow-ups joined with real install/register/load evidence from
+  the published artifact.
 - A maintained result that is retested when DSH or the plugin changes.
 - One managed issue that is updated on repeat failures, reopened on regression,
   and closed after a clean retest.
@@ -77,7 +83,7 @@ them:
 ## Run one check
 
 ```bash
-npx --yes upstream-radar@0.42.0 review dsh-plugin \
+npx --yes upstream-radar@0.43.0 review dsh-plugin \
   <package>@<version> \
   --dsh-version <dsh-version>
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,9 +20,12 @@ Radar 会再次检查并关闭闭环。
 
 **维护 100 个安装/加载目标 · 覆盖目录全部 21 个类别 · 4 条上游报告已关闭**
 
-[最近一次全量运行](https://github.com/MicroMilo/upstream-radar/actions/runs/32637649422)：
-**观测 96 个可执行目录插件 · 67 个兼容 · 29 个需要复核 · 0 个复现不兼容 · 4 个仅源码目标**。
+[最近一次 Agent 驱动的 headless 运行](https://github.com/MicroMilo/upstream-radar/actions/runs/32684879130)：
+**观测 96 个可执行目录插件 · 74 个兼容 · 22 个需要复核 · 0 个复现不兼容 · 4 个仅源码目标**。
 需要复核的信号不会被宣传成插件故障。
+
+第一轮真实闭环从 29 个待复核插件开始。Agent 选择了 9 个受限重试，其中 7 个转为
+兼容；另 2 个明确停在 Web 客户端依赖边界，没有被误报成插件坏了。
 
 ## 为什么需要它
 
@@ -38,23 +41,25 @@ Upstream Radar 检查的是这层真实关系，而不只是分别看两个仓�
 ```mermaid
 flowchart TB
   Schedule["定时 GitHub Action"] --> Watch["观察 DSH 与插件发布"]
-  Watch --> Matrix["精确的插件 × DSH 测试矩阵"]
-  Matrix --> Static["静态契约检查"]
-  Matrix --> Runtime["一次性环境：安装 → 注册 → 加载"]
-  Static --> Evidence["可复现的兼容性证据"]
-  Runtime --> Evidence
-  Evidence --> Issue["一条可修复的 Issue"]
+  Watch --> Evidence["当前精确的 headless 证据"]
+  Evidence --> Agent["Agent 决定下一次受限重试"]
+  Agent --> Runtime["一次性虚拟机：安装 → 注册 → 加载"]
+  Runtime -->|"出现下一层门槛"| Agent
+  Runtime -->|"兼容"| Ledger["保存精确结果"]
+  Runtime -->|"超出 headless"| Hold["保留为待复核证据"]
+  Runtime -->|"复现真实失败"| Issue["一条可修复的 Issue"]
   Issue --> Fix["作者发布修复"]
   Fix --> Watch
 ```
 
-Radar 用确定性证据得出结果。DSH Agent 可以补充影响解释和下一步建议，但模型不能
-把缺失的证据说成通过。
+Agent 读取仓库说明和最新运行证据，决定 headless 是否重试、重试时允许哪些安装条件。
+真正的结果由一次性虚拟机执行得出，而不是模型判断。模型不能凭空增加安装包、不能
+进入目标虚拟机执行，也不能把缺失证据说成通过。
 
 ## 你会得到什么
 
 - `插件版本 × DSH 版本 × Node/profile` 的精确结果，而不是永不过期的“兼容”标签。
-- 把静态依赖和 peer 契约，与真实发布物的安装、注册、加载结果放在一起判断。
+- 把 Agent 规划的后续动作，与真实发布物的安装、注册、加载结果放在一起判断。
 - DSH 或插件变化后自动重新检查，而不是只生成一次报告。
 - 同一问题持续更新；回归时重新打开；干净复测通过后自动关闭。
 
@@ -70,7 +75,7 @@ Radar 用确定性证据得出结果。DSH Agent 可以补充影响解释和下�
 ## 检查一个插件
 
 ```bash
-npx --yes upstream-radar@0.42.0 review dsh-plugin \
+npx --yes upstream-radar@0.43.0 review dsh-plugin \
   <包名>@<版本> \
   --dsh-version <DSH版本>
 ```

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.42.0
+    default: 0.43.0
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -98,7 +98,7 @@ FIRST EPSS estimated exploitation probability: 97.2% (percentile 100.0%)
 想立即检查一个真实发布的 DSH 插件，可以在空目录直接运行：
 
 ```bash
-npx --yes upstream-radar@0.42.0 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.43.0 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 它会直接输出简短的准入结论、覆盖情况、依赖数量、漏洞数量和下一步，不需要先
@@ -111,7 +111,7 @@ npx --yes upstream-radar@0.42.0 inspect dsh-feishu-bot@0.15.8 --deep
 npm 解析环境中目前无法建立完整依赖图：
 
 ```bash
-npx --yes upstream-radar@0.42.0 inspect \
+npx --yes upstream-radar@0.43.0 inspect \
   @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
   --deep --fail-on never
 ```
@@ -337,9 +337,9 @@ npm：     dsh-feishu-bot@0.15.8
 会继续显示为 `incomplete`，不会被当成已经确认的故障。
 
 ```bash
-npx --yes upstream-radar@0.42.0 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.43.0 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.42.0 observe ./targets.yml \
+npx --yes upstream-radar@0.43.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -377,7 +377,7 @@ Radar 会在三层目录内自动找到它；npm 名称和源码 manifest 不一
 想明确选择锁文件时再加 `--lockfile`：
 
 ```bash
-npx --yes upstream-radar@0.42.0 observe \
+npx --yes upstream-radar@0.43.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -400,7 +400,7 @@ workspace 边保留为未解析证据；不会安装或启动 DSH。
 会额外指定 `--package`：
 
 ```bash
-npx --yes upstream-radar@0.42.0 observe \
+npx --yes upstream-radar@0.43.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -679,7 +679,7 @@ cd my-dsh-plugin
 pnpm install --ignore-scripts
 
 # 把插件放进 DSH profile 前，先读取精确依赖图。
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
 ```
 
 这棵图会保留精确的 DSH 包版本，也会把未解析的可选 peer 明确显示出来；它不会加载生成的插件，也不会运行 lifecycle script。审查后，把下面这个完整 workflow 复制到 `.github/workflows/upstream-radar.yml`：
@@ -701,7 +701,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.42.0
+      - uses: MicroMilo/upstream-radar@v0.43.0
         with:
           fail-on: high
           fail-on-compatibility: breaking
@@ -712,7 +712,7 @@ Action 会自动识别唯一的 `pnpm-lock.yaml`，检查同一棵精确依赖�
 也可以直接检查一个真实发布的 DSH 包：
 
 ```bash
-npx --yes upstream-radar@0.42.0 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.43.0 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 这次检查的结论是 `REVIEW`：registry 完整性、签名、provenance 和 89 个已解析包都
@@ -725,7 +725,7 @@ npx --yes upstream-radar@0.42.0 inspect dsh-feishu-bot@0.15.8 --deep
 如果不想分别执行 `inspect`、打包和 `probe`，可以用一个命令完成一次 DSH 插件审查：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar review dsh-plugin \
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar review dsh-plugin \
   dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
@@ -891,7 +891,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -904,7 +904,7 @@ pnpm dlx --package=upstream-radar@0.42.0 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -930,7 +930,7 @@ pnpm run showcase:dsh-probe
 如果要比较多个 DSH 版本，可以使用矩阵入口：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -948,7 +948,7 @@ JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.42.0
+  - uses: MicroMilo/upstream-radar@v0.43.0
     with:
       fail-on: high
       # 可选：把确定性的 DSH/插件兼容性破坏也作为 CI 失败条件
@@ -962,7 +962,7 @@ steps:
 如果仓库还没有提交 Radar 配置，最短接入方式是省略 `config`、`pnpm-lock` 和 `npm-lock`。checkout 之后，Action 会自动使用唯一存在的 `pnpm-lock.yaml` 或 `package-lock.json`，生成临时的审查清单，再执行同一个 frozen 检查：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.42.0
+- uses: MicroMilo/upstream-radar@v0.43.0
   with:
     fail-on: high
 ```
@@ -972,7 +972,7 @@ steps:
 如果要在插件进入 DSH 前审查精确发布物，可以增加 `inspect-package`：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.42.0
+- uses: MicroMilo/upstream-radar@v0.43.0
   with:
     inspect-package: dsh-cloudflare-browser-run@0.1.1
     # review 是安全默认值；只有允许覆盖不完整时才使用 block
@@ -984,7 +984,7 @@ steps:
 如果仓库只有 pnpm 锁文件，还没有提交 Radar 配置，可以让 Action 在同一个 job 中生成配置；可直接复制[pnpm workflow 示例](../examples/github-actions/upstream-radar-pnpm.yml)：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.42.0
+- uses: MicroMilo/upstream-radar@v0.43.0
   with:
     pnpm-lock: pnpm-lock.yaml
     fail-on: high
@@ -998,7 +998,7 @@ npm 项目可以改用 `npm-lock: package-lock.json`；`pnpm-lock` 和 `npm-lock
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -1006,7 +1006,7 @@ pnpm dlx --package=upstream-radar@0.42.0 upstream-radar radar check \
 如果还要检查一个已发布插件能否跨多个 DSH 版本加载，可以增加三个 input：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.42.0
+- uses: MicroMilo/upstream-radar@v0.43.0
   id: radar
   with:
     config: upstream-radar.config.json

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -210,7 +210,7 @@ When the native DSH adapter is running, it additionally verifies the exact `@dee
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -224,7 +224,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.42.0
+  - uses: MicroMilo/upstream-radar@v0.43.0
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -257,7 +257,7 @@ It packs without lifecycle scripts, runs one temporary DSH profile per version, 
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -271,7 +271,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```

--- a/examples/dsh/install-observer/README.md
+++ b/examples/dsh/install-observer/README.md
@@ -1,8 +1,8 @@
 # DSH isolated install observer
 
-This directory is the maintained dynamic-test corpus for Upstream Radar.
-Static checks cover source and dependency changes every day; isolated execution
-establishes behavior evidence for the current active matrix. The corpus now
+This directory is the maintained headless-test corpus for Upstream Radar.
+The Agent plans bounded follow-ups from repository instructions and the latest
+runtime evidence; isolated execution establishes the result. The corpus now
 contains 100 exact published plugins: 96 identity-checked npm artifacts imported
 from the [`awesome-dsh-plugin` cohort](../awesome-observer/README.md), plus four
 maintained behavior and repair cases.
@@ -15,6 +15,8 @@ Action gives the exact evidence plus bounded repository documents to the
 configured Agent. There is deliberately no static environment-planning
 fallback. The Agent either stops the headless path or requests one retry whose
 build approvals are a subset of the package names already observed by pnpm.
+When pnpm reveals another gate, the next Agent decision must retain earlier
+approvals and may only add newly observed names, so the loop cannot oscillate.
 
 The plan is persisted in [`agent-plans.json`](agent-plans.json), rendered in
 [`agent-plans.md`](agent-plans.md), and bound to the exact plugin artifact, DSH
@@ -80,11 +82,10 @@ contract explicitly approves named dependency scripts. The names become pnpm
 An absent list means no dependency build is approved; Radar never turns one
 blocked script into a global “allow all” policy.
 
-- Every daily static pass builds the desired current matrix from the observed
-  DSH/plugin coordinates, source/lockfile graph facts, and the reviewed runtime
-  contract.
+- Every scheduled pass builds the desired current matrix from the observed
+  DSH/plugin coordinates and retained runtime evidence.
 - A cell runs when it is missing, has become older than `refreshAfterHours`, or
-  its static evidence, runtime image, or allowed-build policy differs from the
+  its source/package evidence, runtime image, or allowed-build policy differs from the
   record in the ledger. DSH and mapped plugin publications are immediate
   invalidation signals, not the sole source of work.
 - A `runtime-incompatible` result records the artifact's Node engine before any
@@ -93,7 +94,7 @@ blocked script into a global “allow all” policy.
   incompatible.
 - Every selected cell receives a separate hosted VM through the workflow
   matrix. The ledger accepts a report only when its case label, tarball, DSH
-  version, Node major, and explicit build approvals match the static plan.
+  version, Node major, and explicit build approvals match the scheduled plan.
 - A missing or malformed report is never saved as compatible. It remains
   unsatisfied and will be selected again on the next reconciliation.
 - A `compatible` result only closes its matrix cell when the final effective
@@ -101,7 +102,7 @@ blocked script into a global “allow all” policy.
   resolves inside the real profile with a version satisfying the declared
   range. A green install/load with missing, out-of-range, or unresolved
   contract evidence remains an explicit evidence gap. The report keeps a
-  bounded sample of unresolved edges and labels static peer use as runtime,
+  bounded sample of unresolved edges and labels source-level peer use as runtime,
   type-only, no literal reference observed, or scan-incomplete.
 - An actionable incompatibility creates one managed issue keyed by the stable
   target/runtime cell. Persistent failures update that issue, regressions

--- a/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
+++ b/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
@@ -19,7 +19,7 @@ From a clean checkout, the finding is reproducible without installing or
 executing the plugin:
 
 ```bash
-npx --yes upstream-radar@0.42.0 scan . --json
+npx --yes upstream-radar@0.43.0 scan . --json
 ```
 
 The current static scan reports:

--- a/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
+++ b/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
@@ -43,5 +43,5 @@ graph, the unresolved peer boundary, the vulnerability result, and the two
 remaining review actions in one report.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.42.0`. Review the Draft PR before relying on the fallback
+`upstream-radar@0.43.0`. Review the Draft PR before relying on the fallback
 resolver from npm.

--- a/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
+++ b/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
@@ -21,7 +21,7 @@ Reproduce it with:
 
 ```bash
 npm pack --ignore-scripts --pack-destination /tmp dsh-feishu-bot@0.15.4
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar probe dsh-matrix \
   /tmp/dsh-feishu-bot-0.15.4.tgz \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```

--- a/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
+++ b/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
@@ -8,7 +8,7 @@ graph without installing anything.
 ## Reproduction
 
 ```bash
-npx --yes upstream-radar@0.42.0 scan \
+npx --yes upstream-radar@0.43.0 scan \
   https://github.com/2008924/dsh-progress-viz \
   --fail-on never
 ```

--- a/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
+++ b/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
@@ -13,11 +13,11 @@ No DSH profile, plugin code, lifecycle script, or LLM was started.
 ## Commands
 
 ```bash
-npx --yes upstream-radar@0.42.0 scan \
+npx --yes upstream-radar@0.43.0 scan \
   https://github.com/ccch1mneyyy/dsh-TUI \
   --fail-on never
 
-npx --yes upstream-radar@0.42.0 inspect \
+npx --yes upstream-radar@0.43.0 inspect \
   npm:@deepseek-harness-tui/dsh-tui@0.8.0 \
   --deep --fail-on never
 ```

--- a/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
+++ b/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
@@ -8,7 +8,7 @@ release.
 ## Rechecked with the public CLI
 
 Each repository was cloned at its current public `main` commit and scanned with
-`upstream-radar@0.42.0`. No package was installed, loaded, or executed.
+`upstream-radar@0.43.0`. No package was installed, loaded, or executed.
 
 | Repository | Commit | `package.json` | `package-lock.json` root | Result |
 | --- | --- | ---: | ---: | --- |

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -40,7 +40,7 @@ The optional probe is load-only. It packs with `--ignore-scripts`, uses a tempor
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.42.0 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.43.0 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.42.0
+      - uses: MicroMilo/upstream-radar@v0.43.0
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/dsh-plugin-review-minimal.yml
+++ b/examples/github-actions/dsh-plugin-review-minimal.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.42.0
+        uses: MicroMilo/upstream-radar@v0.43.0
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/examples/github-actions/upstream-observer-minimal.yml
+++ b/examples/github-actions/upstream-observer-minimal.yml
@@ -53,7 +53,7 @@ jobs:
           llm_env_file="$RUNNER_TEMP/issue-locator.env"
           trap 'rm -f "$llm_env_file"' EXIT
           observe_args=(
-            npx --yes upstream-radar@0.42.0 observe "$repository"
+            npx --yes upstream-radar@0.43.0 observe "$repository"
             --ref "$ref"
             --state observations.json
             --report "$report"

--- a/examples/github-actions/upstream-radar-npm.yml
+++ b/examples/github-actions/upstream-radar-npm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.42.0
+      - uses: MicroMilo/upstream-radar@v0.43.0
         with:
           npm-lock: package-lock.json
           fail-on: high

--- a/examples/github-actions/upstream-radar-pnpm.yml
+++ b/examples/github-actions/upstream-radar-pnpm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.42.0
+      - uses: MicroMilo/upstream-radar@v0.43.0
         with:
           pnpm-lock: pnpm-lock.yaml
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.42.0
+      - uses: MicroMilo/upstream-radar@v0.43.0
         with:
           # The Action auto-detects one pnpm-lock.yaml or package-lock.json.
           fail-on: high

--- a/examples/github-actions/upstream-scan-minimal.yml
+++ b/examples/github-actions/upstream-scan-minimal.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           report="$RUNNER_TEMP/upstream-radar-scan.json"
-          npx --yes upstream-radar@0.42.0 scan \
+          npx --yes upstream-radar@0.43.0 scan \
             "$OBSERVER_REPOSITORY_INPUT" \
             --json --fail-on never > "$report"
           if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/examples/upstream-observer/README.md
+++ b/examples/upstream-observer/README.md
@@ -24,7 +24,7 @@ Replace it with the repositories your team depends on.
 For one repository, the shortest path skips YAML and lockfile configuration entirely:
 
 ```bash
-npx --yes upstream-radar@0.42.0 observe \
+npx --yes upstream-radar@0.43.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -35,7 +35,7 @@ Radar automatically chooses the committed `pnpm-lock.yaml` or
 the explicit form below adds `--package`:
 
 ```bash
-npx --yes upstream-radar@0.42.0 observe \
+npx --yes upstream-radar@0.43.0 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -75,9 +75,9 @@ Build one index from saved DSH plugin scan/review/config JSON, then give it to
 the observer:
 
 ```bash
-npx --yes upstream-radar@0.42.0 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.43.0 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.42.0 observe ./targets.yml \
+npx --yes upstream-radar@0.43.0 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -99,7 +99,7 @@ and run `pnpm run showcase:observer` to replay a real
 The scheduled workflow uses the checked-in index directly:
 
 ```bash
-npx --yes upstream-radar@0.42.0 observe ./targets.yml \
+npx --yes upstream-radar@0.43.0 observe ./targets.yml \
   --reverse-index ../dsh/first-batch/reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -126,7 +126,7 @@ Run it from any directory with the published CLI:
 
 ```bash
 export GITHUB_TOKEN='a read-only token with repository metadata access'
-npx --yes upstream-radar@0.42.0 observe \
+npx --yes upstream-radar@0.43.0 observe \
   /path/to/targets.yml \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md

--- a/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
+++ b/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
@@ -30,5 +30,5 @@ than silently monitoring the repository root. Local `workspace:` links remain
 explicitly unresolved; Radar does not guess their published versions.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.42.0`. Review the Draft PR before using the auto-discovery
+`upstream-radar@0.43.0`. Review the Draft PR before using the auto-discovery
 path from npm.

--- a/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
+++ b/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
@@ -14,12 +14,12 @@ The baseline was taken at the commit that produced the published `0.5.4`
 artifact, then the same state was checked against the current `master`:
 
 ```bash
-npx --yes upstream-radar@0.42.0 observe \
+npx --yes upstream-radar@0.43.0 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref aa5f4efc7827176cce27c73f73a2f42514da1ebf \
   --state observations.json --report baseline.md --json
 
-npx --yes upstream-radar@0.42.0 observe \
+npx --yes upstream-radar@0.43.0 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref master \
   --state observations.json --report repair.md --json

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -1,9 +1,9 @@
 {
   "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha1",
-  "generatedAt": "2026-08-24T03:02:08.258Z",
+  "generatedAt": "2026-08-24T03:06:16.972Z",
   "producer": {
     "name": "upstream-radar",
-    "version": "0.42.0",
+    "version": "0.43.0",
     "repository": "https://github.com/MicroMilo/upstream-radar",
     "license": "Apache-2.0"
   },

--- a/feeds/dsh-plugin-compatibility.md
+++ b/feeds/dsh-plugin-compatibility.md
@@ -1,6 +1,6 @@
 # DSH directory compatibility evidence
 
-Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-24T03:02:08.258Z`.
+Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-24T03:06:16.972Z`.
 
 **74 observed compatible · 0 observed incompatible · 22 needs review · 4 not observed**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Always-on dependency and compatibility monitoring for DeepSeek Harness plugins, including exact paths, upstream changes, and isolated install/load evidence.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.42.0'
+export const TOOL_VERSION = '0.43.0'

--- a/test/release-preflight.test.ts
+++ b/test/release-preflight.test.ts
@@ -23,7 +23,7 @@ describe('release preflight', () => {
       checks: Array<{ status: string }>
     }
     assert.equal(report.schema, 'upstream-radar.release-preflight/v1alpha1')
-    assert.equal(report.version, '0.42.0')
+    assert.equal(report.version, '0.43.0')
     assert.equal(report.passed, true)
     assert.equal(report.publishedCheck, false)
     assert.ok(report.checks.length >= 4)


### PR DESCRIPTION
## Agent-driven headless closure

This release turns the headless compatibility follow-up into a real Agent/runtime loop:

- Agent plans bounded retries from repository instructions and current isolated evidence
- no static environment-planning fallback
- exact artifact/DSH/Node binding and secret separation
- staged pnpm build approvals accumulate instead of oscillating
- fast `headless-agent` workflow mode

## Live result

[Run 32684879130](https://github.com/MicroMilo/upstream-radar/actions/runs/32684879130) completed the first loop: 29 catalog review cells → 9 Agent-selected retries → 7 newly compatible → 2 explicit Web-client boundary stops. The public baseline is now 74 compatible, 22 review-only, 0 reproduced-incompatible and 4 source-only.

## Verification

- 347 tests pass
- release preflight passes
- packed artifact installs and starts offline
- README and Chinese README carry the new loop and live evidence