### PR TITLE
Follow declared npm release channels

### DIFF
--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.2
+      - uses: MicroMilo/upstream-radar@v0.43.3
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/.github/workflows/review-dsh-plugin.yml
+++ b/.github/workflows/review-dsh-plugin.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.43.2
+        uses: MicroMilo/upstream-radar@v0.43.3
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Upstream Radar are documented here.
 
 ## [Unreleased]
 
+## [0.43.3] - 2026-08-24
+
+### Domain report index
+
+- Reclassify the 13 maintainer-facing reports into DSH host/plugin contract,
+  published artifact/install contract, and dependency-graph observability.
+- Clarify that historical browser/web compatibility cases are closed reference
+  cases, not open Upstream Radar incidents.
+- Publish the full evidence and validation boundary in `docs/domain-reports.md`.
+
 ## [0.43.2] - 2026-08-24
 
 ### npm README selection

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -18,7 +18,7 @@ Upstream Radar 持续把一批真实插件发布物放到一次性隔离环境�
 版本重新配对测试。某个组合坏了，就生成一条可复现的 Issue；作者发布修复后，
 Radar 会再次检查并关闭闭环。
 
-**维护 100 个安装/加载目标 · 覆盖目录全部 21 个类别 · 4 条上游报告已关闭 · 另有 4 条持续观察**
+**维护 100 个安装/加载目标 · 已提出 13 条 domain 报告 · 4 条已关闭 · 9 条开放或持续观察**
 
 [最近一次 Agent 驱动的 headless 运行](https://github.com/MicroMilo/upstream-radar/actions/runs/32684879130)：
 **观测 96 个可执行目录插件 · 74 个兼容 · 22 个需要复核 · 0 个复现不兼容 · 4 个仅源码目标**。
@@ -61,26 +61,46 @@ Agent 读取仓库说明和最新运行证据，决定 headless 是否重试、�
 - DSH 或插件变化后自动重新检查，而不是只生成一次报告。
 - 同一问题持续更新；回归时重新打开；干净复测通过后自动关闭。
 
-## 已关闭的上游报告
+## 我们闭环中提出的 domain 报告
 
-以下报告由我们提出，目前均已被对应上游维护者关闭：
+以下是 Upstream Radar 提出的 13 条面向维护者的报告。它们不全都表示
+“插件坏了”：第一组是运行时兼容性，第二组是精确发布物/安装边界，第三组是
+持续监控所依赖的依赖图是否可信。
 
-- [Sanqi-normal/dsh-webui-market-plugin#5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
-- [1na-ko/dsh-hdc-bridge#3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
-- [6Mikao9/dsh-wsl-workspace#6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
-- [3274375092/dsh-voice#2](https://github.com/3274375092/dsh-voice/issues/2)
+### DSH 宿主/插件契约 · 2 条
 
-另有 4 条较新的报告仍在持续观察：
+- **已关闭** · [Sanqi-normal/dsh-webui-market-plugin#5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
+- **开放** · [shaoshi20/dshscan#1](https://github.com/shaoshi20/dshscan/issues/1)
 
-- [AmeKrance/anan-thermal-monitor#1](https://github.com/AmeKrance/anan-thermal-monitor/issues/1)
-- [AbcdefgXW/dsh-msg-hub#3](https://github.com/AbcdefgXW/dsh-msg-hub/issues/3)
-- [030611/dsh-verification-receipt#3](https://github.com/030611/dsh-verification-receipt/issues/3)
-- [0xsline/dsh-spotlight#5](https://github.com/0xsline/dsh-spotlight/issues/5)
+### 发布物与安装契约 · 7 条
+
+- **已关闭** · [1na-ko/dsh-hdc-bridge#3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
+- **已关闭** · [6Mikao9/dsh-wsl-workspace#6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
+- **已关闭** · [3274375092/dsh-voice#2](https://github.com/3274375092/dsh-voice/issues/2)
+- **开放** · [AmeKrance/anan-thermal-monitor#1](https://github.com/AmeKrance/anan-thermal-monitor/issues/1)
+- **开放** · [AbcdefgXW/dsh-msg-hub#3](https://github.com/AbcdefgXW/dsh-msg-hub/issues/3)
+- **开放** · [030611/dsh-verification-receipt#3](https://github.com/030611/dsh-verification-receipt/issues/3)
+- **开放** · [0xsline/dsh-spotlight#5](https://github.com/0xsline/dsh-spotlight/issues/5)
+
+### 依赖图与源码/发布版本对齐 · 4 条
+
+- **开放** · [lninghaha/dsh-coding-subscription-oauth#14](https://github.com/lninghaha/dsh-coding-subscription-oauth/issues/14)
+- **开放** · [AbcdefgXW/dsh-msg-hub#1](https://github.com/AbcdefgXW/dsh-msg-hub/issues/1)
+- **开放** · [AbcdefgXW/dsh-toolbox-web#1](https://github.com/AbcdefgXW/dsh-toolbox-web/issues/1)
+- **开放** · [13071301808/dsh-composer-expand#1](https://github.com/13071301808/dsh-composer-expand/issues/1)
+
+你记得的 browser/web 案例——[`dsh-web-ui#35`](https://github.com/zhu1090093659/dsh-web-ui/issues/35)
+和 [`dsh-web-ui#71`](https://github.com/zhu1090093659/dsh-web-ui/issues/71)——是有价值的历史兼容性
+对照，且目前已关闭；但它们不是 Upstream Radar 提出的报告，所以不计入上面的 13 条。
+当前维护中的 `dsh-browser` 条目也都观测为兼容，不应被列成问题。
+
+查看[完整分类与证据索引](docs/domain-reports.md)，其中区分了动态复现、源码/发布物证据，
+以及仍需维护者确认的弱结论。
 
 ## 检查一个插件
 
 ```bash
-npx --yes upstream-radar@0.43.2 review dsh-plugin \
+npx --yes upstream-radar@0.43.3 review dsh-plugin \
   <包名>@<版本> \
   --dsh-version <DSH版本>
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ plugins against changing
 releases in disposable runners. When a pair breaks, it produces a reproducible
 issue; when the author ships a fix, it retests and closes the loop.
 
-**100 maintained install/load targets · 100 catalog entries across all 21 categories · 4 upstream reports closed · 4 more under watch**
+**100 maintained install/load targets · 13 domain reports filed · 4 closed · 9 open or under watch**
 
 [Latest Agent-driven headless run](https://github.com/MicroMilo/upstream-radar/actions/runs/32684879130):
 **96 executable catalog cells observed · 74 compatible · 22 need review · 0 reproduced incompatibilities · 4 source-only**.
@@ -68,27 +68,49 @@ inside the target VM, or turn missing evidence into a pass.
 - One managed issue that is updated on repeat failures, reopened on regression,
   and closed after a clean retest.
 
-## Upstream reports now closed
+## Domain reports from our loop
 
-We opened the following reports; their upstream maintainers have now closed
-them:
+These are the 13 maintainer-facing reports filed by Upstream Radar. They are
+not all “the plugin is broken”: the first group is runtime compatibility, the
+second is the exact package/install boundary, and the third is whether a
+dependency graph can be trusted for continuous monitoring.
 
-- [Sanqi-normal/dsh-webui-market-plugin#5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
-- [1na-ko/dsh-hdc-bridge#3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
-- [6Mikao9/dsh-wsl-workspace#6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
-- [3274375092/dsh-voice#2](https://github.com/3274375092/dsh-voice/issues/2)
+### DSH host/plugin contract · 2
 
-Four newer reports are still open and being watched:
+- **closed** · [Sanqi-normal/dsh-webui-market-plugin#5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
+- **open** · [shaoshi20/dshscan#1](https://github.com/shaoshi20/dshscan/issues/1)
 
-- [AmeKrance/anan-thermal-monitor#1](https://github.com/AmeKrance/anan-thermal-monitor/issues/1)
-- [AbcdefgXW/dsh-msg-hub#3](https://github.com/AbcdefgXW/dsh-msg-hub/issues/3)
-- [030611/dsh-verification-receipt#3](https://github.com/030611/dsh-verification-receipt/issues/3)
-- [0xsline/dsh-spotlight#5](https://github.com/0xsline/dsh-spotlight/issues/5)
+### Published artifact and install contract · 7
+
+- **closed** · [1na-ko/dsh-hdc-bridge#3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
+- **closed** · [6Mikao9/dsh-wsl-workspace#6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
+- **closed** · [3274375092/dsh-voice#2](https://github.com/3274375092/dsh-voice/issues/2)
+- **open** · [AmeKrance/anan-thermal-monitor#1](https://github.com/AmeKrance/anan-thermal-monitor/issues/1)
+- **open** · [AbcdefgXW/dsh-msg-hub#3](https://github.com/AbcdefgXW/dsh-msg-hub/issues/3)
+- **open** · [030611/dsh-verification-receipt#3](https://github.com/030611/dsh-verification-receipt/issues/3)
+- **open** · [0xsline/dsh-spotlight#5](https://github.com/0xsline/dsh-spotlight/issues/5)
+
+### Dependency graph and source/release alignment · 4
+
+- **open** · [lninghaha/dsh-coding-subscription-oauth#14](https://github.com/lninghaha/dsh-coding-subscription-oauth/issues/14)
+- **open** · [AbcdefgXW/dsh-msg-hub#1](https://github.com/AbcdefgXW/dsh-msg-hub/issues/1)
+- **open** · [AbcdefgXW/dsh-toolbox-web#1](https://github.com/AbcdefgXW/dsh-toolbox-web/issues/1)
+- **open** · [13071301808/dsh-composer-expand#1](https://github.com/13071301808/dsh-composer-expand/issues/1)
+
+The browser/web cases you may remember—[`dsh-web-ui#35`](https://github.com/zhu1090093659/dsh-web-ui/issues/35)
+and [`dsh-web-ui#71`](https://github.com/zhu1090093659/dsh-web-ui/issues/71)—are
+useful historical compatibility references and are closed, but they were not
+filed by Upstream Radar and are therefore not counted above. The maintained
+`dsh-browser` entries currently observed compatible are also not findings.
+
+See the [full classification and evidence index](docs/domain-reports.md) for
+validation level, impact, and the boundary between a confirmed runtime issue
+and a report that only needs maintainer confirmation.
 
 ## Run one check
 
 ```bash
-npx --yes upstream-radar@0.43.2 review dsh-plugin \
+npx --yes upstream-radar@0.43.3 review dsh-plugin \
   <package>@<version> \
   --dsh-version <dsh-version>
 ```

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.43.2
+    default: 0.43.3
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -98,7 +98,7 @@ FIRST EPSS estimated exploitation probability: 97.2% (percentile 100.0%)
 想立即检查一个真实发布的 DSH 插件，可以在空目录直接运行：
 
 ```bash
-npx --yes upstream-radar@0.43.2 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.43.3 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 它会直接输出简短的准入结论、覆盖情况、依赖数量、漏洞数量和下一步，不需要先
@@ -111,7 +111,7 @@ npx --yes upstream-radar@0.43.2 inspect dsh-feishu-bot@0.15.8 --deep
 npm 解析环境中目前无法建立完整依赖图：
 
 ```bash
-npx --yes upstream-radar@0.43.2 inspect \
+npx --yes upstream-radar@0.43.3 inspect \
   @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
   --deep --fail-on never
 ```
@@ -337,9 +337,9 @@ npm：     dsh-feishu-bot@0.15.8
 会继续显示为 `incomplete`，不会被当成已经确认的故障。
 
 ```bash
-npx --yes upstream-radar@0.43.2 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.43.3 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.43.2 observe ./targets.yml \
+npx --yes upstream-radar@0.43.3 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -377,7 +377,7 @@ Radar 会在三层目录内自动找到它；npm 名称和源码 manifest 不一
 想明确选择锁文件时再加 `--lockfile`：
 
 ```bash
-npx --yes upstream-radar@0.43.2 observe \
+npx --yes upstream-radar@0.43.3 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -400,7 +400,7 @@ workspace 边保留为未解析证据；不会安装或启动 DSH。
 会额外指定 `--package`：
 
 ```bash
-npx --yes upstream-radar@0.43.2 observe \
+npx --yes upstream-radar@0.43.3 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -679,7 +679,7 @@ cd my-dsh-plugin
 pnpm install --ignore-scripts
 
 # 把插件放进 DSH profile 前，先读取精确依赖图。
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
 ```
 
 这棵图会保留精确的 DSH 包版本，也会把未解析的可选 peer 明确显示出来；它不会加载生成的插件，也不会运行 lifecycle script。审查后，把下面这个完整 workflow 复制到 `.github/workflows/upstream-radar.yml`：
@@ -701,7 +701,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.2
+      - uses: MicroMilo/upstream-radar@v0.43.3
         with:
           fail-on: high
           fail-on-compatibility: breaking
@@ -712,7 +712,7 @@ Action 会自动识别唯一的 `pnpm-lock.yaml`，检查同一棵精确依赖�
 也可以直接检查一个真实发布的 DSH 包：
 
 ```bash
-npx --yes upstream-radar@0.43.2 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.43.3 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 这次检查的结论是 `REVIEW`：registry 完整性、签名、provenance 和 89 个已解析包都
@@ -725,7 +725,7 @@ npx --yes upstream-radar@0.43.2 inspect dsh-feishu-bot@0.15.8 --deep
 如果不想分别执行 `inspect`、打包和 `probe`，可以用一个命令完成一次 DSH 插件审查：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar review dsh-plugin \
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar review dsh-plugin \
   dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
@@ -891,7 +891,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -904,7 +904,7 @@ pnpm dlx --package=upstream-radar@0.43.2 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -930,7 +930,7 @@ pnpm run showcase:dsh-probe
 如果要比较多个 DSH 版本，可以使用矩阵入口：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -948,7 +948,7 @@ JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.43.2
+  - uses: MicroMilo/upstream-radar@v0.43.3
     with:
       fail-on: high
       # 可选：把确定性的 DSH/插件兼容性破坏也作为 CI 失败条件
@@ -962,7 +962,7 @@ steps:
 如果仓库还没有提交 Radar 配置，最短接入方式是省略 `config`、`pnpm-lock` 和 `npm-lock`。checkout 之后，Action 会自动使用唯一存在的 `pnpm-lock.yaml` 或 `package-lock.json`，生成临时的审查清单，再执行同一个 frozen 检查：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.43.2
+- uses: MicroMilo/upstream-radar@v0.43.3
   with:
     fail-on: high
 ```
@@ -972,7 +972,7 @@ steps:
 如果要在插件进入 DSH 前审查精确发布物，可以增加 `inspect-package`：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.43.2
+- uses: MicroMilo/upstream-radar@v0.43.3
   with:
     inspect-package: dsh-cloudflare-browser-run@0.1.1
     # review 是安全默认值；只有允许覆盖不完整时才使用 block
@@ -984,7 +984,7 @@ steps:
 如果仓库只有 pnpm 锁文件，还没有提交 Radar 配置，可以让 Action 在同一个 job 中生成配置；可直接复制[pnpm workflow 示例](../examples/github-actions/upstream-radar-pnpm.yml)：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.43.2
+- uses: MicroMilo/upstream-radar@v0.43.3
   with:
     pnpm-lock: pnpm-lock.yaml
     fail-on: high
@@ -998,7 +998,7 @@ npm 项目可以改用 `npm-lock: package-lock.json`；`pnpm-lock` 和 `npm-lock
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -1006,7 +1006,7 @@ pnpm dlx --package=upstream-radar@0.43.2 upstream-radar radar check \
 如果还要检查一个已发布插件能否跨多个 DSH 版本加载，可以增加三个 input：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.43.2
+- uses: MicroMilo/upstream-radar@v0.43.3
   id: radar
   with:
     config: upstream-radar.config.json

--- a/docs/domain-reports.md
+++ b/docs/domain-reports.md
@@ -1,0 +1,453 @@
+# Upstream Radar domain reports
+
+> Snapshot checked on 2026-08-24. This index covers the reports filed by
+> Upstream Radar, not every issue that mentions DSH.
+
+## 对当前项目的借鉴意义
+
+这批报告证明我们的 domain 不是“找一条有风险的依赖”，而是核对三层真实关系：
+
+1. DSH 宿主版本与插件声明、运行时导入是否一致。
+2. 用户真正拿到的 npm 发布物能否被可靠解析、安装并进入 DSH。
+3. 源码、发布版本、lockfile 和依赖图是否足够准确，让持续监控有东西可比。
+
+因此，报告中的“开放”不等于“插件有漏洞”，“需要确认”也不等于“插件不兼容”。
+只有真实运行失败，才可以称为已复现的不兼容；发布物和依赖图问题则分别标成安装
+契约问题和观测可信度问题。
+
+### 1. 可迁移的 drift 模式
+
+- **宿主契约漂移**：插件代码实际导入 DSH `rc.2`，但发布包只声明 `rc.6`；代码可能
+  偶然加载，严格安装器却会拒绝，造成“能跑但契约不成立”。
+- **发布物漂移**：仓库代码、README 和 npm tarball 指向不同版本，或者 tarball 本身
+  无法解析。用户照着 README 得不到作者声称的修复。
+- **安装边界漂移**：`prepare`、`postinstall` 或 native build 在 DSH 接纳插件前执行。
+  这不是恶意代码结论，但它改变了安装所需的权限、工具链和网络边界。
+- **图谱不可观测**：package-lock 根版本落后，或宿主依赖指向未发布包。此时漏洞“未
+  发现”没有意义，因为我们连完整的上下游集合都没有建立起来。
+
+### 2. 对当前项目迭代的建议
+
+- 把“动态复现的运行失败”与“静态发现的契约/安装/图谱问题”分开评分和措辞。
+- 将 `exact artifact + DSH version + Node/runtime + observed path` 作为每一条报告的
+  最小证据包。
+- 将 dshscan 的 peer-range mismatch、Sanqi 的未发布宿主链、anan 的坏 tarball 和
+  dsh-web-ui 的 Apply/boot 崩溃作为 benchmark/gold case 候选。
+- 对源码、README、package.json、lockfile、npm metadata 建立同一份 IR；只要其中一方
+  不能对齐，就输出“监控覆盖不完整”，不要输出“安全”。
+
+### 3. 覆盖边界与 residual risk
+
+本轮维护池有 100 个目录条目：96 个有可执行发布物，74 个已观测兼容，22 个仍需
+复核，0 个已复现为插件不兼容，4 个只有源码。browser/web 相关条目不是全部失败：
+维护池中的 `anweat/dsh-browser` 与 `dsh-builtin-browser` 已观测兼容；
+`Lum1104/dsh-browser` 只有源码，不能据此判断坏或好。
+
+`dsh-web-ui#35` 与 `#71` 是生态中的历史 browser/web 兼容性对照，均已关闭，但不是
+Upstream Radar 提出的报告。当前 13 条列表只统计我们的 maintainer-facing reports。
+
+### 4. Benchmark / gold case 候选价值
+
+- **适合**：dsh-web-ui#35 的“Apply 后 boot 崩溃”、dshscan#1 的“运行时导入与 peer
+  range 不一致”、Sanqi#5 的“宿主依赖链无法解析”、anan#1 的“精确 tarball 无法解析”。
+  它们分别覆盖动态运行失败、契约漂移、图谱不完整和发布物损坏。
+- **不适合直接当作漏洞样本**：hdc、wsl、voice、msg-hub、verification-receipt、
+  spotlight 的安装脚本报告。它们是安装边界证据，除非在受限环境中复现用户可见的
+  安装或加载失败，否则不应包装成漏洞。
+
+## 逐项报告
+
+## 问题一：DSH 宿主依赖链无法建立（Sanqi）
+
+### 问题说明
+
+精确发布物 `@sanqi-normal/dsh-webui-market-plugin@0.5.4` 的干净解析会走到未发布的
+`@deepseek-ai/dsh-compact@^0.0.1-rc.1`，因此无法建立完整的 DSH 宿主依赖图。
+
+### 为什么有危害
+
+用户可以安装到一个表面存在、但依赖链无法完整解析的插件；监控器也可能因为图不完整
+而漏掉真实依赖和漏洞。这里不能直接归责给插件作者，因为缺失包可能是 DSH 宿主发布契约
+的问题。
+
+### 证据
+
+- [公开 Issue #5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
+- [本地依赖解析报告](../examples/dsh/reports/sanqi-market-plugin-dependency-resolution.md)
+- 证据中的结果：`review / incomplete`，registry 返回 `404 Not Found`。
+
+### 验证结果
+
+源码与精确 npm tarball 的 scripts-disabled 解析已验证；没有安装或执行插件业务代码。
+修复后的 `0.5.5` 已重新解析为完整图并验证通过。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #5 已关闭，维护者通过宿主依赖范围和发布物修复覆盖了同一根因；当前不需要重复
+提交 PR。
+
+### 修复建议
+
+暂不提出新 PR。把该案例保留为“宿主依赖未发布 → 完整图不可建立 → 修复后重新验证”的
+gold case，并要求插件发布 CI 做一次 scripts-disabled 的 registry 解析。
+
+## 问题二：运行时使用的 DSH 版本超出 peer contract（dshscan）
+
+### 问题说明
+
+`@shaoshi/dshscan@0.5.0` 声明 `@deepseek-ai/dsh-tools: 0.1.0-rc.6`，但在 DSH
+`0.1.1-rc.2` 中实际解析并被运行时导入的是 `0.1.1-rc.2`。插件加载成功，然而发布包
+没有声明它实际工作的 DSH 版本边界。
+
+### 为什么有危害
+
+严格包管理器和兼容性工具可能因为 peer range 不匹配而拒绝安装；维护者也无法从包元数据
+判断 `rc.2` 是正式支持、偶然可用，还是未测试。
+
+### 证据
+
+- [公开 Issue #1](https://github.com/shaoshi20/dshscan/issues/1)
+- 精确包 SHA-256：`db62d1fb00272fd174cd6d8650a432a25a16103ec11b4f1a4bc78d6c31d70dc5`
+- 运行时：DSH `0.1.1-rc.2`、Node `22.23.2`、Linux x64。
+
+### 验证结果
+
+已在隔离环境安装并加载精确发布物；这是动态“加载成功 + 契约不一致”，不是动态崩溃。
+Web 业务功能尚未完整验证，因此不能扩大成“全部兼容”。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #1 仍开放，页面当前没有关联 PR；没有发现其他 PR 覆盖 peer range 与运行时导入的
+同一根因。
+
+### 修复建议
+
+先确认再提 PR。若维护者确认支持 `rc.2`，应更新 peer range 并补一条对应 DSH 的加载测试；
+若只支持 `rc.6`，应让报告和运行矩阵明确显示该边界。
+
+## 问题三：传递依赖在安装时执行宿主外部命令（hdc）
+
+### 问题说明
+
+`dsh-hdc-bridge@0.7.2` 的精确发布物会到达 `@deveco/deveco-cli@1.3.0`，该依赖声明
+`postinstall` 和 `prepare: husky` 等 lifecycle 行为。
+
+### 为什么有危害
+
+普通安装可能在 DSH 接纳插件之前执行脚本，要求额外命令、网络或本地权限；这会导致安装
+在不同机器上表现不同，也扩大了插件进入 Agent 前的信任边界。它不是恶意代码结论。
+
+### 证据
+
+- [公开 Issue #3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
+- 精确依赖图中 `@deveco/deveco-cli@1.3.0` 的 lifecycle metadata。
+
+### 验证结果
+
+本轮是精确发布物的静态依赖/脚本观察，脚本被禁用，没有把外部命令实际执行当成插件故障。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #3 已关闭；维护者在后续版本移除了相关可选依赖。当前没有需要重复提交的 PR。
+
+### 修复建议
+
+暂不提出新 PR。将“依赖树中存在安装脚本”作为需要解释的安装边界信号，只有动态复现
+安装失败或未声明权限要求时才升级为兼容性事件。
+
+## 问题四：native 依赖在安装阶段构建（wsl）
+
+### 问题说明
+
+`dsh-wsl-workspace@0.2.3` 的发布物到达 `koffi@3.1.6`，安装时可能选择或构建 native
+addon。
+
+### 为什么有危害
+
+没有编译器、匹配的 Node ABI 或支持平台的用户会在安装阶段失败；即使最终能安装，构建
+行为也应被作者明确声明，而不是让 DSH 用户从日志中猜。
+
+### 证据
+
+- [公开 Issue #6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
+- 精确发布物依赖路径：`dsh-wsl-workspace@0.2.3 → koffi@3.1.6`。
+
+### 验证结果
+
+已确认安装边界和 native 构建入口；没有把缺少某个平台工具链的观察直接称为插件运行
+不兼容。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #6 已关闭，维护者补充了平台/安装说明；没有新的同根因 PR 需要我们追加。
+
+### 修复建议
+
+暂不提出新 PR。将 Node ABI、操作系统和工具链记录为动态运行矩阵的环境维度。
+
+## 问题五：prepare 在消费者安装时重新构建（voice）
+
+### 问题说明
+
+`dsh-voice@0.2.5` 的源码和精确 npm 发布物都声明 `prepare: npm run build`，因此消费者
+安装时可能重新运行项目构建。
+
+### 为什么有危害
+
+发布物如果已经包含运行所需产物，就不应要求用户重复构建；重复构建会引入 Node、包管理器、
+网络和脚本权限差异，最终可能出现“作者机器能装，用户机器不能装”。
+
+### 证据
+
+- [公开 Issue #2](https://github.com/3274375092/dsh-voice/issues/2)
+- 源码 manifest 与精确发布物 manifest 的 `prepare` 字段一致。
+
+### 验证结果
+
+这是源码与发布物的静态一致性证据；脚本没有在本轮只读检查中执行。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #2 已关闭，维护者处理了发布/构建边界；没有发现仍需我们提交的同根因 PR。
+
+### 修复建议
+
+暂不提出新 PR。把“发布时构建、消费时只加载”作为 DSH 插件发布检查项。
+
+## 问题六：精确 npm tarball 无法解析（anan）
+
+### 问题说明
+
+`anan-thermal-monitor@1.0.4` 的公开 npm archive 被标准 tar reader 拒绝，报
+`unsupported PAX size override`。
+
+### 为什么有危害
+
+用户无法可靠提取、检查或安装作者发布的精确版本；我们也无法建立可信依赖图。这里是
+发布物完整性问题，不是恶意行为或 CVE 指控。
+
+### 证据
+
+- [公开 Issue #1](https://github.com/AmeKrance/anan-thermal-monitor/issues/1)
+- registry 精确包 `anan-thermal-monitor@1.0.4`，结果为 `npm-archive-invalid`。
+
+### 验证结果
+
+独立 tar reader 对公开归档的解析失败已复现；没有进入插件代码执行阶段。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #1 仍开放，页面当前没有关联 PR；没有发现相同根因的修复覆盖。
+
+### 修复建议
+
+值得维护者处理，但不需要我们代写 PR：重新发布标准 npm archive，并在发布前用独立 reader
+验证文件列表和可提取性。
+
+## 问题七：传递依赖带有 protobufjs postinstall（msg-hub）
+
+### 问题说明
+
+`dsh-msg-hub@0.1.8` 的精确依赖图到达 `protobufjs@7.6.5`，其 metadata 声明
+`postinstall: node scripts/postinstall`。
+
+### 为什么有危害
+
+安装脚本会在 DSH 接纳插件前运行，改变安装所需的执行权限和可观测行为；目前证据只说明
+脚本存在，不能说明它恶意或必然造成运行失败。
+
+### 证据
+
+- [公开 Issue #3](https://github.com/AbcdefgXW/dsh-msg-hub/issues/3)
+- 路径：`dsh-msg-hub@0.1.8 → protobufjs@7.6.5`。
+
+### 验证结果
+
+脚本被禁用的精确依赖审查已完成；没有执行 `postinstall`，也没有动态证明它会破坏 DSH。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #3 仍开放，且与该仓库的 lockfile 元数据 Issue #1 是两个不同根因；没有发现 PR 覆盖
+安装脚本路径。
+
+### 修复建议
+
+先确认再提 PR。作者应判断脚本是否是运行必需；若不是，移除依赖路径；若是，应记录输入、
+输出和脚本关闭时的加载行为。
+
+## 问题八：prepare 在安装时执行 pnpm build（verification-receipt）
+
+### 问题说明
+
+`dsh-verification-receipt@0.1.0` 的源码与发布物都声明 `prepare: pnpm run build`。
+
+### 为什么有危害
+
+用户安装时会进入项目构建路径，而不是只解压并加载已发布产物；缺失 pnpm、编译工具或网络
+时可能安装失败，且 DSH 尚未有机会限制插件行为。
+
+### 证据
+
+- [公开 Issue #3](https://github.com/030611/dsh-verification-receipt/issues/3)
+- 源码和精确 tarball 的 `prepare` 字段均为 `pnpm run build`。
+
+### 验证结果
+
+已完成源码/发布物静态对齐；脚本没有在只读检查中执行，因此尚未宣称安装失败。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #3 仍开放，页面当前没有关联 PR；没有发现同根因覆盖。
+
+### 修复建议
+
+值得维护者确认。优先在发布工作流构建并发布产物；若必须保留 prepare，增加关闭脚本后的
+加载测试并说明输入输出。
+
+## 问题九：prepare 在安装时执行（dsh-spotlight）
+
+### 问题说明
+
+`dsh-spotlight@0.0.2` 的精确发布物声明安装阶段的 prepare 脚本。
+
+### 为什么有危害
+
+这会把构建或其他代码执行引入 DSH 接纳前的安装边界，导致不同机器上的 Node、工具链和
+网络条件影响结果；单凭脚本存在不能推断恶意。
+
+### 证据
+
+- [公开 Issue #5](https://github.com/0xsline/dsh-spotlight/issues/5)
+- 精确 npm 发布物的 manifest lifecycle metadata。
+
+### 验证结果
+
+这是发布物静态证据；没有执行 prepare，也没有动态复现 DSH 加载失败。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #5 仍开放，页面当前没有关联 PR；没有发现同根因覆盖。
+
+### 修复建议
+
+先确认再提 PR。作者应把构建移到发布阶段，或明确说明 prepare 必须执行的环境与边界。
+
+## 问题十：README、源码版本与 npm latest 不一致（coding-subscription-oauth）
+
+### 问题说明
+
+仓库和 README 宣传 `0.6.1`，但 npm latest 和 GitHub Release 仍只有 `0.6.0`；用户照文档
+安装不到文档声称的修复版本。
+
+### 为什么有危害
+
+这是最直接的“修复已经存在但用户拿不到”问题，也会让依赖监控把源码版本和用户实际运行版本
+错误地对齐。
+
+### 证据
+
+- [公开 Issue #14](https://github.com/lninghaha/dsh-coding-subscription-oauth/issues/14)
+- registry latest、GitHub Release、README 与 `package.json` 的版本对比。
+
+### 验证结果
+
+源码/registry 元数据差异已复核；`0.6.0` 精确包在 DSH `0.1.1-rc.2` 可加载，但 Web
+功能没有完整验证，因此不扩大为“全部功能兼容”。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #14 仍开放，页面当前没有关联 PR；没有发现发布 `0.6.1` 或修正文档的覆盖。
+
+### 修复建议
+
+值得提出一个聚焦的发布修复：发布 `0.6.1` 并创建对应 release，或先把 README 改回可安装
+版本；同时明确 DSH peer range 的真实支持范围。
+
+## 问题十一：package-lock 根版本落后（msg-hub）
+
+### 问题说明
+
+`dsh-msg-hub` 的 `package.json` 已到 `0.1.7`，但 `package-lock.json` 根 metadata 仍报告
+`0.1.1`，导致源码版本和锁文件观察点不一致。
+
+### 为什么有危害
+
+监控器无法确定 lockfile 对应哪个发布状态，可能把旧图当成当前图，漏报依赖变化或误报版本
+变化；这首先是可观测性问题，不是运行时漏洞。
+
+### 证据
+
+- [公开 Issue #1](https://github.com/AbcdefgXW/dsh-msg-hub/issues/1)
+- `package.json` 与 `package-lock.json` 根节点版本差异。
+
+### 验证结果
+
+源码与 lockfile 的静态对比已完成；没有安装或执行插件代码。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #1 仍开放，页面当前没有关联 PR；与 Issue #3 的 postinstall 发现不构成覆盖关系。
+
+### 修复建议
+
+值得提出一个小 PR：重新生成并提交与当前源码版本一致的 lockfile，并在发布 CI 中检查根
+版本和 package.json 对齐。
+
+## 问题十二：package-lock 根版本落后（toolbox-web）
+
+### 问题说明
+
+`dsh-toolbox-web` 的 package-lock 根 metadata 仍报告 `0.1.1`，而当前发布/源码版本为
+`0.1.9`，因此无法把锁定依赖图准确归属到当前插件版本。
+
+### 为什么有危害
+
+上游依赖更新后，Radar 可能读取旧图，无法可靠回答“哪些插件受影响”；作者也无法复现
+监控报告对应的依赖集合。
+
+### 证据
+
+- [公开 Issue #1](https://github.com/AbcdefgXW/dsh-toolbox-web/issues/1)
+- package.json 与 package-lock 根 metadata 的版本差异。
+
+### 验证结果
+
+已完成静态版本对比；未安装或执行插件。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #1 仍开放，页面当前没有关联 PR；没有发现同根因覆盖。
+
+### 修复建议
+
+值得提出一个聚焦的 lockfile 更新 PR，并在 CI 中增加根版本一致性检查。
+
+## 问题十三：package-lock 根版本落后（composer-expand）
+
+### 问题说明
+
+`dsh-composer-expand` 的 `package.json` 为 `0.1.2`，而 package-lock 根 metadata 仍为
+`0.1.0`。
+
+### 为什么有危害
+
+这是同一类图谱可信度问题：依赖路径可能来自旧发布状态，持续漏洞监控和上下游反向索引
+都可能建立在错误版本上。
+
+### 证据
+
+- [公开 Issue #1](https://github.com/13071301808/dsh-composer-expand/issues/1)
+- package.json 与 package-lock 根 metadata 的版本差异。
+
+### 验证结果
+
+已完成源码/lockfile 静态对比；没有安装或执行插件。
+
+### 现有 issue/PR 覆盖状况
+
+Issue #1 仍开放，页面当前没有关联 PR；没有发现同根因覆盖。
+
+### 修复建议
+
+值得提出一个小 PR：重新生成 lockfile 并在发布前校验根版本。修复后再用精确发布物重建
+依赖图，不要只凭源码仓库状态关闭观察项。

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -210,7 +210,7 @@ When the native DSH adapter is running, it additionally verifies the exact `@dee
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -224,7 +224,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.43.2
+  - uses: MicroMilo/upstream-radar@v0.43.3
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -257,7 +257,7 @@ It packs without lifecycle scripts, runs one temporary DSH profile per version, 
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -271,7 +271,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```

--- a/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
+++ b/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
@@ -19,7 +19,7 @@ From a clean checkout, the finding is reproducible without installing or
 executing the plugin:
 
 ```bash
-npx --yes upstream-radar@0.43.2 scan . --json
+npx --yes upstream-radar@0.43.3 scan . --json
 ```
 
 The current static scan reports:

--- a/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
+++ b/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
@@ -43,5 +43,5 @@ graph, the unresolved peer boundary, the vulnerability result, and the two
 remaining review actions in one report.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.43.2`. Review the Draft PR before relying on the fallback
+`upstream-radar@0.43.3`. Review the Draft PR before relying on the fallback
 resolver from npm.

--- a/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
+++ b/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
@@ -21,7 +21,7 @@ Reproduce it with:
 
 ```bash
 npm pack --ignore-scripts --pack-destination /tmp dsh-feishu-bot@0.15.4
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar probe dsh-matrix \
   /tmp/dsh-feishu-bot-0.15.4.tgz \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```

--- a/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
+++ b/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
@@ -8,7 +8,7 @@ graph without installing anything.
 ## Reproduction
 
 ```bash
-npx --yes upstream-radar@0.43.2 scan \
+npx --yes upstream-radar@0.43.3 scan \
   https://github.com/2008924/dsh-progress-viz \
   --fail-on never
 ```

--- a/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
+++ b/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
@@ -13,11 +13,11 @@ No DSH profile, plugin code, lifecycle script, or LLM was started.
 ## Commands
 
 ```bash
-npx --yes upstream-radar@0.43.2 scan \
+npx --yes upstream-radar@0.43.3 scan \
   https://github.com/ccch1mneyyy/dsh-TUI \
   --fail-on never
 
-npx --yes upstream-radar@0.43.2 inspect \
+npx --yes upstream-radar@0.43.3 inspect \
   npm:@deepseek-harness-tui/dsh-tui@0.8.0 \
   --deep --fail-on never
 ```

--- a/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
+++ b/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
@@ -8,7 +8,7 @@ release.
 ## Rechecked with the public CLI
 
 Each repository was cloned at its current public `main` commit and scanned with
-`upstream-radar@0.43.2`. No package was installed, loaded, or executed.
+`upstream-radar@0.43.3`. No package was installed, loaded, or executed.
 
 | Repository | Commit | `package.json` | `package-lock.json` root | Result |
 | --- | --- | ---: | ---: | --- |

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -40,7 +40,7 @@ The optional probe is load-only. It packs with `--ignore-scripts`, uses a tempor
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.2 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.43.3 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.2
+      - uses: MicroMilo/upstream-radar@v0.43.3
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/dsh-plugin-review-minimal.yml
+++ b/examples/github-actions/dsh-plugin-review-minimal.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.43.2
+        uses: MicroMilo/upstream-radar@v0.43.3
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/examples/github-actions/upstream-observer-minimal.yml
+++ b/examples/github-actions/upstream-observer-minimal.yml
@@ -53,7 +53,7 @@ jobs:
           llm_env_file="$RUNNER_TEMP/issue-locator.env"
           trap 'rm -f "$llm_env_file"' EXIT
           observe_args=(
-            npx --yes upstream-radar@0.43.2 observe "$repository"
+            npx --yes upstream-radar@0.43.3 observe "$repository"
             --ref "$ref"
             --state observations.json
             --report "$report"

--- a/examples/github-actions/upstream-radar-npm.yml
+++ b/examples/github-actions/upstream-radar-npm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.2
+      - uses: MicroMilo/upstream-radar@v0.43.3
         with:
           npm-lock: package-lock.json
           fail-on: high

--- a/examples/github-actions/upstream-radar-pnpm.yml
+++ b/examples/github-actions/upstream-radar-pnpm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.2
+      - uses: MicroMilo/upstream-radar@v0.43.3
         with:
           pnpm-lock: pnpm-lock.yaml
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.2
+      - uses: MicroMilo/upstream-radar@v0.43.3
         with:
           # The Action auto-detects one pnpm-lock.yaml or package-lock.json.
           fail-on: high

--- a/examples/github-actions/upstream-scan-minimal.yml
+++ b/examples/github-actions/upstream-scan-minimal.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           report="$RUNNER_TEMP/upstream-radar-scan.json"
-          npx --yes upstream-radar@0.43.2 scan \
+          npx --yes upstream-radar@0.43.3 scan \
             "$OBSERVER_REPOSITORY_INPUT" \
             --json --fail-on never > "$report"
           if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/examples/upstream-observer/README.md
+++ b/examples/upstream-observer/README.md
@@ -24,7 +24,7 @@ Replace it with the repositories your team depends on.
 For one repository, the shortest path skips YAML and lockfile configuration entirely:
 
 ```bash
-npx --yes upstream-radar@0.43.2 observe \
+npx --yes upstream-radar@0.43.3 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -35,7 +35,7 @@ Radar automatically chooses the committed `pnpm-lock.yaml` or
 the explicit form below adds `--package`:
 
 ```bash
-npx --yes upstream-radar@0.43.2 observe \
+npx --yes upstream-radar@0.43.3 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -75,9 +75,9 @@ Build one index from saved DSH plugin scan/review/config JSON, then give it to
 the observer:
 
 ```bash
-npx --yes upstream-radar@0.43.2 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.43.3 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.43.2 observe ./targets.yml \
+npx --yes upstream-radar@0.43.3 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -99,7 +99,7 @@ and run `pnpm run showcase:observer` to replay a real
 The scheduled workflow uses the checked-in index directly:
 
 ```bash
-npx --yes upstream-radar@0.43.2 observe ./targets.yml \
+npx --yes upstream-radar@0.43.3 observe ./targets.yml \
   --reverse-index ../dsh/first-batch/reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -126,7 +126,7 @@ Run it from any directory with the published CLI:
 
 ```bash
 export GITHUB_TOKEN='a read-only token with repository metadata access'
-npx --yes upstream-radar@0.43.2 observe \
+npx --yes upstream-radar@0.43.3 observe \
   /path/to/targets.yml \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md

--- a/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
+++ b/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
@@ -30,5 +30,5 @@ than silently monitoring the repository root. Local `workspace:` links remain
 explicitly unresolved; Radar does not guess their published versions.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.43.2`. Review the Draft PR before using the auto-discovery
+`upstream-radar@0.43.3`. Review the Draft PR before using the auto-discovery
 path from npm.

--- a/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
+++ b/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
@@ -14,12 +14,12 @@ The baseline was taken at the commit that produced the published `0.5.4`
 artifact, then the same state was checked against the current `master`:
 
 ```bash
-npx --yes upstream-radar@0.43.2 observe \
+npx --yes upstream-radar@0.43.3 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref aa5f4efc7827176cce27c73f73a2f42514da1ebf \
   --state observations.json --report baseline.md --json
 
-npx --yes upstream-radar@0.43.2 observe \
+npx --yes upstream-radar@0.43.3 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref master \
   --state observations.json --report repair.md --json

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -3,7 +3,7 @@
   "generatedAt": "2026-08-24T03:06:16.972Z",
   "producer": {
     "name": "upstream-radar",
-    "version": "0.43.2",
+    "version": "0.43.3",
     "repository": "https://github.com/MicroMilo/upstream-radar",
     "license": "Apache-2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "description": "Always-on dependency and compatibility monitoring for DeepSeek Harness plugins, including exact paths, upstream changes, and isolated install/load evidence.",
   "type": "module",
   "license": "Apache-2.0",

--- a/scripts/expand-awesome-dsh-cohort.mjs
+++ b/scripts/expand-awesome-dsh-cohort.mjs
@@ -8,6 +8,7 @@ import { promisify } from 'node:util'
 import { parseAwesomeDshCohort } from '../dist/src/dsh-directory-feed.js'
 import { parseDshInstallTargets } from '../dist/src/dsh-install-plan.js'
 import { parseNpmSpec } from '../dist/src/npm.js'
+import { resolveNpmReleaseTag } from '../dist/src/npm-release-channel.js'
 import { satisfiesSemverRange } from '../dist/src/semver.js'
 import { parseObserverConfigText } from '../dist/src/upstream-observer.js'
 
@@ -189,10 +190,10 @@ function githubHeaders(token) {
 async function verifyCandidate(item, input) {
   const [owner, repo] = item.repository.split('/')
   const repositoryApi = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
-  const npmApi = `https://registry.npmjs.org/${encodeURIComponent(item.npm)}/latest`
-  const [repositoryMetadataValue, npmManifestValue] = await Promise.all([
+  const npmApi = `https://registry.npmjs.org/${encodeURIComponent(item.npm)}`
+  const [repositoryMetadataValue, latestNpmManifestValue] = await Promise.all([
     fetchJson(repositoryApi, githubHeaders(input.token)),
-    fetchJson(npmApi, { accept: 'application/json' }),
+    fetchJson(`${npmApi}/latest`, { accept: 'application/json' }),
   ])
   const repositoryMetadata = object(repositoryMetadataValue, `${item.repository} metadata`)
   if (repositoryMetadata.archived === true || repositoryMetadata.disabled === true) throw new Error('repository is archived or disabled')
@@ -207,10 +208,14 @@ async function verifyCandidate(item, input) {
   const decoded = Buffer.from(source.content.replace(/\s+/g, ''), 'base64')
   if (decoded.length === 0 || decoded.length > MAX_MANIFEST_BYTES) throw new Error('source package.json is empty or exceeds the byte budget')
   const sourceManifest = object(JSON.parse(decoded.toString('utf8')), `${item.repository} package.json`)
-  const npmManifest = object(npmManifestValue, `${item.npm} latest manifest`)
+  const distTag = resolveNpmReleaseTag(sourceManifest)
+  const npmManifestValue = distTag === 'latest'
+    ? latestNpmManifestValue
+    : await fetchJson(`${npmApi}/${encodeURIComponent(distTag)}`, { accept: 'application/json' })
+  const npmManifest = object(npmManifestValue, `${item.npm} ${distTag} manifest`)
   if (sourceManifest.name !== item.npm || npmManifest.name !== item.npm) throw new Error('catalog, source and npm package names do not align')
   const sourceVersion = string(sourceManifest.version, `${item.repository} source version`, 256)
-  const selectedVersion = string(npmManifest.version, `${item.npm} latest version`, 256)
+  const selectedVersion = string(npmManifest.version, `${item.npm} ${distTag} version`, 256)
   if (!EXACT_VERSION.test(sourceVersion) || !EXACT_VERSION.test(selectedVersion)) throw new Error('source or npm version is not exact')
   const publishedRepository = normalizeRepository(npmManifest.repository)
   if (publishedRepository?.toLowerCase() !== item.repository.toLowerCase()) throw new Error('npm repository metadata does not point to the catalog repository')
@@ -244,7 +249,7 @@ async function verifyCandidate(item, input) {
     category: item.category,
     packagePath,
     sourceCoordinateAtSelection: { name: item.npm, version: sourceVersion },
-    distribution: { kind: 'npm', name: item.npm, selectedVersion, distTag: 'latest' },
+    distribution: { kind: 'npm', name: item.npm, selectedVersion, distTag },
     signals: {
       downloads: item.downloads,
       stars: item.stars,

--- a/src/npm-release-channel.ts
+++ b/src/npm-release-channel.ts
@@ -1,0 +1,34 @@
+const SAFE_NPM_DIST_TAG = /^[a-z][a-z0-9._-]{0,127}$/
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+  return value as Record<string, unknown>
+}
+
+function validateTag(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty lowercase npm dist-tag`)
+  }
+  if (!SAFE_NPM_DIST_TAG.test(value)) throw new Error(`${label} must be a lowercase npm dist-tag`)
+  return value
+}
+
+/**
+ * Select the npm stream that a maintainer intends users to consume.
+ *
+ * An explicit observer setting is policy and therefore wins. Otherwise the
+ * current source manifest may declare its publishing stream. Falling back to
+ * `latest` is safe only when neither source provides a tag; malformed source
+ * metadata remains incomplete evidence instead of silently selecting a
+ * different artifact.
+ */
+export function resolveNpmReleaseTag(manifest: unknown, explicitTag?: string): string {
+  if (explicitTag !== undefined) return validateTag(explicitTag, 'configured npm release tag')
+  const source = record(manifest)
+  if (source === undefined) throw new Error('npm package manifest must be an object')
+  if (source.publishConfig === undefined) return 'latest'
+  const publishConfig = record(source.publishConfig)
+  if (publishConfig === undefined) throw new Error('package.json publishConfig must be an object')
+  if (publishConfig.tag === undefined) return 'latest'
+  return validateTag(publishConfig.tag, 'package.json publishConfig.tag')
+}

--- a/src/upstream-observer.ts
+++ b/src/upstream-observer.ts
@@ -6,6 +6,7 @@ import { findReverseDependencyImpacts, type ReverseDependencyImpact, type Revers
 import type { DshLoadMatrixReport } from './dsh-probe.js'
 import { parseNpmLockGraph, parsePnpmLockGraph } from './graph.js'
 import { parsePackageManifestSnapshot } from './inventory.js'
+import { resolveNpmReleaseTag } from './npm-release-channel.js'
 import { buildUpstreamDownstreamIR, parseUpstreamDownstreamIR, type UpstreamDownstreamIR } from './upstream-alignment.js'
 import type { DependencyGraph, PackageManifestSnapshot } from './radar-types.js'
 import type {
@@ -1151,7 +1152,7 @@ export class UpstreamObserverClient implements ObserverSource {
     }
     const packageObservation = targetValue.observeNpm === false
       ? undefined
-      : await this.fetchNpmObservation(packageName, targetValue.packageTag)
+      : await this.fetchNpmObservation(packageName, resolveNpmReleaseTag(rawManifest, targetValue.packageTag))
     if (targetValue.observeNpm !== false && packageObservation === undefined) {
       warnings.push(`${packageName} was not found on the configured npm registry`)
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.43.2'
+export const TOOL_VERSION = '0.43.3'

--- a/test/npm-release-channel.test.ts
+++ b/test/npm-release-channel.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { resolveNpmReleaseTag } from '../src/npm-release-channel.js'
+
+describe('npm release channel selection', () => {
+  it('prefers an explicit observer tag over package metadata', () => {
+    assert.equal(resolveNpmReleaseTag({ publishConfig: { tag: 'alpha' } }, 'next'), 'next')
+  })
+
+  it('uses the source manifest publish tag when no explicit tag is configured', () => {
+    assert.equal(resolveNpmReleaseTag({ publishConfig: { tag: 'alpha' } }), 'alpha')
+  })
+
+  it('defaults to latest only when the source declares no release channel', () => {
+    assert.equal(resolveNpmReleaseTag({ name: 'demo-plugin', version: '1.0.0' }), 'latest')
+  })
+
+  it('rejects malformed declared tags instead of silently observing latest', () => {
+    assert.throws(
+      () => resolveNpmReleaseTag({ publishConfig: { tag: 'Alpha Channel' } }),
+      /lowercase npm dist-tag/,
+    )
+    assert.throws(
+      () => resolveNpmReleaseTag({ publishConfig: { tag: 42 } }),
+      /non-empty lowercase npm dist-tag/,
+    )
+  })
+})

--- a/test/release-preflight.test.ts
+++ b/test/release-preflight.test.ts
@@ -23,7 +23,7 @@ describe('release preflight', () => {
       checks: Array<{ status: string }>
     }
     assert.equal(report.schema, 'upstream-radar.release-preflight/v1alpha1')
-    assert.equal(report.version, '0.43.2')
+    assert.equal(report.version, '0.43.3')
     assert.equal(report.passed, true)
     assert.equal(report.publishedCheck, false)
     assert.ok(report.checks.length >= 4)

--- a/test/upstream-observer.test.ts
+++ b/test/upstream-observer.test.ts
@@ -296,7 +296,11 @@ targets:
         const url = String(input)
         if (url.includes('/commits/main')) return new Response(JSON.stringify({ sha: 'commit-1' }), { status: 200 })
         if (url.endsWith('/commit-1/plugin/package.json')) {
-          return new Response(JSON.stringify({ name: 'dsh-demo', version: '2.0.0-rc.1' }), { status: 200 })
+          return new Response(JSON.stringify({
+            name: 'dsh-demo',
+            version: '3.0.0-alpha.1',
+            publishConfig: { tag: 'alpha' },
+          }), { status: 200 })
         }
         if (url.startsWith('https://registry.npmjs.org/')) {
           return new Response(JSON.stringify({
@@ -327,6 +331,76 @@ targets:
     assert.equal(result.package?.version, '2.0.0-rc.1')
     assert.equal(result.package?.distTag, 'next')
     assert.equal(result.package?.integrity, 'sha512-next')
+  })
+
+  it('observes the source-declared npm release channel when no target override exists', async () => {
+    const source = new UpstreamObserverClient({
+      fetch: async input => {
+        const url = String(input)
+        if (url.includes('/commits/main')) return new Response(JSON.stringify({ sha: 'commit-1' }), { status: 200 })
+        if (url.endsWith('/commit-1/plugin/package.json')) {
+          return new Response(JSON.stringify({
+            name: 'dsh-demo',
+            version: '2.0.0-alpha.2',
+            publishConfig: { tag: 'alpha' },
+          }), { status: 200 })
+        }
+        if (url.startsWith('https://registry.npmjs.org/')) {
+          return new Response(JSON.stringify({
+            'dist-tags': { latest: '1.0.0', alpha: '2.0.0-alpha.2' },
+            versions: {
+              '1.0.0': { dist: { integrity: 'sha512-latest' } },
+              '2.0.0-alpha.2': { dist: { integrity: 'sha512-alpha' } },
+            },
+          }), { status: 200 })
+        }
+        if (url.endsWith('/commit-1/plugin/pnpm-lock.yaml')) {
+          return new Response([
+            "lockfileVersion: '9.0'",
+            '',
+            'importers:',
+            '  plugin: {}',
+            '',
+            'packages: {}',
+            '',
+            'snapshots: {}',
+            '',
+          ].join('\n'), { status: 200 })
+        }
+        throw new Error(`unexpected request: ${url}`)
+      },
+    })
+    const result = await source.observe(target, '2026-08-21T00:00:00.000Z')
+    assert.equal(result.package?.version, '2.0.0-alpha.2')
+    assert.equal(result.package?.distTag, 'alpha')
+    assert.equal(result.package?.integrity, 'sha512-alpha')
+  })
+
+  it('does not fall back to latest when a declared release channel is unavailable', async () => {
+    const source = new UpstreamObserverClient({
+      fetch: async input => {
+        const url = String(input)
+        if (url.includes('/commits/main')) return new Response(JSON.stringify({ sha: 'commit-1' }), { status: 200 })
+        if (url.endsWith('/commit-1/plugin/package.json')) {
+          return new Response(JSON.stringify({
+            name: 'dsh-demo',
+            version: '2.0.0-alpha.1',
+            publishConfig: { tag: 'alpha' },
+          }), { status: 200 })
+        }
+        if (url.startsWith('https://registry.npmjs.org/')) {
+          return new Response(JSON.stringify({
+            'dist-tags': { latest: '1.0.0' },
+            versions: { '1.0.0': { dist: { integrity: 'sha512-latest' } } },
+          }), { status: 200 })
+        }
+        throw new Error(`unexpected request: ${url}`)
+      },
+    })
+    await assert.rejects(
+      source.observe(target, '2026-08-21T00:00:00.000Z'),
+      /no alpha manifest/,
+    )
   })
 
   it('observes GitHub-only source and lockfile evidence without querying npm', async () => {


### PR DESCRIPTION
## Outcome

Radar now observes the npm stream that maintainers declare instead of silently assuming `latest`.

- An explicit observer `package-tag` remains authoritative.
- Otherwise the observer and cohort importer read the bounded `package.json#publishConfig.tag` value.
- Packages with no declaration still use `latest`.
- Invalid or unavailable declared tags fail as incomplete evidence; Radar does not fall back to a different artifact.

## Concrete regression

`dsh-codex-connect` publishes through `alpha`. npm currently maps `latest` to `0.1.0-alpha.4.14` and `alpha` to `0.1.0-alpha.4.18`. Before this patch Radar selected `.4.14`. A live check with the patched observer and no explicit tag selected `alpha@0.1.0-alpha.4.18` including its exact integrity and tarball URL.

## Verification

- Targeted release-channel and observer tests: 28 passed.
- Clean detached worktree: 354 tests passed, 0 failed.
- Live GitHub plus npm observation selected `dsh-codex-connect@0.1.0-alpha.4.18` via `alpha`.

Refs #104