### PR TITLE
Keep current compatibility evidence honest

### DIFF
--- a/.github/workflows/upstream-observer.yml
+++ b/.github/workflows/upstream-observer.yml
@@ -33,6 +33,7 @@ jobs:
       run_install_observation: ${{ steps.install-plan.outputs.run }}
       install_dsh_version: ${{ steps.install-plan.outputs.dsh_version }}
       install_matrix: ${{ steps.install-plan.outputs.matrix }}
+      observer_exit: ${{ steps.observe.outputs.exit }}
     steps:
       - name: Check out the observer and its targets
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -69,6 +70,11 @@ jobs:
       - name: Observe upstream changes
         if: inputs.mode != 'headless-agent'
         id: observe
+        # A source outage is degraded evidence, not permission to discard the
+        # successful targets from this cycle. Preserve the exit code, continue
+        # planning/retesting those targets, then surface the outage after the
+        # dynamic jobs have finished.
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OBSERVER_REPORT: ${{ runner.temp }}/upstream-radar-observer.md
@@ -352,4 +358,19 @@ jobs:
         run: |
           echo "Compatibility evidence was partially persisted: accepted=${RADAR_ACCEPTED:-unknown}, missing=${RADAR_MISSING:-unknown}, rejected=${RADAR_REJECTED:-unknown}."
           echo 'The incomplete cells remain unsatisfied and will be selected by the next reconciliation run.'
+          exit 1
+
+  # Keep a partial source outage visible without letting it short-circuit the
+  # successful targets discovered in the same observer cycle.
+  observer-source-health:
+    needs: [observe, install-observation, reconcile-install-observations]
+    if: always() && needs.observe.outputs.observer_exit != '' && needs.observe.outputs.observer_exit != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Surface the partial observer failure after downstream work
+        env:
+          OBSERVER_EXIT: ${{ needs.observe.outputs.observer_exit }}
+        run: |
+          echo "The observer returned exit code ${OBSERVER_EXIT}; successful targets still completed planning and isolated retesting."
           exit 1

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -1,11 +1,15 @@
 {
-  "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha1",
-  "generatedAt": "2026-08-25T01:47:48.411Z",
+  "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha2",
+  "generatedAt": "2026-08-25T03:41:29.487Z",
   "producer": {
     "name": "upstream-radar",
     "version": "0.43.4",
     "repository": "https://github.com/MicroMilo/upstream-radar",
     "license": "Apache-2.0"
+  },
+  "selectedHost": {
+    "package": "@deepseek-ai/dsh",
+    "version": "0.1.1-rc.2"
   },
   "sourceCatalog": {
     "repository": "awesome-dsh-plugin/awesome-dsh-plugin",
@@ -20,14 +24,15 @@
     "executionPlane": "headless",
     "profile": "headless",
     "isolation": "fresh GitHub-hosted VM plus restricted container",
-    "consumptionRule": "Treat a cell as stale after recheckDueAt. needs-review and not-observed must never be rendered as pass or fail.",
+    "consumptionRule": "A plugin status applies only when a cell exactly matches the selected artifact. Treat update-pending, needs-review and not-observed as neither pass nor fail, and treat a cell as stale after recheckDueAt.",
     "refreshAfterHours": 168
   },
   "summary": {
     "total": 100,
-    "observed-compatible": 73,
+    "observed-compatible": 67,
     "observed-incompatible": 0,
-    "needs-review": 23,
+    "needs-review": 22,
+    "update-pending": 7,
     "not-observed": 4
   },
   "plugins": [
@@ -475,7 +480,7 @@
         "selectedVersion": "0.6.13",
         "distTag": "latest"
       },
-      "status": "observed-compatible",
+      "status": "update-pending",
       "cells": [
         {
           "caseId": "dsh-remote-plugin-node22",
@@ -776,7 +781,7 @@
         "selectedVersion": "0.5.1",
         "distTag": "latest"
       },
-      "status": "observed-compatible",
+      "status": "update-pending",
       "cells": [
         {
           "caseId": "dsh-taskboard-node22",
@@ -1701,7 +1706,7 @@
         "selectedVersion": "1.22.1",
         "distTag": "latest"
       },
-      "status": "observed-compatible",
+      "status": "update-pending",
       "cells": [
         {
           "caseId": "dsh-xueqiu-node22",
@@ -2769,7 +2774,7 @@
         "selectedVersion": "0.3.2",
         "distTag": "latest"
       },
-      "status": "observed-compatible",
+      "status": "update-pending",
       "cells": [
         {
           "caseId": "dsh-better-edit-node22",
@@ -3027,7 +3032,7 @@
         "selectedVersion": "0.3.3",
         "distTag": "latest"
       },
-      "status": "observed-compatible",
+      "status": "update-pending",
       "cells": [
         {
           "caseId": "dsh-rewind-plugin-node22",
@@ -3775,7 +3780,7 @@
         "selectedVersion": "1.6.0",
         "distTag": "latest"
       },
-      "status": "needs-review",
+      "status": "update-pending",
       "cells": [
         {
           "caseId": "dsh-codex-subscription-node22",
@@ -3861,7 +3866,7 @@
         "selectedVersion": "0.2.8",
         "distTag": "latest"
       },
-      "status": "observed-compatible",
+      "status": "update-pending",
       "cells": [
         {
           "caseId": "xgone-dsh-remote-node22",

--- a/feeds/dsh-plugin-compatibility.md
+++ b/feeds/dsh-plugin-compatibility.md
@@ -1,117 +1,119 @@
 # DSH directory compatibility evidence
 
-Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-25T01:47:48.411Z`.
+Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-25T03:41:29.487Z`.
+Selected host: `@deepseek-ai/dsh@0.1.1-rc.2`.
 
-**73 observed compatible · 0 observed incompatible · 23 needs review · 4 not observed**
+**67 observed compatible · 0 observed incompatible · 22 needs review · 7 update pending · 4 not observed**
 
-| Catalog plugin | Exact artifact | Exact DSH / runtime | Evidence status | Observed |
-| --- | --- | --- | --- | --- |
-| [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) | `@1e0zj/dsh-plugin-mall@0.4.14` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:26.137Z |
-| [263311487-ux/dsh-verify](https://github.com/263311487-ux/dsh-verify) | `dsh-verify@0.9.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:33.710Z |
-| [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) | `@awiki/dsh-plugin@0.3.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:35.321Z |
-| [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) | `@a9i5k4/dsh-auto-memory@0.1.29` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:34.439Z |
-| [Airmetro/dsh-update-checker](https://github.com/Airmetro/dsh-update-checker) | `dsh-update-checker@1.4.15` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:25.952Z |
-| [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) | `dsh-agy-link@0.4.13` | `0.1.1-rc.2` / Node 24 | `observed-compatible` | 2026-08-24T04:45:31.755Z |
-| [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) | `@anionex/dsh-turn-rewind@0.1.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.848Z |
-| [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | `@anionex/dsh-vision-toolkit@0.1.38` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:36.169Z |
-| [anweat/dsh-browser](https://github.com/anweat/dsh-browser) | `@anweat/dsh-browser@0.1.8` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T02:43:13.234Z |
-| [awesome-dsh-plugin/dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) | `dsh-find-plugin@0.3.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:40.622Z |
-| [Blank-not-black/dsh-Remote](https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin) | `dsh-remote-plugin@0.6.12` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:40.652Z |
-| [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) | `dsh-context@0.29.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.736Z |
-| [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | `@deepseek-harness-tui/dsh-tui@0.9.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:50.085Z |
-| [chen731215-dev/dsh-tavern](https://github.com/chen731215-dev/dsh-tavern) | `dsh-tavern@1.9.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.537Z |
-| [chenproton/dsh-history](https://github.com/chenproton/dsh-history) | `dsh-history@0.1.24` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:45.845Z |
-| [ChongCyrus/Vibe-Mathematics](https://github.com/ChongCyrus/Vibe-Mathematics) | `dsh-vibe-math@1.0.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:31.725Z |
-| [clarknu/dsh-gateway](https://github.com/clarknu/dsh-gateway) | `dsh-gateway@1.6.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:34.896Z |
-| [cloader/dsh-taskboard](https://github.com/cloader/dsh-taskboard) | `dsh-taskboard@0.5.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:32.472Z |
-| [cookiesheep/whale-on-desk](https://github.com/cookiesheep/whale-on-desk) | `whale-on-desk@3.0.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:54:29.086Z |
-| [DDDMUC/dsh-free-search](https://github.com/DDDMUC/dsh-free-search) | `dsh-free-search@0.4.12` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:40.522Z |
-| [dickpy/dsh-imagegen](https://github.com/dickpy/dsh-imagegen) | `@dickpy/dsh-imagegen@1.2.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:34.903Z |
-| [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) | `dsh-univer-office@0.2.9` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:54:42.004Z |
-| [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) | `dshmarket@1.21.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:40.751Z |
-| [dsh-plugins/dsh-auxiliary](https://github.com/dsh-plugins/dsh-auxiliary) | `@dsh-plugin/dsh-auxiliary@0.5.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:37.260Z |
-| [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) | `dsh-plugin-wallpaper-engine@0.6.3` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:17.330Z |
-| [feibi-mochi/deepseek-harness-control-center](https://github.com/feibi-mochi/deepseek-harness-control-center) | `deepseek-harness-wallet@0.3.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:46:29.311Z |
-| [feng78-boop/dsh-thirteen-bg](https://github.com/feng78-boop/dsh-thirteen-bg) | `dsh-thirteen-bg@0.5.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:54:30.752Z |
-| [flymysql/dsh-remote](https://github.com/flymysql/dsh-remote) | `dsh-remote@0.8.8` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:59:55.498Z |
-| [Flyvhidbwo/dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | `dsh-vision-proxy@0.4.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T03:01:19.585Z |
-| [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) | `dsh-codex-connect@0.1.0-alpha.4.18` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:31.880Z |
-| [FuzzySoul/dsh-chatvoice](https://github.com/FuzzySoul/dsh-chatvoice) | `dsh-chatvoice@0.1.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:36.797Z |
-| [FuzzySoul/dsh-free-vision](https://github.com/FuzzySoul/dsh-free-vision) | `dsh-free-vision@1.0.8` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T03:01:25.614Z |
-| [GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis) | — | — | `not-observed` | — |
-| [Han-1413141/dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) | `dsh-cost-meter@1.5.42` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:28.561Z |
-| [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | `dsh-client-auto-continue@0.8.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:33.893Z |
-| [iiwish/dsh-testkit](https://github.com/iiwish/dsh-testkit) | `dsh-testkit@0.3.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:47.936Z |
-| [jingzhao-l/iterate-plugin](https://github.com/jingzhao-l/iterate-plugin) | `iterate-plugin@2.12.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:28.155Z |
-| [jsdvjx/dsh-strata](https://github.com/jsdvjx/dsh-strata) | `dsh-strata@0.8.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:34.496Z |
-| [JUANWANG-BUAA/dsh-full-remote](https://github.com/JUANWANG-BUAA/dsh-full-remote) | `dsh-full-remote@0.3.7` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:42.519Z |
-| [kangjinghang/dsh-xueqiu](https://github.com/kangjinghang/dsh-xueqiu) | `dsh-xueqiu@1.21.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:34.258Z |
-| [liustack/modlens](https://github.com/liustack/modlens) | `@liustack/modlens@3.24.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.561Z |
-| [liustack/modsearch](https://github.com/liustack/modsearch) | `@liustack/modsearch@5.9.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:43.536Z |
-| [lninghaha/dsh-coding-subscription-oauth](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `dsh-coding-subscription-oauth@0.6.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:38.709Z |
-| [Lum1104/dsh-browser](https://github.com/Lum1104/dsh-browser/tree/main/packages/browser/bridge-browser) | — | — | `not-observed` | — |
-| [Mars-Sea/dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) | `@mars-sea/dsh-commandcode-provider@0.8.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:41.370Z |
-| [MichengAI/dsh-agency-agents](https://github.com/MichengAI/dsh-agency-agents) | `@michengai/dsh-agency-agents@0.1.21` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:52.492Z |
-| [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) | `@michengai/dsh-archive-manager@0.1.14` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:46:15.360Z |
-| [MichengAI/dsh-im-connect](https://github.com/MichengAI/dsh-im-connect) | `@michengai/dsh-im-connect@0.1.23` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:59:44.491Z |
-| [MichengAI/dsh-skills-manager](https://github.com/MichengAI/dsh-skills-manager) | `@michengai/dsh-skills-manager@0.1.24` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:36.246Z |
-| [modusensus/dsh-mneme](https://github.com/modusensus/dsh-mneme/tree/main/dsh-mneme) | `@modusensus/dsh-mneme@0.7.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:59:54.069Z |
-| [moonquake2004/dsh-doctor](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) | `@moonquake2004/dsh-doctor@0.4.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:40.923Z |
-| [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | `@nanmicoder/dsh-agent-teams@0.1.13` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:35.030Z |
-| [NoNameLeGo/dsh-catppuccin-theme](https://github.com/NoNameLeGo/dsh-catppuccin-theme) | `@nonamelego/dsh-catppuccin@0.3.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:32.811Z |
-| [nonewind/dsh-spend](https://github.com/nonewind/dsh-spend) | `dsh-spend@0.4.6` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:41.211Z |
-| [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | `dsh-chat-import@0.7.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.663Z |
-| [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | `dsh-better-sidebar@0.15.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:47:07.838Z |
-| [omdsh-dev/dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | `dsh-mnemon@0.2.16` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:37.835Z |
-| [openma-ai/deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | `@openma/deepseek-harness-acp@0.4.24` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:46:27.798Z |
-| [orziz/odai](https://github.com/orziz/odai/tree/main/dsh/plugin) | `odai-dsh-plugin@0.2.8` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:39.851Z |
-| [PAKIKNOWLEDGE/dsh-auto-classifier](https://github.com/PAKIKNOWLEDGE/dsh-auto-classifier) | `dsh-auto-classifier@0.1.14` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:27.365Z |
-| [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) | `dsh-pet@0.1.7` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:53:30.779Z |
-| [Q00/ouroboros](https://github.com/Q00/ouroboros/tree/main/integrations/dsh-plugin) | — | — | `not-observed` | — |
-| [Relistencode/dsh-extension-hub](https://github.com/Relistencode/dsh-extension-hub) | `dsh-extension-hub@0.2.19` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:31.897Z |
-| [Renzic-Stone/DSH-EasyRewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) | `dsh-easyrewrite@2.1.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:43.725Z |
-| [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) | `dsh-dream-skin@0.4.10` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:25.128Z |
-| [Rianico/dsh-better-edit](https://github.com/Rianico/dsh-better-edit) | `dsh-better-edit@0.3.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.785Z |
-| [Roarpeng/GraphFlow](https://github.com/Roarpeng/GraphFlow) | `@roarpeng/graphflow@1.12.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:46:39.319Z |
-| [saya-ch/dsh-mobile](https://github.com/saya-ch/dsh-mobile) | `dsh-mobile@0.2.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:31.171Z |
-| [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) | `dsh-pocket@1.13.4` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:46:27.002Z |
-| [shaoshi20/dshscan](https://github.com/shaoshi20/dshscan) | `@shaoshi/dshscan@0.5.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:53:45.378Z |
-| [siegfly/dsh-deepseek-vision](https://github.com/siegfly/dsh-deepseek-vision) | `dsh-deepseek-vision@0.1.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:39.005Z |
-| [SiriLee/dsh-rewind](https://github.com/SiriLee/dsh-rewind) | `dsh-rewind-plugin@0.3.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:32.151Z |
-| [sjh9714/dsh-movein](https://github.com/sjh9714/dsh-movein) | `dsh-movein@0.12.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:30.822Z |
-| [sjh9714/dsh-win32](https://github.com/sjh9714/dsh-win32) | `dsh-win32@0.16.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.447Z |
-| [slywalker2006/dsh-passwords](https://github.com/slywalker2006/dsh-passwords) | `dsh-passwords@2.6.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.315Z |
-| [STARDUSTLC666/dsh-email](https://github.com/STARDUSTLC666/dsh-email) | `dsh-email@0.6.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:42.713Z |
-| [stuarthu/dsh-crew](https://github.com/stuarthu/dsh-crew) | `dsh-crew@0.10.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:29.188Z |
-| [TecFancy/dsh-auth-gate](https://github.com/TecFancy/dsh-auth-gate) | `dsh-auth-gate@0.7.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:27.902Z |
-| [THEWOLFWALKER/dsh-notifier](https://github.com/THEWOLFWALKER/dsh-notifier) | `dsh-notifier@0.8.6` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T02:43:05.159Z |
-| [Tkingxiao/dsh-any-background](https://github.com/Tkingxiao/dsh-any-background) | `dsh-any-background@0.1.9` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:39.776Z |
-| [toby-bridges/api-relay-audit](https://github.com/toby-bridges/api-relay-audit) | — | — | `not-observed` | — |
-| [trench-xinxin/dsh-tool-lens](https://github.com/trench-xinxin/dsh-tool-lens) | `@trench-xinxin/dsh-tool-lens@2.0.5` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:22.626Z |
-| [truelove-dreamer/dsh-plugin-vetting](https://github.com/truelove-dreamer/dsh-plugin-vetting) | `dsh-plugin-vetting@0.5.6` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:39.650Z |
-| [tt-a1i/archify](https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness) | `@tt-a1i/archify-dsh@0.1.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:34.782Z |
-| [V1ki/dsh-plugin-subscriptions](https://github.com/V1ki/dsh-plugin-subscriptions) | `dsh-plugin-subscriptions@0.5.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:29.022Z |
-| [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/coding-agents) | `@vectorize-io/hindsight-coding-agents@0.4.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.525Z |
-| [volcengine/OpenViking](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin) | `@openviking/dsh-memory-plugin@0.2.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.036Z |
-| [wloops/dsh-git-worktree](https://github.com/wloops/dsh-git-worktree) | `dsh-git-worktree@0.4.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:36.570Z |
-| [wqty123/dsh-browser](https://github.com/wqty123/dsh-browser) | `dsh-builtin-browser@0.1.15` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:40.180Z |
-| [WSL043/dsh-codex-subscription](https://github.com/WSL043/dsh-codex-subscription) | `dsh-codex-subscription@1.5.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:28.223Z |
-| [wulun811/dsh-plugin-vet](https://github.com/wulun811/dsh-plugin-vet) | `@jieai/dsh-plugin-vet@0.2.6` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:27.045Z |
-| [xgone/dsh-remote](https://github.com/xgone/dsh-remote) | `@xgone/dsh-remote@0.2.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:32.325Z |
-| [xiajiajun516/dsh-config-manager](https://github.com/xiajiajun516/dsh-config-manager) | `dsh-config-manager@0.1.51` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:29.304Z |
-| [xiehuan123/dsh-deepread](https://github.com/xiehuan123/dsh-deepread) | `dsh-deepread@1.0.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:31.947Z |
-| [xmanrui/dsh-im](https://github.com/xmanrui/dsh-im) | `@xmanrui/dsh-im@2.0.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:37.246Z |
-| [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) | `dsh-plugin-writing-guard@1.6.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:32.939Z |
-| [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | `dsh-vision-router@1.7.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:59:57.675Z |
-| [yyh-001/dsh-meme](https://github.com/yyh-001/dsh-meme) | `dsh-meme@0.1.39` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:25.255Z |
-| [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-web-ui-all) | `@linxin666/dsh-web-ui-all@0.3.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:59:52.725Z |
-| [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | `@zseven-w/dsh-openpencil@0.1.0-rc.1` | `0.1.1-rc.2` / Node 24 | `needs-review` | 2026-08-23T11:53:40.988Z |
+| Catalog plugin | Selected artifact | Tested artifact | Exact DSH / runtime | Evidence status | Observed |
+| --- | --- | --- | --- | --- | --- |
+| [1e0zj/dsh-plugin-mall](https://github.com/1e0zj/dsh-plugin-mall) | `@1e0zj/dsh-plugin-mall@0.4.14` | `@1e0zj/dsh-plugin-mall@0.4.14` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:26.137Z |
+| [263311487-ux/dsh-verify](https://github.com/263311487-ux/dsh-verify) | `dsh-verify@0.9.0` | `dsh-verify@0.9.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:33.710Z |
+| [AgentConnect/dsh-awiki](https://github.com/AgentConnect/dsh-awiki) | `@awiki/dsh-plugin@0.3.2` | `@awiki/dsh-plugin@0.3.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:35.321Z |
+| [Aik358/dsh-auto-memory](https://github.com/Aik358/dsh-auto-memory) | `@a9i5k4/dsh-auto-memory@0.1.29` | `@a9i5k4/dsh-auto-memory@0.1.29` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:34.439Z |
+| [Airmetro/dsh-update-checker](https://github.com/Airmetro/dsh-update-checker) | `dsh-update-checker@1.4.15` | `dsh-update-checker@1.4.15` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:25.952Z |
+| [amlyczz/dsh-agy-link](https://github.com/amlyczz/dsh-agy-link) | `dsh-agy-link@0.4.13` | `dsh-agy-link@0.4.13` | `0.1.1-rc.2` / Node 24 | `observed-compatible` | 2026-08-24T04:45:31.755Z |
+| [Anionex/dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) | `@anionex/dsh-turn-rewind@0.1.2` | `@anionex/dsh-turn-rewind@0.1.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.848Z |
+| [Anionex/dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | `@anionex/dsh-vision-toolkit@0.1.38` | `@anionex/dsh-vision-toolkit@0.1.38` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:36.169Z |
+| [anweat/dsh-browser](https://github.com/anweat/dsh-browser) | `@anweat/dsh-browser@0.1.8` | `@anweat/dsh-browser@0.1.8` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T02:43:13.234Z |
+| [awesome-dsh-plugin/dsh-find-plugin](https://github.com/awesome-dsh-plugin/dsh-find-plugin) | `dsh-find-plugin@0.3.7` | `dsh-find-plugin@0.3.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:40.622Z |
+| [Blank-not-black/dsh-Remote](https://github.com/Blank-not-black/dsh-Remote/tree/main/packages/plugin) | `dsh-remote-plugin@0.6.13` | `dsh-remote-plugin@0.6.12` | `0.1.1-rc.2` / Node 22 | `update-pending` | 2026-08-24T04:45:40.652Z |
+| [bowenliang123/dsh-context](https://github.com/bowenliang123/dsh-context) | `dsh-context@0.29.0` | `dsh-context@0.29.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.736Z |
+| [ccch1mneyyy/dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | `@deepseek-harness-tui/dsh-tui@0.9.0` | `@deepseek-harness-tui/dsh-tui@0.9.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:50.085Z |
+| [chen731215-dev/dsh-tavern](https://github.com/chen731215-dev/dsh-tavern) | `dsh-tavern@1.9.2` | `dsh-tavern@1.9.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.537Z |
+| [chenproton/dsh-history](https://github.com/chenproton/dsh-history) | `dsh-history@0.1.24` | `dsh-history@0.1.24` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:45.845Z |
+| [ChongCyrus/Vibe-Mathematics](https://github.com/ChongCyrus/Vibe-Mathematics) | `dsh-vibe-math@1.0.2` | `dsh-vibe-math@1.0.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:31.725Z |
+| [clarknu/dsh-gateway](https://github.com/clarknu/dsh-gateway) | `dsh-gateway@1.6.0` | `dsh-gateway@1.6.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:34.896Z |
+| [cloader/dsh-taskboard](https://github.com/cloader/dsh-taskboard) | `dsh-taskboard@0.5.1` | `dsh-taskboard@0.5.0` | `0.1.1-rc.2` / Node 22 | `update-pending` | 2026-08-24T04:45:32.472Z |
+| [cookiesheep/whale-on-desk](https://github.com/cookiesheep/whale-on-desk) | `whale-on-desk@3.0.0` | `whale-on-desk@3.0.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:54:29.086Z |
+| [DDDMUC/dsh-free-search](https://github.com/DDDMUC/dsh-free-search) | `dsh-free-search@0.4.12` | `dsh-free-search@0.4.12` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:40.522Z |
+| [dickpy/dsh-imagegen](https://github.com/dickpy/dsh-imagegen) | `@dickpy/dsh-imagegen@1.2.1` | `@dickpy/dsh-imagegen@1.2.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:34.903Z |
+| [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) | `dsh-univer-office@0.2.9` | `dsh-univer-office@0.2.9` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:54:42.004Z |
+| [dsh-market/dsh-market](https://github.com/dsh-market/dsh-market) | `dshmarket@1.21.2` | `dshmarket@1.21.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:40.751Z |
+| [dsh-plugins/dsh-auxiliary](https://github.com/dsh-plugins/dsh-auxiliary) | `@dsh-plugin/dsh-auxiliary@0.5.1` | `@dsh-plugin/dsh-auxiliary@0.5.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:37.260Z |
+| [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) | `dsh-plugin-wallpaper-engine@0.6.3` | `dsh-plugin-wallpaper-engine@0.6.3` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:17.330Z |
+| [feibi-mochi/deepseek-harness-control-center](https://github.com/feibi-mochi/deepseek-harness-control-center) | `deepseek-harness-wallet@0.3.2` | `deepseek-harness-wallet@0.3.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:46:29.311Z |
+| [feng78-boop/dsh-thirteen-bg](https://github.com/feng78-boop/dsh-thirteen-bg) | `dsh-thirteen-bg@0.5.2` | `dsh-thirteen-bg@0.5.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:54:30.752Z |
+| [flymysql/dsh-remote](https://github.com/flymysql/dsh-remote) | `dsh-remote@0.8.8` | `dsh-remote@0.8.8` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:59:55.498Z |
+| [Flyvhidbwo/dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | `dsh-vision-proxy@0.4.1` | `dsh-vision-proxy@0.4.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T03:01:19.585Z |
+| [franksong2702/dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) | `dsh-codex-connect@0.1.0-alpha.4.18` | `dsh-codex-connect@0.1.0-alpha.4.18` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:31.880Z |
+| [FuzzySoul/dsh-chatvoice](https://github.com/FuzzySoul/dsh-chatvoice) | `dsh-chatvoice@0.1.7` | `dsh-chatvoice@0.1.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:36.797Z |
+| [FuzzySoul/dsh-free-vision](https://github.com/FuzzySoul/dsh-free-vision) | `dsh-free-vision@1.0.8` | `dsh-free-vision@1.0.8` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T03:01:25.614Z |
+| [GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis) | — | — | — | `not-observed` | — |
+| [Han-1413141/dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) | `dsh-cost-meter@1.5.42` | `dsh-cost-meter@1.5.42` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:28.561Z |
+| [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | `dsh-client-auto-continue@0.8.1` | `dsh-client-auto-continue@0.8.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:33.893Z |
+| [iiwish/dsh-testkit](https://github.com/iiwish/dsh-testkit) | `dsh-testkit@0.3.3` | `dsh-testkit@0.3.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:47.936Z |
+| [jingzhao-l/iterate-plugin](https://github.com/jingzhao-l/iterate-plugin) | `iterate-plugin@2.12.1` | `iterate-plugin@2.12.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:28.155Z |
+| [jsdvjx/dsh-strata](https://github.com/jsdvjx/dsh-strata) | `dsh-strata@0.8.2` | `dsh-strata@0.8.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:34.496Z |
+| [JUANWANG-BUAA/dsh-full-remote](https://github.com/JUANWANG-BUAA/dsh-full-remote) | `dsh-full-remote@0.3.7` | `dsh-full-remote@0.3.7` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:42.519Z |
+| [kangjinghang/dsh-xueqiu](https://github.com/kangjinghang/dsh-xueqiu) | `dsh-xueqiu@1.22.1` | `dsh-xueqiu@1.21.7` | `0.1.1-rc.2` / Node 22 | `update-pending` | 2026-08-24T04:45:34.258Z |
+| [liustack/modlens](https://github.com/liustack/modlens) | `@liustack/modlens@3.24.1` | `@liustack/modlens@3.24.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.561Z |
+| [liustack/modsearch](https://github.com/liustack/modsearch) | `@liustack/modsearch@5.9.0` | `@liustack/modsearch@5.9.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:43.536Z |
+| [lninghaha/dsh-coding-subscription-oauth](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `dsh-coding-subscription-oauth@0.6.0` | `dsh-coding-subscription-oauth@0.6.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:38.709Z |
+| [Lum1104/dsh-browser](https://github.com/Lum1104/dsh-browser/tree/main/packages/browser/bridge-browser) | — | — | — | `not-observed` | — |
+| [Mars-Sea/dsh-commandcode-provider](https://github.com/Mars-Sea/dsh-commandcode-provider) | `@mars-sea/dsh-commandcode-provider@0.8.0` | `@mars-sea/dsh-commandcode-provider@0.8.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:41.370Z |
+| [MichengAI/dsh-agency-agents](https://github.com/MichengAI/dsh-agency-agents) | `@michengai/dsh-agency-agents@0.1.21` | `@michengai/dsh-agency-agents@0.1.21` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:52.492Z |
+| [MichengAI/dsh-archive-manager](https://github.com/MichengAI/dsh-archive-manager) | `@michengai/dsh-archive-manager@0.1.14` | `@michengai/dsh-archive-manager@0.1.14` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:46:15.360Z |
+| [MichengAI/dsh-im-connect](https://github.com/MichengAI/dsh-im-connect) | `@michengai/dsh-im-connect@0.1.23` | `@michengai/dsh-im-connect@0.1.23` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:59:44.491Z |
+| [MichengAI/dsh-skills-manager](https://github.com/MichengAI/dsh-skills-manager) | `@michengai/dsh-skills-manager@0.1.24` | `@michengai/dsh-skills-manager@0.1.24` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:36.246Z |
+| [modusensus/dsh-mneme](https://github.com/modusensus/dsh-mneme/tree/main/dsh-mneme) | `@modusensus/dsh-mneme@0.7.0` | `@modusensus/dsh-mneme@0.7.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:59:54.069Z |
+| [moonquake2004/dsh-doctor](https://github.com/moonquake2004/dsh-doctor/tree/main/plugin) | `@moonquake2004/dsh-doctor@0.4.3` | `@moonquake2004/dsh-doctor@0.4.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:40.923Z |
+| [NanmiCoder/dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | `@nanmicoder/dsh-agent-teams@0.1.13` | `@nanmicoder/dsh-agent-teams@0.1.13` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:35.030Z |
+| [NoNameLeGo/dsh-catppuccin-theme](https://github.com/NoNameLeGo/dsh-catppuccin-theme) | `@nonamelego/dsh-catppuccin@0.3.1` | `@nonamelego/dsh-catppuccin@0.3.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:32.811Z |
+| [nonewind/dsh-spend](https://github.com/nonewind/dsh-spend) | `dsh-spend@0.4.6` | `dsh-spend@0.4.6` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:41.211Z |
+| [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | `dsh-chat-import@0.7.0` | `dsh-chat-import@0.7.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.663Z |
+| [omdsh-dev/DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | `dsh-better-sidebar@0.15.2` | `dsh-better-sidebar@0.15.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:47:07.838Z |
+| [omdsh-dev/dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | `dsh-mnemon@0.2.16` | `dsh-mnemon@0.2.16` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:52:37.835Z |
+| [openma-ai/deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) | `@openma/deepseek-harness-acp@0.4.24` | `@openma/deepseek-harness-acp@0.4.24` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:46:27.798Z |
+| [orziz/odai](https://github.com/orziz/odai/tree/main/dsh/plugin) | `odai-dsh-plugin@0.2.8` | `odai-dsh-plugin@0.2.8` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:39.851Z |
+| [PAKIKNOWLEDGE/dsh-auto-classifier](https://github.com/PAKIKNOWLEDGE/dsh-auto-classifier) | `dsh-auto-classifier@0.1.14` | `dsh-auto-classifier@0.1.14` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:27.365Z |
+| [PC2005-cloud/dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) | `dsh-pet@0.1.7` | `dsh-pet@0.1.7` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:53:30.779Z |
+| [Q00/ouroboros](https://github.com/Q00/ouroboros/tree/main/integrations/dsh-plugin) | — | — | — | `not-observed` | — |
+| [Relistencode/dsh-extension-hub](https://github.com/Relistencode/dsh-extension-hub) | `dsh-extension-hub@0.2.19` | `dsh-extension-hub@0.2.19` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:31.897Z |
+| [Renzic-Stone/DSH-EasyRewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) | `dsh-easyrewrite@2.1.0` | `dsh-easyrewrite@2.1.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:43.725Z |
+| [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) | `dsh-dream-skin@0.4.10` | `dsh-dream-skin@0.4.10` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:25.128Z |
+| [Rianico/dsh-better-edit](https://github.com/Rianico/dsh-better-edit) | `dsh-better-edit@0.3.2` | `dsh-better-edit@0.3.1` | `0.1.1-rc.2` / Node 22 | `update-pending` | 2026-08-24T04:45:33.785Z |
+| [Roarpeng/GraphFlow](https://github.com/Roarpeng/GraphFlow) | `@roarpeng/graphflow@1.12.2` | `@roarpeng/graphflow@1.12.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:46:39.319Z |
+| [saya-ch/dsh-mobile](https://github.com/saya-ch/dsh-mobile) | `dsh-mobile@0.2.0` | `dsh-mobile@0.2.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:31.171Z |
+| [shaobeichen/dsh-pocket](https://github.com/shaobeichen/dsh-pocket) | `dsh-pocket@1.13.4` | `dsh-pocket@1.13.4` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:46:27.002Z |
+| [shaoshi20/dshscan](https://github.com/shaoshi20/dshscan) | `@shaoshi/dshscan@0.5.0` | `@shaoshi/dshscan@0.5.0` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-23T11:53:45.378Z |
+| [siegfly/dsh-deepseek-vision](https://github.com/siegfly/dsh-deepseek-vision) | `dsh-deepseek-vision@0.1.7` | `dsh-deepseek-vision@0.1.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:39.005Z |
+| [SiriLee/dsh-rewind](https://github.com/SiriLee/dsh-rewind) | `dsh-rewind-plugin@0.3.3` | `dsh-rewind-plugin@0.3.2` | `0.1.1-rc.2` / Node 22 | `update-pending` | 2026-08-24T04:45:32.151Z |
+| [sjh9714/dsh-movein](https://github.com/sjh9714/dsh-movein) | `dsh-movein@0.12.1` | `dsh-movein@0.12.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:30.822Z |
+| [sjh9714/dsh-win32](https://github.com/sjh9714/dsh-win32) | `dsh-win32@0.16.3` | `dsh-win32@0.16.3` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.447Z |
+| [slywalker2006/dsh-passwords](https://github.com/slywalker2006/dsh-passwords) | `dsh-passwords@2.6.1` | `dsh-passwords@2.6.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:33.315Z |
+| [STARDUSTLC666/dsh-email](https://github.com/STARDUSTLC666/dsh-email) | `dsh-email@0.6.2` | `dsh-email@0.6.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:42.713Z |
+| [stuarthu/dsh-crew](https://github.com/stuarthu/dsh-crew) | `dsh-crew@0.10.0` | `dsh-crew@0.10.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:29.188Z |
+| [TecFancy/dsh-auth-gate](https://github.com/TecFancy/dsh-auth-gate) | `dsh-auth-gate@0.7.2` | `dsh-auth-gate@0.7.2` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:27.902Z |
+| [THEWOLFWALKER/dsh-notifier](https://github.com/THEWOLFWALKER/dsh-notifier) | `dsh-notifier@0.8.6` | `dsh-notifier@0.8.6` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T02:43:05.159Z |
+| [Tkingxiao/dsh-any-background](https://github.com/Tkingxiao/dsh-any-background) | `dsh-any-background@0.1.9` | `dsh-any-background@0.1.9` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:39.776Z |
+| [toby-bridges/api-relay-audit](https://github.com/toby-bridges/api-relay-audit) | — | — | — | `not-observed` | — |
+| [trench-xinxin/dsh-tool-lens](https://github.com/trench-xinxin/dsh-tool-lens) | `@trench-xinxin/dsh-tool-lens@2.0.5` | `@trench-xinxin/dsh-tool-lens@2.0.5` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:54:22.626Z |
+| [truelove-dreamer/dsh-plugin-vetting](https://github.com/truelove-dreamer/dsh-plugin-vetting) | `dsh-plugin-vetting@0.5.6` | `dsh-plugin-vetting@0.5.6` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:39.650Z |
+| [tt-a1i/archify](https://github.com/tt-a1i/archify/tree/main/integrations/deepseek-harness) | `@tt-a1i/archify-dsh@0.1.0` | `@tt-a1i/archify-dsh@0.1.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:34.782Z |
+| [V1ki/dsh-plugin-subscriptions](https://github.com/V1ki/dsh-plugin-subscriptions) | `dsh-plugin-subscriptions@0.5.1` | `dsh-plugin-subscriptions@0.5.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:29.022Z |
+| [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight/tree/main/hindsight-integrations/coding-agents) | `@vectorize-io/hindsight-coding-agents@0.4.1` | `@vectorize-io/hindsight-coding-agents@0.4.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.525Z |
+| [volcengine/OpenViking](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin) | `@openviking/dsh-memory-plugin@0.2.1` | `@openviking/dsh-memory-plugin@0.2.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:35.036Z |
+| [wloops/dsh-git-worktree](https://github.com/wloops/dsh-git-worktree) | `dsh-git-worktree@0.4.0` | `dsh-git-worktree@0.4.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:52:36.570Z |
+| [wqty123/dsh-browser](https://github.com/wqty123/dsh-browser) | `dsh-builtin-browser@0.1.15` | `dsh-builtin-browser@0.1.15` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:40.180Z |
+| [WSL043/dsh-codex-subscription](https://github.com/WSL043/dsh-codex-subscription) | `dsh-codex-subscription@1.6.0` | `dsh-codex-subscription@1.5.0` | `0.1.1-rc.2` / Node 22 | `update-pending` | 2026-08-24T04:45:28.223Z |
+| [wulun811/dsh-plugin-vet](https://github.com/wulun811/dsh-plugin-vet) | `@jieai/dsh-plugin-vet@0.2.6` | `@jieai/dsh-plugin-vet@0.2.6` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:27.045Z |
+| [xgone/dsh-remote](https://github.com/xgone/dsh-remote) | `@xgone/dsh-remote@0.2.8` | `@xgone/dsh-remote@0.2.7` | `0.1.1-rc.2` / Node 22 | `update-pending` | 2026-08-23T11:54:32.325Z |
+| [xiajiajun516/dsh-config-manager](https://github.com/xiajiajun516/dsh-config-manager) | `dsh-config-manager@0.1.51` | `dsh-config-manager@0.1.51` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:45:29.304Z |
+| [xiehuan123/dsh-deepread](https://github.com/xiehuan123/dsh-deepread) | `dsh-deepread@1.0.0` | `dsh-deepread@1.0.0` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:31.947Z |
+| [xmanrui/dsh-im](https://github.com/xmanrui/dsh-im) | `@xmanrui/dsh-im@2.0.1` | `@xmanrui/dsh-im@2.0.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:45:37.246Z |
+| [xmutfyh/dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) | `dsh-plugin-writing-guard@1.6.1` | `dsh-plugin-writing-guard@1.6.1` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:32.939Z |
+| [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | `dsh-vision-router@1.7.7` | `dsh-vision-router@1.7.7` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-24T04:59:57.675Z |
+| [yyh-001/dsh-meme](https://github.com/yyh-001/dsh-meme) | `dsh-meme@0.1.39` | `dsh-meme@0.1.39` | `0.1.1-rc.2` / Node 22 | `observed-compatible` | 2026-08-23T11:53:25.255Z |
+| [zhu1090093659/dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui/tree/main/packages/dsh-web-ui-all) | `@linxin666/dsh-web-ui-all@0.3.2` | `@linxin666/dsh-web-ui-all@0.3.2` | `0.1.1-rc.2` / Node 22 | `needs-review` | 2026-08-24T04:59:52.725Z |
+| [ZSeven-W/dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | `@zseven-w/dsh-openpencil@0.1.0-rc.1` | `@zseven-w/dsh-openpencil@0.1.0-rc.1` | `0.1.1-rc.2` / Node 24 | `needs-review` | 2026-08-23T11:53:40.988Z |
 
 ## Reading the status
 
 - `observed-compatible`: the exact artifact installed, registered and loaded in the stated headless cell.
 - `observed-incompatible`: the exact cell reproduced a runtime gate, install, registration or load failure.
 - `needs-review`: evidence exists, but Radar cannot yet separate a plugin defect from an uncovered execution plane, environment condition, or explicit dependency-build approval gate.
+- `update-pending`: the selected npm artifact changed and has no exact cell yet; historical evidence is retained but never inherited as the current result.
 - `not-observed`: the catalog entry is monitored statically but has no matching executable npm artifact in this cohort.
 
 A cell expires at its `recheckDueAt` value (168 hours after observation). Consumers must then show it as stale. This is exact compatibility evidence, not a security review or endorsement.

--- a/scripts/write-dsh-directory-feed.mjs
+++ b/scripts/write-dsh-directory-feed.mjs
@@ -39,5 +39,6 @@ process.stdout.write(`${JSON.stringify({
   observedCompatible: feed.summary['observed-compatible'],
   observedIncompatible: feed.summary['observed-incompatible'],
   needsReview: feed.summary['needs-review'],
+  updatePending: feed.summary['update-pending'],
   notObserved: feed.summary['not-observed'],
 }, null, 2)}\n`)

--- a/src/dsh-directory-feed.ts
+++ b/src/dsh-directory-feed.ts
@@ -4,7 +4,7 @@ import { parseNpmSpec } from './npm.js'
 import { TOOL_VERSION } from './version.js'
 
 export const AWESOME_DSH_COHORT_SCHEMA = 'upstream-radar.awesome-dsh-cohort/v1alpha1' as const
-export const DSH_DIRECTORY_COMPATIBILITY_FEED_SCHEMA = 'upstream-radar.dsh-directory-compatibility-feed/v1alpha1' as const
+export const DSH_DIRECTORY_COMPATIBILITY_FEED_SCHEMA = 'upstream-radar.dsh-directory-compatibility-feed/v1alpha2' as const
 
 const MAX_COHORT_PLUGINS = 100
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
@@ -14,6 +14,7 @@ export type DshDirectoryEvidenceStatus =
   | 'observed-compatible'
   | 'observed-incompatible'
   | 'needs-review'
+  | 'update-pending'
   | 'not-observed'
 
 export interface AwesomeDshCohortPlugin {
@@ -60,7 +61,7 @@ export interface DshDirectoryEvidenceCell {
   }
   executionPlane: 'headless'
   profile: 'headless'
-  status: Exclude<DshDirectoryEvidenceStatus, 'not-observed'>
+  status: Exclude<DshDirectoryEvidenceStatus, 'not-observed' | 'update-pending'>
   radarResult: DshCompatibilityLedgerEntry['result']
   requiredDependencyBuilds?: string[]
   observedAt: string
@@ -90,6 +91,10 @@ export interface DshDirectoryCompatibilityFeed {
     version: string
     repository: string
     license: 'Apache-2.0'
+  }
+  selectedHost?: {
+    package: '@deepseek-ai/dsh'
+    version: string
   }
   sourceCatalog: AwesomeDshCohort['source']
   boundary: {
@@ -223,7 +228,7 @@ export function parseAwesomeDshCohort(input: unknown): AwesomeDshCohort {
   }
 }
 
-function cellStatus(result: DshCompatibilityLedgerEntry['result']): Exclude<DshDirectoryEvidenceStatus, 'not-observed'> {
+function cellStatus(result: DshCompatibilityLedgerEntry['result']): Exclude<DshDirectoryEvidenceStatus, 'not-observed' | 'update-pending'> {
   if (result === 'compatible') return 'observed-compatible'
   if (result === 'runtime-incompatible' || result === 'install-failed' || result === 'load-failed') {
     return 'observed-incompatible'
@@ -231,11 +236,27 @@ function cellStatus(result: DshCompatibilityLedgerEntry['result']): Exclude<DshD
   return 'needs-review'
 }
 
-function aggregateStatus(cells: readonly DshDirectoryEvidenceCell[]): DshDirectoryEvidenceStatus {
+function aggregateExactCellStatus(cells: readonly DshDirectoryEvidenceCell[]): DshDirectoryEvidenceStatus {
   if (cells.length === 0) return 'not-observed'
   if (cells.some(cell => cell.status === 'observed-incompatible')) return 'observed-incompatible'
   if (cells.some(cell => cell.status === 'needs-review')) return 'needs-review'
   return 'observed-compatible'
+}
+
+function aggregateStatus(
+  distribution: AwesomeDshCohortPlugin['distribution'],
+  cells: readonly DshDirectoryEvidenceCell[],
+  selectedDshVersion?: string,
+): DshDirectoryEvidenceStatus {
+  if (cells.length === 0) return 'not-observed'
+  if (distribution.kind !== 'npm') return aggregateExactCellStatus(cells)
+  const selectedSpec = `${distribution.name}@${distribution.selectedVersion}`
+  const currentCells = cells.filter(cell => (
+    cell.artifact.spec === selectedSpec
+    && (selectedDshVersion === undefined || cell.dsh.version === selectedDshVersion)
+  ))
+  if (currentCells.length === 0) return 'update-pending'
+  return aggregateExactCellStatus(currentCells)
 }
 
 function dueAt(observedAt: string, refreshAfterHours: number): string {
@@ -267,23 +288,20 @@ export function buildDshDirectoryCompatibilityFeed(input: {
     .filter(target => target.observerTargetId !== undefined)
     .map(target => [target.observerTargetId as string, target]))
 
-  const observedDistribution = (plugin: AwesomeDshCohortPlugin): AwesomeDshCohortPlugin['distribution'] => {
-    if (plugin.distribution.kind !== 'npm') return plugin.distribution
-    if (typeof input.observations !== 'object' || input.observations === null || Array.isArray(input.observations)) {
-      return plugin.distribution
-    }
+  const observedPackage = (targetId: string): { name: string; version: string; distTag?: string } | undefined => {
+    if (typeof input.observations !== 'object' || input.observations === null || Array.isArray(input.observations)) return undefined
     const rawTargets = (input.observations as Record<string, unknown>).targets
-    if (typeof rawTargets !== 'object' || rawTargets === null || Array.isArray(rawTargets)) return plugin.distribution
-    const rawObservation = (rawTargets as Record<string, unknown>)[plugin.id]
-    if (typeof rawObservation !== 'object' || rawObservation === null || Array.isArray(rawObservation)) return plugin.distribution
+    if (typeof rawTargets !== 'object' || rawTargets === null || Array.isArray(rawTargets)) return undefined
+    const rawObservation = (rawTargets as Record<string, unknown>)[targetId]
+    if (typeof rawObservation !== 'object' || rawObservation === null || Array.isArray(rawObservation)) return undefined
     const rawPackage = (rawObservation as Record<string, unknown>).package
-    if (typeof rawPackage !== 'object' || rawPackage === null || Array.isArray(rawPackage)) return plugin.distribution
+    if (typeof rawPackage !== 'object' || rawPackage === null || Array.isArray(rawPackage)) return undefined
     const packageRecord = rawPackage as Record<string, unknown>
-    if (packageRecord.name !== plugin.distribution.name || typeof packageRecord.version !== 'string') return plugin.distribution
+    if (typeof packageRecord.name !== 'string' || typeof packageRecord.version !== 'string') return undefined
     try {
       parseNpmSpec(`${packageRecord.name}@${packageRecord.version}`)
     } catch {
-      return plugin.distribution
+      return undefined
     }
     const distTag = typeof packageRecord.distTag === 'string'
       && packageRecord.distTag.trim() !== ''
@@ -291,10 +309,24 @@ export function buildDshDirectoryCompatibilityFeed(input: {
       ? packageRecord.distTag
       : undefined
     return {
+      name: packageRecord.name,
+      version: packageRecord.version,
+      ...(distTag === undefined ? {} : { distTag }),
+    }
+  }
+
+  const observedDsh = observedPackage('deepseek-harness')
+  const selectedDshVersion = observedDsh?.name === '@deepseek-ai/dsh' ? observedDsh.version : undefined
+
+  const observedDistribution = (plugin: AwesomeDshCohortPlugin): AwesomeDshCohortPlugin['distribution'] => {
+    if (plugin.distribution.kind !== 'npm') return plugin.distribution
+    const observed = observedPackage(plugin.id)
+    if (observed?.name !== plugin.distribution.name) return plugin.distribution
+    return {
       kind: 'npm',
       name: plugin.distribution.name,
-      selectedVersion: packageRecord.version,
-      ...(distTag === undefined ? {} : { distTag }),
+      selectedVersion: observed.version,
+      ...(observed.distTag === undefined ? {} : { distTag: observed.distTag }),
     }
   }
 
@@ -325,6 +357,7 @@ export function buildDshDirectoryCompatibilityFeed(input: {
       recheckDueAt: dueAt(entry.observedAt, installTargets.refreshAfterHours),
       reason: entry.reason,
     })).sort((left, right) => left.caseId.localeCompare(right.caseId))
+    const distribution = observedDistribution(plugin)
     return {
       id: plugin.id,
       repository: plugin.repository,
@@ -333,8 +366,8 @@ export function buildDshDirectoryCompatibilityFeed(input: {
       catalogEntry: plugin.catalogEntry,
       catalogEntryUrl: `https://github.com/${cohort.source.repository}/blob/${cohort.source.commit}/${plugin.catalogEntry}`,
       category: plugin.category,
-      distribution: observedDistribution(plugin),
-      status: aggregateStatus(cells),
+      distribution,
+      status: aggregateStatus(distribution, cells, selectedDshVersion),
       cells,
       evidenceUrl: `${repositoryBaseUrl}/blob/main/compatibility-ledger.json`,
     }
@@ -345,6 +378,7 @@ export function buildDshDirectoryCompatibilityFeed(input: {
     'observed-compatible': 0,
     'observed-incompatible': 0,
     'needs-review': 0,
+    'update-pending': 0,
     'not-observed': 0,
   }
   for (const plugin of plugins) summary[plugin.status] += 1
@@ -353,13 +387,16 @@ export function buildDshDirectoryCompatibilityFeed(input: {
     schema: DSH_DIRECTORY_COMPATIBILITY_FEED_SCHEMA,
     generatedAt,
     producer: { name: 'upstream-radar', version: TOOL_VERSION, repository: repositoryBaseUrl, license: 'Apache-2.0' },
+    ...(selectedDshVersion === undefined ? {} : {
+      selectedHost: { package: '@deepseek-ai/dsh' as const, version: selectedDshVersion },
+    }),
     sourceCatalog: cohort.source,
     boundary: {
       claim: 'exact-cell compatibility evidence; not a security review, endorsement, or timeless compatibility badge',
       executionPlane: 'headless',
       profile: 'headless',
       isolation: 'fresh GitHub-hosted VM plus restricted container',
-      consumptionRule: 'Treat a cell as stale after recheckDueAt. needs-review and not-observed must never be rendered as pass or fail.',
+      consumptionRule: 'A plugin status applies only when a cell exactly matches the selected artifact. Treat update-pending, needs-review and not-observed as neither pass nor fail, and treat a cell as stale after recheckDueAt.',
       refreshAfterHours: installTargets.refreshAfterHours,
     },
     summary,
@@ -374,6 +411,11 @@ function markdown(value: string): string {
 function cellCoordinate(entry: DshDirectoryCompatibilityEntry): string {
   if (entry.cells.length === 0) return '—'
   return entry.cells.map(cell => `\`${markdown(cell.artifact.spec)}\``).join('<br>')
+}
+
+function selectedCoordinate(entry: DshDirectoryCompatibilityEntry): string {
+  if (entry.distribution.kind !== 'npm') return '—'
+  return `\`${markdown(`${entry.distribution.name}@${entry.distribution.selectedVersion}`)}\``
 }
 
 function dshCoordinate(entry: DshDirectoryCompatibilityEntry): string {
@@ -391,14 +433,15 @@ export function renderDshDirectoryCompatibilityFeed(feed: DshDirectoryCompatibil
     '# DSH directory compatibility evidence',
     '',
     `Generated from catalog commit [\`${feed.sourceCatalog.commit.slice(0, 12)}\`](${feed.sourceCatalog.commitUrl}) at \`${feed.generatedAt}\`.`,
+    ...(feed.selectedHost === undefined ? [] : [`Selected host: \`${feed.selectedHost.package}@${feed.selectedHost.version}\`.`]),
     '',
-    `**${feed.summary['observed-compatible']} observed compatible · ${feed.summary['observed-incompatible']} observed incompatible · ${feed.summary['needs-review']} needs review · ${feed.summary['not-observed']} not observed**`,
+    `**${feed.summary['observed-compatible']} observed compatible · ${feed.summary['observed-incompatible']} observed incompatible · ${feed.summary['needs-review']} needs review · ${feed.summary['update-pending']} update pending · ${feed.summary['not-observed']} not observed**`,
     '',
-    '| Catalog plugin | Exact artifact | Exact DSH / runtime | Evidence status | Observed |',
-    '| --- | --- | --- | --- | --- |',
+    '| Catalog plugin | Selected artifact | Tested artifact | Exact DSH / runtime | Evidence status | Observed |',
+    '| --- | --- | --- | --- | --- | --- |',
   ]
   for (const entry of feed.plugins) {
-    lines.push(`| [${markdown(entry.repository)}](${entry.catalogUrl}) | ${cellCoordinate(entry)} | ${dshCoordinate(entry)} | \`${entry.status}\` | ${observedCoordinate(entry)} |`)
+    lines.push(`| [${markdown(entry.repository)}](${entry.catalogUrl}) | ${selectedCoordinate(entry)} | ${cellCoordinate(entry)} | ${dshCoordinate(entry)} | \`${entry.status}\` | ${observedCoordinate(entry)} |`)
   }
   lines.push(
     '',
@@ -407,6 +450,7 @@ export function renderDshDirectoryCompatibilityFeed(feed: DshDirectoryCompatibil
     '- `observed-compatible`: the exact artifact installed, registered and loaded in the stated headless cell.',
     '- `observed-incompatible`: the exact cell reproduced a runtime gate, install, registration or load failure.',
     '- `needs-review`: evidence exists, but Radar cannot yet separate a plugin defect from an uncovered execution plane, environment condition, or explicit dependency-build approval gate.',
+    '- `update-pending`: the selected npm artifact changed and has no exact cell yet; historical evidence is retained but never inherited as the current result.',
     '- `not-observed`: the catalog entry is monitored statically but has no matching executable npm artifact in this cohort.',
     '',
     `A cell expires at its \`recheckDueAt\` value (${feed.boundary.refreshAfterHours} hours after observation). Consumers must then show it as stale. This is exact compatibility evidence, not a security review or endorsement.`,

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -142,6 +142,7 @@ describe('reusable GitHub Action', () => {
     assert.match(checkedInReviewWorkflow, /finding\.remediation/)
     const observationPersistStep = checkedInObserverWorkflow.indexOf('name: Persist observation and Agent planning state')
     const installObservationJob = checkedInObserverWorkflow.indexOf('\n  install-observation:')
+    const observerHealthJob = checkedInObserverWorkflow.indexOf('\n  observer-source-health:')
     const reconcileStep = checkedInObserverWorkflow.indexOf('name: Reconcile dynamic evidence into the compatibility ledger')
     const publishStep = checkedInObserverWorkflow.indexOf('name: Publish directory-consumable compatibility evidence')
     const persistStep = checkedInObserverWorkflow.indexOf('name: Persist compatibility evidence')
@@ -149,10 +150,18 @@ describe('reusable GitHub Action', () => {
     assert.ok(reconcileStep >= 0)
     assert.ok(observationPersistStep >= 0)
     assert.ok(installObservationJob > observationPersistStep)
+    assert.ok(observerHealthJob > incompleteGate)
     assert.ok(publishStep > reconcileStep)
     assert.ok(persistStep > publishStep)
     assert.ok(incompleteGate > persistStep)
     assert.match(checkedInObserverWorkflow.slice(reconcileStep, publishStep), /continue-on-error: true/)
+    const observeStep = checkedInObserverWorkflow.slice(
+      checkedInObserverWorkflow.indexOf('name: Observe upstream changes'),
+      checkedInObserverWorkflow.indexOf('name: Reuse current evidence for the headless Agent loop'),
+    )
+    assert.match(observeStep, /continue-on-error: true/)
+    assert.match(checkedInObserverWorkflow.slice(observerHealthJob), /needs\.observe\.outputs\.observer_exit/)
+    assert.match(checkedInObserverWorkflow.slice(observerHealthJob), /exit 1/)
     const observationPersistence = checkedInObserverWorkflow.slice(observationPersistStep, installObservationJob)
     assert.match(observationPersistence, /git diff --quiet -- observations\.json/)
     assert.match(observationPersistence, /node scripts\/write-dsh-directory-feed\.mjs/)

--- a/test/dsh-directory-feed.test.ts
+++ b/test/dsh-directory-feed.test.ts
@@ -86,6 +86,9 @@ function fixture() {
     },
     observations: {
       targets: {
+        'deepseek-harness': {
+          package: { name: '@deepseek-ai/dsh', version: '0.1.1-rc.2', distTag: 'next' },
+        },
         clean: {
           package: { name: 'clean', version: '2.0.0-beta.1', distTag: 'beta' },
         },
@@ -104,12 +107,13 @@ describe('DSH directory compatibility feed', () => {
 
     assert.deepEqual(feed.summary, {
       total: 6,
-      'observed-compatible': 1,
+      'observed-compatible': 0,
       'observed-incompatible': 1,
       'needs-review': 3,
+      'update-pending': 1,
       'not-observed': 1,
     })
-    assert.equal(feed.plugins.find(item => item.id === 'clean')?.status, 'observed-compatible')
+    assert.equal(feed.plugins.find(item => item.id === 'clean')?.status, 'update-pending')
     assert.deepEqual(feed.plugins.find(item => item.id === 'clean')?.distribution, {
       kind: 'npm',
       name: 'clean',
@@ -129,6 +133,38 @@ describe('DSH directory compatibility feed', () => {
     )
     assert.equal(feed.plugins.find(item => item.id === 'clean')?.cells[0]?.recheckDueAt, '2026-08-30T00:00:00.000Z')
     assert.equal(feed.producer.license, 'Apache-2.0')
+    assert.deepEqual(feed.selectedHost, {
+      package: '@deepseek-ai/dsh',
+      version: '0.1.1-rc.2',
+    })
+  })
+
+  it('does not inherit old green cells after the selected DSH host changes', () => {
+    const input = fixture()
+    const feed = buildDshDirectoryCompatibilityFeed({
+      ...input,
+      observations: {
+        ...input.observations,
+        targets: {
+          ...input.observations.targets,
+          'deepseek-harness': {
+            package: { name: '@deepseek-ai/dsh', version: '0.1.1-rc.3', distTag: 'next' },
+          },
+        },
+      },
+      generatedAt: '2026-08-23T01:00:00.000Z',
+    })
+
+    assert.equal(feed.plugins.find(item => item.id === 'broken')?.status, 'update-pending')
+    assert.equal(feed.plugins.find(item => item.id === 'peer-gap')?.status, 'update-pending')
+    assert.deepEqual(feed.summary, {
+      total: 6,
+      'observed-compatible': 0,
+      'observed-incompatible': 0,
+      'needs-review': 0,
+      'update-pending': 5,
+      'not-observed': 1,
+    })
   })
 
   it('does not let malformed or name-mismatched observation state replace catalog distribution metadata', () => {
@@ -158,7 +194,9 @@ describe('DSH directory compatibility feed', () => {
       generatedAt: '2026-08-23T01:00:00.000Z',
     })
     const markdown = renderDshDirectoryCompatibilityFeed(feed)
-    assert.match(markdown, /1 observed compatible · 1 observed incompatible · 3 needs review · 1 not observed/)
+    assert.match(markdown, /0 observed compatible · 1 observed incompatible · 3 needs review · 1 update pending · 1 not observed/)
+    assert.match(markdown, /`clean@2\.0\.0-beta\.1`.*`clean@1\.0\.0`.*`update-pending`/)
+    assert.match(markdown, /has no exact cell yet/)
     assert.match(markdown, /must then show it as stale/)
     assert.match(markdown, /not a security review or endorsement/)
   })


### PR DESCRIPTION
## What changed

- mark a plugin `update-pending` when the selected npm artifact has no exact compatibility cell
- invalidate historical plugin evidence when the selected DSH host changes
- expose the selected host and both selected/tested artifact coordinates in the public feed
- let successful observer targets continue through Agent planning and isolated retesting after a partial source failure
- surface the partial source failure only after downstream work finishes

## Current 100-plugin result

The regenerated exact-version feed now reports:

- 67 observed compatible
- 22 needs review
- 7 update pending
- 4 not observed
- 0 observed incompatible

## Verification

- `pnpm test` (357/357)
- local reconciliation selects 13 current cells, including all seven changed directory artifacts
