### PR TITLE
Keep compatibility observations retryable and current

### DIFF
--- a/.github/workflows/upstream-observer.yml
+++ b/.github/workflows/upstream-observer.yml
@@ -283,7 +283,8 @@ jobs:
             examples/dsh/install-observer/targets.json \
             compatibility-ledger.json \
             feeds/dsh-plugin-compatibility.json \
-            feeds/dsh-plugin-compatibility.md
+            feeds/dsh-plugin-compatibility.md \
+            observations.json
 
       - name: Keep compatibility evidence artifacts
         if: always()

--- a/docker/dsh-install-observer.Dockerfile
+++ b/docker/dsh-install-observer.Dockerfile
@@ -4,7 +4,12 @@ ARG NODE_MAJOR=22
 FROM node:${NODE_MAJOR}-bookworm-slim AS build
 
 RUN corepack enable \
-  && corepack prepare pnpm@11.3.0 --activate
+  && attempt=1 \
+  && until corepack prepare pnpm@11.3.0 --activate; do \
+    if [ "$attempt" -ge 3 ]; then exit 1; fi; \
+    sleep "$((attempt * 2))"; \
+    attempt="$((attempt + 1))"; \
+  done
 
 WORKDIR /build
 COPY package.json pnpm-lock.yaml tsconfig.json .npmrc ./

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -1,6 +1,6 @@
 {
   "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha1",
-  "generatedAt": "2026-08-24T04:47:38.600Z",
+  "generatedAt": "2026-08-24T04:54:24.120Z",
   "producer": {
     "name": "upstream-radar",
     "version": "0.43.3",
@@ -42,7 +42,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@1e0zj/dsh-plugin-mall",
-        "selectedVersion": "0.4.7",
+        "selectedVersion": "0.4.14",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -300,7 +300,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@anionex/dsh-turn-rewind",
-        "selectedVersion": "0.1.1",
+        "selectedVersion": "0.1.2",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -472,7 +472,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-remote-plugin",
-        "selectedVersion": "0.6.10",
+        "selectedVersion": "0.6.12",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -515,7 +515,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-context",
-        "selectedVersion": "0.25.3",
+        "selectedVersion": "0.29.0",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -601,7 +601,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-tavern",
-        "selectedVersion": "1.9.1",
+        "selectedVersion": "1.9.2",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -773,7 +773,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-taskboard",
-        "selectedVersion": "0.4.5",
+        "selectedVersion": "0.5.0",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -902,7 +902,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@dickpy/dsh-imagegen",
-        "selectedVersion": "1.0.20",
+        "selectedVersion": "1.2.1",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -988,7 +988,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dshmarket",
-        "selectedVersion": "1.19.0",
+        "selectedVersion": "1.21.2",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -1074,7 +1074,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-plugin-wallpaper-engine",
-        "selectedVersion": "0.5.1",
+        "selectedVersion": "0.6.3",
         "distTag": "latest"
       },
       "status": "needs-review",
@@ -1117,7 +1117,7 @@
       "distribution": {
         "kind": "npm",
         "name": "deepseek-harness-wallet",
-        "selectedVersion": "0.3.1",
+        "selectedVersion": "0.3.2",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -1203,7 +1203,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-remote",
-        "selectedVersion": "0.8.7",
+        "selectedVersion": "0.8.8",
         "distTag": "latest"
       },
       "status": "needs-review",
@@ -1289,8 +1289,8 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-codex-connect",
-        "selectedVersion": "0.1.0-alpha.4.14",
-        "distTag": "latest"
+        "selectedVersion": "0.1.0-alpha.4.18",
+        "distTag": "alpha"
       },
       "status": "needs-review",
       "cells": [
@@ -1435,7 +1435,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-cost-meter",
-        "selectedVersion": "1.5.38",
+        "selectedVersion": "1.5.42",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -1564,7 +1564,7 @@
       "distribution": {
         "kind": "npm",
         "name": "iterate-plugin",
-        "selectedVersion": "2.12.0",
+        "selectedVersion": "2.12.1",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -1693,7 +1693,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-xueqiu",
-        "selectedVersion": "1.21.4",
+        "selectedVersion": "1.21.7",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -1736,7 +1736,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@liustack/modlens",
-        "selectedVersion": "3.24.0",
+        "selectedVersion": "3.24.1",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -1924,7 +1924,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@michengai/dsh-agency-agents",
-        "selectedVersion": "0.1.20",
+        "selectedVersion": "0.1.21",
         "distTag": "latest"
       },
       "status": "needs-review",
@@ -1967,7 +1967,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@michengai/dsh-archive-manager",
-        "selectedVersion": "0.1.12",
+        "selectedVersion": "0.1.14",
         "distTag": "latest"
       },
       "status": "needs-review",
@@ -2010,7 +2010,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@michengai/dsh-im-connect",
-        "selectedVersion": "0.1.19",
+        "selectedVersion": "0.1.23",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -2053,7 +2053,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@michengai/dsh-skills-manager",
-        "selectedVersion": "0.1.23",
+        "selectedVersion": "0.1.24",
         "distTag": "latest"
       },
       "status": "needs-review",
@@ -2096,7 +2096,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@modusensus/dsh-mneme",
-        "selectedVersion": "0.6.10",
+        "selectedVersion": "0.7.0",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -2225,7 +2225,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@nonamelego/dsh-catppuccin",
-        "selectedVersion": "0.2.10",
+        "selectedVersion": "0.3.1",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -2311,7 +2311,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-chat-import",
-        "selectedVersion": "0.6.2",
+        "selectedVersion": "0.7.0",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -2844,7 +2844,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-mobile",
-        "selectedVersion": "0.1.4",
+        "selectedVersion": "0.2.0",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -2887,7 +2887,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-pocket",
-        "selectedVersion": "1.12.3",
+        "selectedVersion": "1.13.4",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -3059,7 +3059,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-movein",
-        "selectedVersion": "0.12.0",
+        "selectedVersion": "0.12.1",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -3102,7 +3102,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-win32",
-        "selectedVersion": "0.16.0",
+        "selectedVersion": "0.16.3",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -3145,7 +3145,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-passwords",
-        "selectedVersion": "2.6.0",
+        "selectedVersion": "2.6.1",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -3231,7 +3231,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-crew",
-        "selectedVersion": "0.9.0",
+        "selectedVersion": "0.10.0",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -3549,7 +3549,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-plugin-subscriptions",
-        "selectedVersion": "0.5.0",
+        "selectedVersion": "0.5.1",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -3764,7 +3764,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-codex-subscription",
-        "selectedVersion": "1.4.0",
+        "selectedVersion": "1.5.0",
         "distTag": "latest"
       },
       "status": "needs-review",
@@ -3807,7 +3807,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@jieai/dsh-plugin-vet",
-        "selectedVersion": "0.2.5",
+        "selectedVersion": "0.2.6",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -3893,7 +3893,7 @@
       "distribution": {
         "kind": "npm",
         "name": "dsh-config-manager",
-        "selectedVersion": "0.1.45",
+        "selectedVersion": "0.1.51",
         "distTag": "latest"
       },
       "status": "needs-review",
@@ -3979,7 +3979,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@xmanrui/dsh-im",
-        "selectedVersion": "1.0.2",
+        "selectedVersion": "2.0.1",
         "distTag": "latest"
       },
       "status": "observed-compatible",
@@ -4151,7 +4151,7 @@
       "distribution": {
         "kind": "npm",
         "name": "@linxin666/dsh-web-ui-all",
-        "selectedVersion": "0.2.9",
+        "selectedVersion": "0.3.2",
         "distTag": "latest"
       },
       "status": "needs-review",

--- a/feeds/dsh-plugin-compatibility.md
+++ b/feeds/dsh-plugin-compatibility.md
@@ -1,6 +1,6 @@
 # DSH directory compatibility evidence
 
-Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-24T04:47:38.600Z`.
+Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-24T04:54:24.120Z`.
 
 **74 observed compatible · 0 observed incompatible · 22 needs review · 4 not observed**
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "showcase:observer": "pnpm run build && node scripts/upstream-observer-showcase.mjs",
     "monitor:dsh-findings": "pnpm run build && node scripts/monitor-dsh-findings.mjs",
     "refresh:dsh-batch": "pnpm run build && node scripts/refresh-dsh-batch-index.mjs",
-    "refresh:dsh-directory-feed": "pnpm run build && node scripts/write-dsh-directory-feed.mjs examples/dsh/awesome-observer/cohort.json examples/dsh/install-observer/targets.json compatibility-ledger.json feeds/dsh-plugin-compatibility.json feeds/dsh-plugin-compatibility.md",
+    "refresh:dsh-directory-feed": "pnpm run build && node scripts/write-dsh-directory-feed.mjs examples/dsh/awesome-observer/cohort.json examples/dsh/install-observer/targets.json compatibility-ledger.json feeds/dsh-plugin-compatibility.json feeds/dsh-plugin-compatibility.md observations.json",
     "expand:dsh-cohort": "pnpm run build && node scripts/expand-awesome-dsh-cohort.mjs",
     "showcase:pnpm-lock": "pnpm run build && node scripts/pnpm-lock-showcase.mjs",
     "showcase:pnpm-lock:monitor": "pnpm run build && node scripts/pnpm-lock-monitor-showcase.mjs",

--- a/scripts/write-dsh-directory-feed.mjs
+++ b/scripts/write-dsh-directory-feed.mjs
@@ -15,15 +15,16 @@ async function readJson(path) {
   return JSON.parse(contents)
 }
 
-const [cohortPath, targetsPath, ledgerPath, jsonPath, markdownPath] = process.argv.slice(2)
+const [cohortPath, targetsPath, ledgerPath, jsonPath, markdownPath, observationsPath] = process.argv.slice(2)
 if ([cohortPath, targetsPath, ledgerPath, jsonPath, markdownPath].some(value => value === undefined)) {
-  throw new Error('usage: write-dsh-directory-feed.mjs <cohort.json> <targets.json> <ledger.json> <feed.json> <feed.md>')
+  throw new Error('usage: write-dsh-directory-feed.mjs <cohort.json> <targets.json> <ledger.json> <feed.json> <feed.md> [observations.json]')
 }
 
 const feed = buildDshDirectoryCompatibilityFeed({
   cohort: await readJson(cohortPath),
   installTargets: await readJson(targetsPath),
   ledger: await readJson(ledgerPath),
+  ...(observationsPath === undefined ? {} : { observations: await readJson(observationsPath) }),
   generatedAt: new Date().toISOString(),
 })
 

--- a/src/dsh-directory-feed.ts
+++ b/src/dsh-directory-feed.ts
@@ -254,6 +254,7 @@ export function buildDshDirectoryCompatibilityFeed(input: {
   cohort: unknown
   installTargets: unknown
   ledger: unknown
+  observations?: unknown
   generatedAt: string
   repositoryBaseUrl?: string
 }): DshDirectoryCompatibilityFeed {
@@ -265,6 +266,37 @@ export function buildDshDirectoryCompatibilityFeed(input: {
   const targetByObserverId = new Map(installTargets.plugins
     .filter(target => target.observerTargetId !== undefined)
     .map(target => [target.observerTargetId as string, target]))
+
+  const observedDistribution = (plugin: AwesomeDshCohortPlugin): AwesomeDshCohortPlugin['distribution'] => {
+    if (plugin.distribution.kind !== 'npm') return plugin.distribution
+    if (typeof input.observations !== 'object' || input.observations === null || Array.isArray(input.observations)) {
+      return plugin.distribution
+    }
+    const rawTargets = (input.observations as Record<string, unknown>).targets
+    if (typeof rawTargets !== 'object' || rawTargets === null || Array.isArray(rawTargets)) return plugin.distribution
+    const rawObservation = (rawTargets as Record<string, unknown>)[plugin.id]
+    if (typeof rawObservation !== 'object' || rawObservation === null || Array.isArray(rawObservation)) return plugin.distribution
+    const rawPackage = (rawObservation as Record<string, unknown>).package
+    if (typeof rawPackage !== 'object' || rawPackage === null || Array.isArray(rawPackage)) return plugin.distribution
+    const packageRecord = rawPackage as Record<string, unknown>
+    if (packageRecord.name !== plugin.distribution.name || typeof packageRecord.version !== 'string') return plugin.distribution
+    try {
+      parseNpmSpec(`${packageRecord.name}@${packageRecord.version}`)
+    } catch {
+      return plugin.distribution
+    }
+    const distTag = typeof packageRecord.distTag === 'string'
+      && packageRecord.distTag.trim() !== ''
+      && packageRecord.distTag.length <= 128
+      ? packageRecord.distTag
+      : undefined
+    return {
+      kind: 'npm',
+      name: plugin.distribution.name,
+      selectedVersion: packageRecord.version,
+      ...(distTag === undefined ? {} : { distTag }),
+    }
+  }
 
   const plugins = cohort.plugins.map((plugin): DshDirectoryCompatibilityEntry => {
     const installTarget = targetByObserverId.get(plugin.id)
@@ -301,7 +333,7 @@ export function buildDshDirectoryCompatibilityFeed(input: {
       catalogEntry: plugin.catalogEntry,
       catalogEntryUrl: `https://github.com/${cohort.source.repository}/blob/${cohort.source.commit}/${plugin.catalogEntry}`,
       category: plugin.category,
-      distribution: plugin.distribution,
+      distribution: observedDistribution(plugin),
       status: aggregateStatus(cells),
       cells,
       evidenceUrl: `${repositoryBaseUrl}/blob/main/compatibility-ledger.json`,

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -38,6 +38,7 @@ describe('reusable GitHub Action', () => {
     const observerTargetsPath = fileURLToPath(new URL('../../examples/upstream-observer/targets.yml', import.meta.url))
     const detectorPath = fileURLToPath(new URL('../../scripts/detect-action-input.mjs', import.meta.url))
     const packagePath = fileURLToPath(new URL('../../package.json', import.meta.url))
+    const installObserverDockerfilePath = fileURLToPath(new URL('../../docker/dsh-install-observer.Dockerfile', import.meta.url))
     const action = await readFile(actionPath, 'utf8')
     const example = await readFile(examplePath, 'utf8')
     const observerWorkflow = await readFile(observerWorkflowPath, 'utf8')
@@ -47,6 +48,7 @@ describe('reusable GitHub Action', () => {
     const checkedInObserverWorkflow = await readFile(checkedInObserverWorkflowPath, 'utf8')
     const observerTargets = await readFile(observerTargetsPath, 'utf8')
     const detector = await readFile(detectorPath, 'utf8')
+    const installObserverDockerfile = await readFile(installObserverDockerfilePath, 'utf8')
     const packageJson = JSON.parse(await readFile(packagePath, 'utf8')) as { version?: unknown }
 
     assert.equal(typeof packageJson.version, 'string')
@@ -149,6 +151,9 @@ describe('reusable GitHub Action', () => {
     assert.match(checkedInObserverWorkflow.slice(reconcileStep, publishStep), /continue-on-error: true/)
     assert.match(checkedInObserverWorkflow.slice(incompleteGate), /if: always\(\) && steps\.ledger\.outcome == 'failure'/)
     assert.match(checkedInObserverWorkflow.slice(incompleteGate), /RADAR_MISSING: \$\{\{ steps\.ledger\.outputs\.missing \}\}/)
+    assert.match(checkedInObserverWorkflow.slice(publishStep, persistStep), /feeds\/dsh-plugin-compatibility\.md \\\n\s+observations\.json/)
+    assert.match(installObserverDockerfile, /until corepack prepare pnpm@11\.3\.0 --activate/)
+    assert.match(installObserverDockerfile, /if \[ "\$attempt" -ge 3 \]; then exit 1; fi/)
     assert.match(observerTargets, /observer-targets\/v1alpha1/)
     assert.match(observerTargets, /ecosystem: dsh/)
   })

--- a/test/dsh-directory-feed.test.ts
+++ b/test/dsh-directory-feed.test.ts
@@ -84,6 +84,13 @@ function fixture() {
         ledgerEntry('unknown', 'unknown'),
       ],
     },
+    observations: {
+      targets: {
+        clean: {
+          package: { name: 'clean', version: '2.0.0-beta.1', distTag: 'beta' },
+        },
+      },
+    },
   }
 }
 
@@ -103,6 +110,13 @@ describe('DSH directory compatibility feed', () => {
       'not-observed': 1,
     })
     assert.equal(feed.plugins.find(item => item.id === 'clean')?.status, 'observed-compatible')
+    assert.deepEqual(feed.plugins.find(item => item.id === 'clean')?.distribution, {
+      kind: 'npm',
+      name: 'clean',
+      selectedVersion: '2.0.0-beta.1',
+      distTag: 'beta',
+    })
+    assert.equal(feed.plugins.find(item => item.id === 'clean')?.cells[0]?.artifact.spec, 'clean@1.0.0')
     assert.equal(feed.plugins.find(item => item.id === 'broken')?.status, 'observed-incompatible')
     assert.equal(feed.plugins.find(item => item.id === 'peer-gap')?.status, 'needs-review')
     assert.equal(feed.plugins.find(item => item.id === 'approval')?.status, 'needs-review')
@@ -115,6 +129,27 @@ describe('DSH directory compatibility feed', () => {
     )
     assert.equal(feed.plugins.find(item => item.id === 'clean')?.cells[0]?.recheckDueAt, '2026-08-30T00:00:00.000Z')
     assert.equal(feed.producer.license, 'Apache-2.0')
+  })
+
+  it('does not let malformed or name-mismatched observation state replace catalog distribution metadata', () => {
+    const input = fixture()
+    const feed = buildDshDirectoryCompatibilityFeed({
+      ...input,
+      observations: {
+        targets: {
+          clean: { package: { name: 'different-package', version: '9.0.0', distTag: 'latest' } },
+          broken: { package: { name: 'broken', version: '^2.0.0', distTag: 'next' } },
+        },
+      },
+      generatedAt: '2026-08-23T01:00:00.000Z',
+    })
+
+    assert.deepEqual(feed.plugins.find(item => item.id === 'clean')?.distribution, {
+      kind: 'npm', name: 'clean', selectedVersion: '1.0.0', distTag: 'latest',
+    })
+    assert.deepEqual(feed.plugins.find(item => item.id === 'broken')?.distribution, {
+      kind: 'npm', name: 'broken', selectedVersion: '1.0.0', distTag: 'latest',
+    })
   })
 
   it('renders a consumer-readable boundary and status table', () => {
@@ -132,11 +167,13 @@ describe('DSH directory compatibility feed', () => {
     const cohort = JSON.parse(await readFile('examples/dsh/awesome-observer/cohort.json', 'utf8')) as unknown
     const installTargets = JSON.parse(await readFile('examples/dsh/install-observer/targets.json', 'utf8')) as unknown
     const ledger = JSON.parse(await readFile('compatibility-ledger.json', 'utf8')) as unknown
+    const observations = JSON.parse(await readFile('observations.json', 'utf8')) as unknown
     const checkedInFeed = JSON.parse(await readFile('feeds/dsh-plugin-compatibility.json', 'utf8')) as { generatedAt: string }
     const feed = buildDshDirectoryCompatibilityFeed({
       cohort,
       installTargets,
       ledger,
+      observations,
       generatedAt: checkedInFeed.generatedAt,
     })
 


### PR DESCRIPTION
## Summary

- retry the build-stage Corepack bootstrap up to three times before an isolated cell gives up
- build directory-feed distribution coordinates from durable observer state
- preserve exact tested artifacts independently in ledger-backed cells
- reject malformed or package-name-mismatched observation overrides
- regenerate the public feed, including the correct `dsh-codex-connect@0.1.0-alpha.4.18` / `alpha` coordinate

## Why

Production run 32690938619 proved that partial reconciliation now preserves accepted cells, but it also exposed two follow-up gaps:

1. one transient Corepack transport assertion prevented `dsh-vision-router-node22` from producing a report;
2. the feed paired the original `.4.14/latest` cohort metadata with a `.4.18` exact evidence cell.

## Verification

```text
pnpm run check
pnpm test
356 tests passed
```

The local Docker daemon was unavailable, so the image build is intentionally left for GitHub CI and the post-merge production retry.

Closes #108
Closes #109
