### PR TITLE
docs: refocus the public README

### DIFF
--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -1,119 +1,93 @@
 <h1 align="center">Upstream Radar</h1>
 
-<p align="center"><strong>每次 DeepSeek Harness 发布后，在用户踩坑前找出哪些插件坏了。</strong></p>
+<p align="center"><strong>在 DeepSeek Harness 生态变化后，找出哪些插件需要维护者关注。</strong></p>
 
 <p align="center">
-  <a href="README.md">English</a> · 简体中文
-</p>
-
-<p align="center">
+  <a href="README.md">English</a> ·
   <a href="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://www.npmjs.com/package/upstream-radar"><img alt="npm" src="https://img.shields.io/npm/v/upstream-radar"></a>
-  <a href="https://github.com/MicroMilo/upstream-radar/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/MicroMilo/upstream-radar"></a>
+  <a href="https://github.com/MicroMilo/upstream-radar/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/MicroMilo/upstream-radar"></a>
   <a href="LICENSE"><img alt="Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
 </p>
 
-Upstream Radar 持续把一批真实插件发布物放到一次性隔离环境中，与不断变化的
-[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness)
-版本重新配对测试。某个组合坏了，就生成一条可复现的 Issue；作者发布修复后，
-Radar 会再次检查并关闭闭环。
+Upstream Radar 持续检查三者之间的真实关系：精确的 DSH 插件发布物、DSH 宿主和依赖图。
+当 DSH 或插件发布新版本改变这层关系时，Radar 告诉你变了什么、实际观测到了什么，以及维护者
+可以修什么。
 
-**维护 100 个安装/加载目标 · 已提出 13 条 domain 报告 · 4 条已关闭 · 9 条开放或持续观察**
-
-[最近一次 Agent 驱动的 headless 运行](https://github.com/MicroMilo/upstream-radar/actions/runs/32684879130)：
-**观测 96 个可执行目录插件 · 74 个兼容 · 22 个需要复核 · 0 个复现不兼容 · 4 个仅源码目标**。
-需要复核的信号不会被宣传成插件故障。
-
-第一轮真实闭环从 29 个待复核插件开始。Agent 选择了 9 个受限重试，其中 7 个转为
-兼容；另 2 个明确停在 Web 客户端依赖边界，没有被误报成插件坏了。
-
-一句话：`DSH/插件变化 → Agent → 一次性 headless 虚拟机 → 精确证据 → 复测或可修复 Issue`。
+它面向 [DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 插件生态。
+静态检查是关于发布包的证据；隔离运行检查是关于某个精确的
+`插件 × DSH × Node/profile` 组合的证据。两者都不会被包装成永久有效的“兼容”徽章或安全证书。
 
 ## 为什么需要它
 
-仓库看起来正常，不代表用户实际安装的插件仍然可用。真实发布物必须同时适配某个
-DSH 版本、Node 运行时、profile 和依赖组合；其中任何一项更新，都可能让插件一夜
-之间失效。
+插件源码仓库看起来正常，但用户真正安装的发布物可能还没有适配当前 DSH 宿主：
 
-Upstream Radar 检查的是这层真实关系，而不只是分别看两个仓库。本地发布前检查
-回答“这个插件今天能不能过”；Radar 回答“生态变化后，维护中的哪些插件不再能过”。
+- README 宣传的版本根本没有发布；
+- 插件实际导入了比 peer range 更新的 DSH 包；
+- `package.json` 和 lockfile 描述的不是同一个版本；
+- 安装阶段需要构建工具或依赖脚本，而用户环境没有；
+- DSH 宿主依赖没有发布，完整依赖图无法建立。
 
-## 完整闭环
+这些是生态关系问题。分别检查两个仓库，很容易漏掉它们。
+
+## Radar 做什么
+
+1. **锁定真实输入。** 读取精确 npm 发布物、DSH 版本、Node 运行时、profile、lockfile 和依赖路径。
+2. **比较真实关系。** 发现上游变化、发布/源码漂移、依赖图不完整和 DSH 契约不一致。
+3. **需要执行时再观察。** 在全新的、无密钥的环境中安装、注册并加载精确发布物，记录结果和边界。
+4. **完成闭环。** 生成有边界的证据，把重要变化交给可选的 DSH Agent，并在干净复测后更新或关闭一条面向维护者的 Issue。
 
 ```mermaid
-flowchart TB
-  Change["定时运行 / DSH 或插件变化"] --> Agent["Agent 规划受限的 headless 重试"]
-  Agent --> Runtime["一次性虚拟机：安装 → 注册 → 加载"]
-  Runtime -->|"出现下一层门槛"| Agent
-  Runtime -->|"兼容 / 超出 headless"| Evidence["发布精确证据"]
-  Runtime -->|"复现真实失败"| Issue["创建一条可修复的 Issue"]
-  Issue -->|"作者发布修复"| Change
+flowchart LR
+  Change["DSH 或插件变化"] --> Graph["精确发布物 + 依赖路径"]
+  Graph --> Runtime["隔离安装 → 注册 → 加载"]
+  Runtime --> Result["证据、复测或可修复 Issue"]
 ```
 
-Agent 读取仓库说明和最新运行证据，决定 headless 是否重试、重试时允许哪些安装条件。
-真正的结果由一次性虚拟机执行得出，而不是模型判断。模型不能凭空增加安装包、不能
-进入目标虚拟机执行，也不能把缺失证据说成通过。
+## 试试一个真实检查
 
-## 你会得到什么
-
-- `插件版本 × DSH 版本 × Node/profile` 的精确结果，而不是永不过期的“兼容”标签。
-- 把 Agent 规划的后续动作，与真实发布物的安装、注册、加载结果放在一起判断。
-- DSH 或插件变化后自动重新检查，而不是只生成一次报告。
-- 同一问题持续更新；回归时重新打开；干净复测通过后自动关闭。
-
-## 我们闭环中提出的 domain 报告
-
-以下是 Upstream Radar 提出的 13 条面向维护者的报告。它们不全都表示
-“插件坏了”：第一组是运行时兼容性，第二组是精确发布物/安装边界，第三组是
-持续监控所依赖的依赖图是否可信。
-
-### DSH 宿主/插件契约 · 2 条
-
-- **已关闭** · [Sanqi-normal/dsh-webui-market-plugin#5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
-- **开放** · [shaoshi20/dshscan#1](https://github.com/shaoshi20/dshscan/issues/1)
-
-### 发布物与安装契约 · 7 条
-
-- **已关闭** · [1na-ko/dsh-hdc-bridge#3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
-- **已关闭** · [6Mikao9/dsh-wsl-workspace#6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
-- **已关闭** · [3274375092/dsh-voice#2](https://github.com/3274375092/dsh-voice/issues/2)
-- **开放** · [AmeKrance/anan-thermal-monitor#1](https://github.com/AmeKrance/anan-thermal-monitor/issues/1)
-- **开放** · [AbcdefgXW/dsh-msg-hub#3](https://github.com/AbcdefgXW/dsh-msg-hub/issues/3)
-- **开放** · [030611/dsh-verification-receipt#3](https://github.com/030611/dsh-verification-receipt/issues/3)
-- **开放** · [0xsline/dsh-spotlight#5](https://github.com/0xsline/dsh-spotlight/issues/5)
-
-### 依赖图与源码/发布版本对齐 · 4 条
-
-- **开放** · [lninghaha/dsh-coding-subscription-oauth#14](https://github.com/lninghaha/dsh-coding-subscription-oauth/issues/14)
-- **开放** · [AbcdefgXW/dsh-msg-hub#1](https://github.com/AbcdefgXW/dsh-msg-hub/issues/1)
-- **开放** · [AbcdefgXW/dsh-toolbox-web#1](https://github.com/AbcdefgXW/dsh-toolbox-web/issues/1)
-- **开放** · [13071301808/dsh-composer-expand#1](https://github.com/13071301808/dsh-composer-expand/issues/1)
-
-你记得的 browser/web 案例——[`dsh-web-ui#35`](https://github.com/zhu1090093659/dsh-web-ui/issues/35)
-和 [`dsh-web-ui#71`](https://github.com/zhu1090093659/dsh-web-ui/issues/71)——是有价值的历史兼容性
-对照，且目前已关闭；但它们不是 Upstream Radar 提出的报告，所以不计入上面的 13 条。
-当前维护中的 `dsh-browser` 条目也都观测为兼容，不应被列成问题。
-
-查看[完整分类与证据索引](docs/domain-reports.md)，其中区分了动态复现、源码/发布物证据，
-以及仍需维护者确认的弱结论。
-
-## 检查一个插件
+第一次检查不需要本地 DSH profile，也不会执行插件代码：
 
 ```bash
-npx --yes upstream-radar@0.43.4 review dsh-plugin \
-  <包名>@<版本> \
-  --dsh-version <DSH版本>
+npx --yes upstream-radar@0.43.4 inspect \
+  @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
+  --deep --fail-on never
 ```
 
-需要执行插件代码时，请使用仓库维护的
-[隔离观察工作流](.github/workflows/observe-dsh-plugin-install.yml)：每个组合都会获得
-一台全新的、无密钥的 GitHub 托管虚拟机和受限容器。
+这个历史 DSH 插件版本会返回 `review / incomplete`，因为它发布的宿主依赖链指向了一个不可用的包。
+这是可复现的发布/宿主契约问题，不是恶意行为指控。查看[完整证据报告](examples/dsh/reports/sanqi-market-plugin-dependency-resolution.md)。
 
-你还可以查看[实时兼容性矩阵](examples/dsh/install-observer/README.md)、
-[可供目录消费的兼容性结果](feeds/dsh-plugin-compatibility.md)、
-[第一批 50 个插件](examples/dsh/first-batch/README.md)和
-[架构说明](docs/architecture.md)。
+如果要检查自己的公开仓库，而不安装它：
 
-<p align="center">
-  <strong>如果 Upstream Radar 对 DSH 生态有帮助，欢迎<a href="https://github.com/MicroMilo/upstream-radar">点一个 Star</a> ⭐</strong>
-</p>
+```bash
+npx --yes upstream-radar@0.43.4 scan \
+  https://github.com/owner/dsh-plugin \
+  --fail-on never
+```
+
+仓库扫描会读取源码 manifest、DSH 元数据和 lockfile；不会安装依赖、执行 lifecycle script、加载插件、启动 DSH 或调用 LLM。
+
+## 让它持续运行
+
+把下面任意一个维护好的 workflow 复制到你的仓库：
+
+- [跨多个 DSH 版本检查一个精确插件](examples/github-actions/dsh-plugin-review-minimal.yml)：手动触发，得到发布物证据和隔离加载矩阵。
+- [每天观察一个插件仓库](examples/github-actions/upstream-observer-minimal.yml)：比较 commit、发布版本、manifest 和依赖图，只有发生重要变化才唤起 Agent。
+- [在 CI 中运行依赖门禁](examples/github-actions/upstream-radar.yml)：在合并前检查 lockfile 或审查过的 Radar 配置。
+
+[隔离观察 workflow](.github/workflows/observe-dsh-plugin-install.yml) 会为需要执行代码的检查使用全新的 GitHub 托管 runner。
+它不是你的电脑，也不会接收项目密钥。
+
+## 信任边界
+
+- 静态收集不会执行目标控制的代码。
+- 动态观察只在一次性、受限环境中运行。
+- DSH Agent 可以选择受限的后续检查或解释证据，但不能凭空增加依赖、把缺失证据说成通过，或替代运行结果。
+
+## 生态证据
+
+仓库维护一份[domain 报告索引](docs/domain-reports.md)，包含公开 Issue、验证等级、影响，以及“已确认运行失败”和“需要维护者确认”之间的区别。
+[兼容性 feed](feeds/dsh-plugin-compatibility.md) 可以供插件目录和其他消费者使用。
+
+如果 Upstream Radar 对你维护 DSH 插件有帮助，欢迎[给项目点个 Star](https://github.com/MicroMilo/upstream-radar) ⭐，
+或者提交一个值得我们持续观察的插件。

--- a/README.md
+++ b/README.md
@@ -1,130 +1,117 @@
 <h1 align="center">Upstream Radar</h1>
 
-<p align="center"><strong>Know which DeepSeek Harness plugins break after every release—before users do.</strong></p>
+<p align="center"><strong>Find the DeepSeek Harness plugins that need attention when the ecosystem moves.</strong></p>
 
 <p align="center">
-  English · <a href="README-zh-CN.md">简体中文</a>
-</p>
-
-<p align="center">
+  <a href="README-zh-CN.md">简体中文</a> ·
   <a href="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/MicroMilo/upstream-radar/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://www.npmjs.com/package/upstream-radar"><img alt="npm" src="https://img.shields.io/npm/v/upstream-radar"></a>
   <a href="https://github.com/MicroMilo/upstream-radar/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/MicroMilo/upstream-radar"></a>
   <a href="LICENSE"><img alt="Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
 </p>
 
-Upstream Radar continuously retests a maintained fleet of exact published
-plugins against changing
-[DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness)
-releases in disposable runners. When a pair breaks, it produces a reproducible
-issue; when the author ships a fix, it retests and closes the loop.
+Upstream Radar continuously checks the relationship between an exact published
+DSH plugin, its DSH host, and its dependency graph. When a DSH or plugin release
+changes that relationship, Radar shows what changed, what was actually observed,
+and what a maintainer can fix.
 
-**100 maintained install/load targets · 13 domain reports filed · 4 closed · 9 open or under watch**
+It is built for the [DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness)
+plugin ecosystem. A static review is evidence about a package; an isolated
+runtime review is evidence about one exact `plugin × DSH × Node/profile` pair.
+Neither is presented as a timeless compatibility badge or a security certificate.
 
-[Latest Agent-driven headless run](https://github.com/MicroMilo/upstream-radar/actions/runs/32684879130):
-**96 executable catalog cells observed · 74 compatible · 22 need review · 0 reproduced incompatibilities · 4 source-only**.
-Review signals are never advertised as plugin failures.
+## The problem
 
-The first live loop started with 29 review cells. The Agent selected nine
-bounded retries; seven became compatible, while two stopped at an explicit Web
-client dependency boundary instead of being mislabeled as broken.
+A source repository can be green while the package users install is not ready
+for the current DSH host:
 
-In one line: `DSH/plugin change → Agent → disposable headless VM → exact evidence → retest or fixable issue`.
+- the README advertises a version that was never published;
+- a plugin imports a newer DSH package than its peer range allows;
+- `package.json` and the lockfile describe different releases;
+- an install-time build or dependency script needs tools the user does not have;
+- a DSH host dependency is missing, so the dependency graph cannot be completed.
 
-## Why it exists
+These are ecosystem relationship problems. They are easy to miss when the two
+repositories are checked separately.
 
-A healthy repository does not prove that its published plugin still works.
-The artifact users install must resolve against a specific DSH host, Node
-runtime, profile, and dependency set—and any of them can change overnight.
+## What Radar does
 
-Upstream Radar checks the relationship, not just the two repositories. A local
-pre-publish check asks, “does this plugin pass today?” Radar asks, “which
-maintained plugins stopped passing after the ecosystem changed?”
-
-## The loop
+1. **Pin the real inputs.** Read the exact npm artifact, DSH version, Node
+   runtime, profile, lockfile, and dependency paths.
+2. **Compare the relationship.** Detect upstream changes, package/release drift,
+   incomplete graphs, and DSH contract mismatches.
+3. **Observe when execution matters.** In a fresh, secret-free runner, install,
+   register, and load the exact artifact; record the result and its boundary.
+4. **Close the loop.** Produce bounded evidence, route meaningful changes to an
+   optional DSH Agent, and update or close one maintainer-facing issue after a
+   clean retest.
 
 ```mermaid
-flowchart TB
-  Change["Schedule / DSH or plugin change"] --> Agent["Agent plans a bounded headless retry"]
-  Agent --> Runtime["Disposable VM: install → register → load"]
-  Runtime -->|"next observed gate"| Agent
-  Runtime -->|"compatible / outside headless"| Evidence["Publish exact evidence"]
-  Runtime -->|"reproduced failure"| Issue["Open one fixable issue"]
-  Issue -->|"author ships a fix"| Change
+flowchart LR
+  Change["DSH or plugin change"] --> Graph["Exact artifact + dependency paths"]
+  Graph --> Runtime["Isolated install → register → load"]
+  Runtime --> Result["Evidence, retest, or fixable issue"]
 ```
 
-The Agent interprets repository instructions and the latest runtime evidence,
-then chooses whether and how headless should retry. The disposable runner—not
-the model—establishes the result. A model cannot invent a build package, execute
-inside the target VM, or turn missing evidence into a pass.
+## Try a real check
 
-## What you get
-
-- An exact result for `plugin version × DSH version × Node/profile`, not a
-  timeless “compatible” badge.
-- Agent-planned follow-ups joined with real install/register/load evidence from
-  the published artifact.
-- A maintained result that is retested when DSH or the plugin changes.
-- One managed issue that is updated on repeat failures, reopened on regression,
-  and closed after a clean retest.
-
-## Domain reports from our loop
-
-These are the 13 maintainer-facing reports filed by Upstream Radar. They are
-not all “the plugin is broken”: the first group is runtime compatibility, the
-second is the exact package/install boundary, and the third is whether a
-dependency graph can be trusted for continuous monitoring.
-
-### DSH host/plugin contract · 2
-
-- **closed** · [Sanqi-normal/dsh-webui-market-plugin#5](https://github.com/Sanqi-normal/dsh-webui-market-plugin/issues/5)
-- **open** · [shaoshi20/dshscan#1](https://github.com/shaoshi20/dshscan/issues/1)
-
-### Published artifact and install contract · 7
-
-- **closed** · [1na-ko/dsh-hdc-bridge#3](https://github.com/1na-ko/dsh-hdc-bridge/issues/3)
-- **closed** · [6Mikao9/dsh-wsl-workspace#6](https://github.com/6Mikao9/dsh-wsl-workspace/issues/6)
-- **closed** · [3274375092/dsh-voice#2](https://github.com/3274375092/dsh-voice/issues/2)
-- **open** · [AmeKrance/anan-thermal-monitor#1](https://github.com/AmeKrance/anan-thermal-monitor/issues/1)
-- **open** · [AbcdefgXW/dsh-msg-hub#3](https://github.com/AbcdefgXW/dsh-msg-hub/issues/3)
-- **open** · [030611/dsh-verification-receipt#3](https://github.com/030611/dsh-verification-receipt/issues/3)
-- **open** · [0xsline/dsh-spotlight#5](https://github.com/0xsline/dsh-spotlight/issues/5)
-
-### Dependency graph and source/release alignment · 4
-
-- **open** · [lninghaha/dsh-coding-subscription-oauth#14](https://github.com/lninghaha/dsh-coding-subscription-oauth/issues/14)
-- **open** · [AbcdefgXW/dsh-msg-hub#1](https://github.com/AbcdefgXW/dsh-msg-hub/issues/1)
-- **open** · [AbcdefgXW/dsh-toolbox-web#1](https://github.com/AbcdefgXW/dsh-toolbox-web/issues/1)
-- **open** · [13071301808/dsh-composer-expand#1](https://github.com/13071301808/dsh-composer-expand/issues/1)
-
-The browser/web cases you may remember—[`dsh-web-ui#35`](https://github.com/zhu1090093659/dsh-web-ui/issues/35)
-and [`dsh-web-ui#71`](https://github.com/zhu1090093659/dsh-web-ui/issues/71)—are
-useful historical compatibility references and are closed, but they were not
-filed by Upstream Radar and are therefore not counted above. The maintained
-`dsh-browser` entries currently observed compatible are also not findings.
-
-See the [full classification and evidence index](docs/domain-reports.md) for
-validation level, impact, and the boundary between a confirmed runtime issue
-and a report that only needs maintainer confirmation.
-
-## Run one check
+No local DSH profile is needed for this first check. It reviews one exact
+published artifact without executing plugin code:
 
 ```bash
-npx --yes upstream-radar@0.43.4 review dsh-plugin \
-  <package>@<version> \
-  --dsh-version <dsh-version>
+npx --yes upstream-radar@0.43.4 inspect \
+  @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
+  --deep --fail-on never
 ```
 
-For code-executing checks, use the maintained
-[isolated observer workflow](.github/workflows/observe-dsh-plugin-install.yml):
-each pair receives a fresh, secret-free GitHub-hosted VM and restricted
-container.
+This historical DSH plugin release returns `review / incomplete` because its
+published host dependency chain reaches an unavailable package. That is a
+useful, reproducible release/host-contract report—not a claim of malicious
+behavior. See the [full evidence report](examples/dsh/reports/sanqi-market-plugin-dependency-resolution.md).
 
-Inspect the [live compatibility matrix](examples/dsh/install-observer/README.md),
-the [directory-consumable evidence feed](feeds/dsh-plugin-compatibility.md),
-the [first 50-plugin corpus](examples/dsh/first-batch/README.md), or the
-[architecture notes](docs/architecture.md).
+To review your own public repository without installing it:
 
-<p align="center">
-  <strong>If Upstream Radar helps the DSH ecosystem stay compatible, <a href="https://github.com/MicroMilo/upstream-radar">please give it a Star</a> ⭐</strong>
-</p>
+```bash
+npx --yes upstream-radar@0.43.4 scan \
+  https://github.com/owner/dsh-plugin \
+  --fail-on never
+```
+
+The repository scan reads source manifests, DSH metadata, and lockfiles. It does
+not install dependencies, run lifecycle scripts, load the plugin, start DSH, or
+call an LLM.
+
+## Run it on every change
+
+Copy one of the maintained workflows into your repository:
+
+- [Review one exact plugin across DSH versions](examples/github-actions/dsh-plugin-review-minimal.yml)
+  — a manual check with artifact evidence and an isolated load matrix.
+- [Observe one plugin repository every day](examples/github-actions/upstream-observer-minimal.yml)
+  — compares commits, published versions, manifests, and dependency graphs, then
+  wakes an Agent only when there is a meaningful change.
+- [Run the dependency gate in CI](examples/github-actions/upstream-radar.yml)
+  — checks the lockfile or reviewed Radar configuration before merge.
+
+The [isolated observer workflow](.github/workflows/observe-dsh-plugin-install.yml)
+uses a fresh GitHub-hosted runner for code-executing checks. The runner is not
+your workstation and does not receive project secrets.
+
+## Trust boundary
+
+- Static collection never executes target-controlled code.
+- Dynamic observation runs only in a disposable, bounded environment.
+- The DSH Agent may choose a constrained follow-up or explain evidence; it cannot
+  invent a dependency, turn missing evidence into a pass, or replace the runtime
+  result.
+
+## Evidence from the ecosystem
+
+The repository keeps a [domain report index](docs/domain-reports.md) with public
+issue links, validation level, impact, and the difference between a confirmed
+runtime failure and a maintainer-confirmation request. The [compatibility feed](feeds/dsh-plugin-compatibility.md)
+is machine-readable for plugin directories and other consumers.
+
+If Upstream Radar helps you keep DSH plugins working as the ecosystem changes,
+[please give the project a Star](https://github.com/MicroMilo/upstream-radar) ⭐
+or open an issue with a plugin we should observe.


### PR DESCRIPTION
## Summary

- Reframe the homepage around the DSH plugin relationship problem.
- Replace internal acceptance metrics and the full issue list with a short public product story.
- Add a real 60-second artifact check, always-on workflow links, and a concise trust boundary.
- Keep detailed issue evidence in `docs/domain-reports.md`.
- Update the English and Chinese homepages together.

## Verification

- `pnpm test` (356/356)
- `pnpm run release:check`
- `git diff --check`
