### PR TITLE
Start queued observers from the latest durable state

### DIFF
--- a/.github/workflows/upstream-observer.yml
+++ b/.github/workflows/upstream-observer.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Check out the observer and its targets
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # A queued run may start after an earlier observer has advanced the
+          # durable state. Read the latest serialized observation point rather
+          # than the commit that happened to trigger this run.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
 
       - name: Set up pnpm

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -141,6 +141,10 @@ describe('reusable GitHub Action', () => {
     assert.match(reviewWorkflow, /finding\.remediation/)
     assert.match(checkedInReviewWorkflow, /finding\.remediation/)
     const observationPersistStep = checkedInObserverWorkflow.indexOf('name: Persist observation and Agent planning state')
+    const initialCheckoutStep = checkedInObserverWorkflow.slice(
+      checkedInObserverWorkflow.indexOf('name: Check out the observer and its targets'),
+      checkedInObserverWorkflow.indexOf('name: Set up pnpm'),
+    )
     const installObservationJob = checkedInObserverWorkflow.indexOf('\n  install-observation:')
     const observerHealthJob = checkedInObserverWorkflow.indexOf('\n  observer-source-health:')
     const reconcileStep = checkedInObserverWorkflow.indexOf('name: Reconcile dynamic evidence into the compatibility ledger')
@@ -149,6 +153,7 @@ describe('reusable GitHub Action', () => {
     const incompleteGate = checkedInObserverWorkflow.indexOf('name: Fail after persisting incomplete reconciliation')
     assert.ok(reconcileStep >= 0)
     assert.ok(observationPersistStep >= 0)
+    assert.match(initialCheckoutStep, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/)
     assert.ok(installObservationJob > observationPersistStep)
     assert.ok(observerHealthJob > incompleteGate)
     assert.ok(publishStep > reconcileStep)


### PR DESCRIPTION
## Problem

A queued observer run checked out the commit that triggered it. If an earlier serialized run advanced `observations.json` or the compatibility ledger, the queued run later failed to push its stale state with a non-fast-forward error.

## Fix

Check out the default branch when the observer job actually starts. The existing concurrency group still serializes state writers; this change makes each serialized writer read the latest durable observation point.

## Production evidence

Run 32807166015 reproduced the race immediately after run 32806397554 advanced `main`.

## Verification

- targeted Action/workflow tests pass
- regression assertion requires the initial observer checkout to use the default branch
