### PR TITLE
fix: retry durable agent tasks without rescanning

### DIFF
--- a/.github/workflows/upstream-observer.yml
+++ b/.github/workflows/upstream-observer.yml
@@ -4,12 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: Run the full observer or reuse current evidence for the headless Agent loop
+        description: Run the full observer, retry durable Agent tasks, or reuse evidence for the headless loop
         required: true
         default: full
         type: choice
         options:
           - full
+          - agent-retry
           - headless-agent
   schedule:
     # The observer is intentionally periodic: durable state makes the loop
@@ -62,7 +63,7 @@ jobs:
           pnpm build
 
       - name: Build downstream reverse dependency index
-        if: inputs.mode != 'headless-agent'
+        if: inputs.mode != 'headless-agent' && inputs.mode != 'agent-retry'
         run: |
           # Use the checked-in index generated from the first-batch corpus of
           # real DSH plugin reports. Refresh it intentionally with
@@ -86,6 +87,7 @@ jobs:
           ISSUE_LOCATOR_LLM_BASE_URL: ${{ secrets.ISSUE_LOCATOR_LLM_BASE_URL }}
           ISSUE_LOCATOR_LLM_API_KEY: ${{ secrets.ISSUE_LOCATOR_LLM_API_KEY }}
           ISSUE_LOCATOR_LLM_MODEL: ${{ secrets.ISSUE_LOCATOR_LLM_MODEL }}
+          OBSERVER_MODE: ${{ inputs.mode }}
         shell: bash
         run: |
           set +e
@@ -96,10 +98,16 @@ jobs:
             examples/upstream-observer/targets.yml
             --state observations.json
             --report "$OBSERVER_REPORT"
-            --reverse-index "$RUNNER_TEMP/reverse-dependency-index.json"
-            --retry-pending
             --json
           )
+          if [[ "$OBSERVER_MODE" == 'agent-retry' ]]; then
+            observe_args+=(--retry-pending-only)
+          else
+            observe_args+=(
+              --reverse-index "$RUNNER_TEMP/reverse-dependency-index.json"
+              --retry-pending
+            )
+          fi
           if [[ -n "${ISSUE_LOCATOR_LLM_BASE_URL:-}" && -n "${ISSUE_LOCATOR_LLM_API_KEY:-}" && -n "${ISSUE_LOCATOR_LLM_MODEL:-}" ]]; then
             umask 077
             {
@@ -132,6 +140,7 @@ jobs:
       # target package; it emits only a bounded headless retry contract. The
       # later reusable workflow receives that contract but no model secret.
       - name: Let the Agent plan bounded headless follow-ups
+        if: inputs.mode != 'agent-retry'
         id: headless-agent-plan
         continue-on-error: true
         env:
@@ -364,17 +373,17 @@ jobs:
           echo 'The incomplete cells remain unsatisfied and will be selected by the next reconciliation run.'
           exit 1
 
-  # Keep a partial source outage visible without letting it short-circuit the
-  # successful targets discovered in the same observer cycle.
-  observer-source-health:
+  # Keep a partial source outage or failed explicit Agent retry visible without
+  # letting it discard successful work from the same observer cycle.
+  observer-final-health:
     needs: [observe, install-observation, reconcile-install-observations]
     if: always() && needs.observe.outputs.observer_exit != '' && needs.observe.outputs.observer_exit != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - name: Surface the partial observer failure after downstream work
+      - name: Surface the deferred observer failure after downstream work
         env:
           OBSERVER_EXIT: ${{ needs.observe.outputs.observer_exit }}
         run: |
-          echo "The observer returned exit code ${OBSERVER_EXIT}; successful targets still completed planning and isolated retesting."
+          echo "The observer returned exit code ${OBSERVER_EXIT}; successful source observations, Agent conclusions, and isolated retests were still persisted."
           exit 1

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -261,7 +261,8 @@ Usage:
     [--report <report.md>] [--dsh-version <v1>,<v2>,...]
     [--reverse-index <index.json>]
     [--dsh-agent-command <executable>]
-    [--dsh-agent-arg <argument>] [--llm-env-file <path>] [--retry-pending]
+    [--dsh-agent-arg <argument>] [--llm-env-file <path>]
+    [--retry-pending | --retry-pending-only]
     [--ecosystem <dsh|codex|pi>] [--id <id>] [--package <name>]
     [--package-path <path>] [--lockfile <path>] [--lockfile-type <npm|pnpm>]
     [--ref <branch>] [--json]
@@ -293,6 +294,11 @@ only the model call. It accepts ISSUE_LOCATOR_LLM_*, OPENAI_*, or MODEL/CODEX_MO
 keys; it never writes the key or endpoint to observations.json.
 If a ModelBest-style base URL ends in /llm/v1, a 404 also retries the known
 /llm/openai/v1 path.
+
+--retry-pending-only consumes durable Agent tasks from observations.json
+without reading GitHub/npm, reviewing artifacts, or changing source observation
+points. It requires an Agent or model configuration and fails while any retry
+still remains pending.
 
 The exact npm artifact review is independent of the DSH Agent/model. It runs
 when a meaningful change has a published package, and its dependency findings
@@ -527,7 +533,7 @@ Usage:
   upstream-radar doctor [config.json] [options]
   upstream-radar scan <directory-or-github-url> [--json] [--fail-on <warn|review|block|never>]
   upstream-radar inspect [npm:]<package>@<exact-version> [--deep] [--json] [--fail-on <warn|review|block|never>]
-  upstream-radar observe <targets.yml|github-url> [--state <observations.json>] [--report <report.md>] [--dsh-version <v1>,<v2>,...] [--reverse-index <index.json>] [--dsh-agent-command <executable>] [--dsh-agent-arg <argument>] [--llm-env-file <path>] [--retry-pending] [--ecosystem <dsh|codex|pi>] [--id <id>] [--package <name>] [--package-path <path>] [--lockfile <path>] [--lockfile-type <npm|pnpm>] [--ref <branch>] [--json]
+  upstream-radar observe <targets.yml|github-url> [--state <observations.json>] [--report <report.md>] [--dsh-version <v1>,<v2>,...] [--reverse-index <index.json>] [--dsh-agent-command <executable>] [--dsh-agent-arg <argument>] [--llm-env-file <path>] [--retry-pending | --retry-pending-only] [--ecosystem <dsh|codex|pi>] [--id <id>] [--package <name>] [--package-path <path>] [--lockfile <path>] [--lockfile-type <npm|pnpm>] [--ref <branch>] [--json]
   upstream-radar graph <npm-lock|pnpm-lock> <lockfile> [--root <package>@<exact-version>] [--json]
   upstream-radar graph reverse <reports-directory> [--package <name>@<exact-version>] [--output <index.json>] [--json]
   upstream-radar profile-check [profile-directory] [--patch <path>] [--report <path>] [--summary] [--json]
@@ -1787,6 +1793,7 @@ async function runObserve(args: readonly string[]): Promise<number> {
   let reverseIndexPath: string | undefined
   let registry: string | undefined
   let retryPending = false
+  let retryPendingOnly = false
   let json = false
   let inlineEcosystem: string | undefined
   let inlineId: string | undefined
@@ -1803,6 +1810,8 @@ async function runObserve(args: readonly string[]): Promise<number> {
       json = true
     } else if (argument === '--retry-pending') {
       retryPending = true
+    } else if (argument === '--retry-pending-only') {
+      retryPendingOnly = true
     } else if (argument === '--ecosystem' || argument === '--id' || argument === '--package' || argument === '--package-path' || argument === '--lockfile' || argument === '--lockfile-type' || argument === '--ref' || argument === '--dsh-version' || argument === '--state' || argument === '--report' || argument === '--reverse-index' || argument === '--dsh-agent-command' || argument === '--dsh-agent-arg' || argument === '--llm-env-file' || argument === '--registry') {
       const value = args[index + 1]
       if (value === undefined || (value.startsWith('-') && argument !== '--dsh-agent-arg')) throw new Error(`${argument} requires a value`)
@@ -1872,10 +1881,17 @@ async function runObserve(args: readonly string[]): Promise<number> {
   if (agentCommand !== undefined && llmEnvFile !== undefined) {
     throw new Error('observe accepts either --dsh-agent-command or --llm-env-file, not both')
   }
+  if (retryPending && retryPendingOnly) {
+    throw new Error('observe accepts either --retry-pending or --retry-pending-only, not both')
+  }
+  if (retryPendingOnly && agentCommand === undefined && llmEnvFile === undefined) {
+    throw new Error('--retry-pending-only requires --dsh-agent-command or --llm-env-file')
+  }
   const result = await runObserver(config, previousState, {
     source,
     ...(reverseDependencyIndex === undefined ? {} : { reverseDependencyIndex }),
     retryPending,
+    retryPendingOnly,
     artifactReviewer: async (spec, target) => reviewObserverArtifact(spec, target, registry),
     ...(agentOptions === undefined ? {} : {
       agent: (task, prompt) => runDshAgentCommand(task, prompt, agentOptions),
@@ -1891,10 +1907,11 @@ async function runObserve(args: readonly string[]): Promise<number> {
   }
   process.stdout.write(json ? reportJson : renderObserverReport(result.report))
   const observerExit = observerExitCode(result.report)
+  const pendingRetryExit = retryPendingOnly && result.report.pendingTasks.length > 0 ? 1 : 0
   if (result.report.agent.failed > 0) {
-    process.stderr.write('upstream-radar: static observation completed; DSH Agent/model analysis remains pending. See the report and rerun with --retry-pending.\n')
+    process.stderr.write(`upstream-radar: DSH Agent/model analysis remains pending. See the report and rerun with ${retryPendingOnly ? '--retry-pending-only' : '--retry-pending'}.\n`)
   }
-  return observerExit
+  return observerExit === 0 && pendingRetryExit === 0 ? 0 : 1
 }
 
 async function runQuickstart(args: readonly string[]): Promise<number> {

--- a/src/upstream-observer.ts
+++ b/src/upstream-observer.ts
@@ -342,6 +342,8 @@ export interface RunObserverOptions {
   reverseDependencyIndex?: ReverseDependencyIndex
   agent?: (task: UpstreamChangeTask, prompt: string) => Promise<ObserverAgentInvocation>
   retryPending?: boolean
+  /** Retry durable Agent tasks without reading GitHub, npm, or artifact inputs again. */
+  retryPendingOnly?: boolean
 }
 
 interface GitHubRepository {
@@ -1912,87 +1914,89 @@ export async function runObserver(
   const errors: Array<{ targetId: string; message: string }> = []
   const newTasks: UpstreamChangeTask[] = []
 
-  for (const configuredTarget of config.targets) {
-    try {
-      const current = await source.observe(configuredTarget, checkedAt)
-      const before = previousState.targets[configuredTarget.id]
-      if (before === undefined) {
-        nextTargets[configuredTarget.id] = current
-        baselineTargets.push(configuredTarget.id)
-        if (current.alignment !== undefined) alignmentFindings.push({ targetId: configuredTarget.id, alignment: structuredClone(current.alignment) })
-        continue
-      }
-      // checkedAt belongs in the run report. Keep the durable observation point
-      // byte-stable when its evidence did not change, so a no-op cron run does
-      // not manufacture a commit from a fresh timestamp alone.
-      nextTargets[configuredTarget.id] = snapshotEvidenceSignature(before) === snapshotEvidenceSignature(current)
-        ? before
-        : current
-      if (before.alignment === undefined && current.alignment !== undefined) {
-        // Upgrade legacy state into the IR and show its first finding once.
-        // This is evidence for the author, not a fake upstream change and not
-        // a reason to wake the Agent on every subsequent scheduled run.
-        alignmentFindings.push({ targetId: configuredTarget.id, alignment: structuredClone(current.alignment) })
-      }
-      const sourceChange = before.source.commit === current.source.commit
-        ? {
-            beforeCommit: before.source.commit,
-            afterCommit: current.source.commit,
-            comparison: 'complete' as const,
-            changedFiles: [],
-            runtimeFiles: [],
-            nonRuntimeFiles: [],
-          }
-        : await source.compare(current.source.repository, before.source.commit, current.source.commit)
-      const change = createChange(configuredTarget, before, current, sourceChange, options.reverseDependencyIndex)
-      if (change.reasons.length === 0) continue
-      let reviewedChange = change
-      if (change.meaningful && current.package !== undefined && options.artifactReviewer !== undefined) {
-        const packageSpec = `npm:${current.package.name}@${current.package.version}`
-        try {
-          reviewedChange = {
-            ...change,
-            artifactReview: await options.artifactReviewer(packageSpec, configuredTarget),
-          }
-        } catch (error: unknown) {
-          // Artifact review is useful evidence, but it must not turn a valid
-          // source observation into a source-observation error. Keep the
-          // change and make the incomplete review explicit for the author and
-          // for a later retry of the whole scheduled run.
-          reviewedChange = {
-            ...change,
-            artifactReview: {
-              spec: packageSpec,
-              verdict: 'review',
-              riskVerdict: 'review',
-              coverageVerdict: 'incomplete',
-              artifactIntegrity: 'not-checked',
-              registrySignature: 'not-checked',
-              provenance: 'not-checked',
-              dependencyResolution: 'manifest-only',
-              dependencyAuditStatus: 'failed',
-              packages: null,
-              unresolved: 0,
-              vulnerabilities: null,
-              installScriptPackages: [],
-              installScriptDetails: [],
-              findings: [],
-              error: safeError(error),
-            },
+  if (options.retryPendingOnly !== true) {
+    for (const configuredTarget of config.targets) {
+      try {
+        const current = await source.observe(configuredTarget, checkedAt)
+        const before = previousState.targets[configuredTarget.id]
+        if (before === undefined) {
+          nextTargets[configuredTarget.id] = current
+          baselineTargets.push(configuredTarget.id)
+          if (current.alignment !== undefined) alignmentFindings.push({ targetId: configuredTarget.id, alignment: structuredClone(current.alignment) })
+          continue
+        }
+        // checkedAt belongs in the run report. Keep the durable observation point
+        // byte-stable when its evidence did not change, so a no-op cron run does
+        // not manufacture a commit from a fresh timestamp alone.
+        nextTargets[configuredTarget.id] = snapshotEvidenceSignature(before) === snapshotEvidenceSignature(current)
+          ? before
+          : current
+        if (before.alignment === undefined && current.alignment !== undefined) {
+          // Upgrade legacy state into the IR and show its first finding once.
+          // This is evidence for the author, not a fake upstream change and not
+          // a reason to wake the Agent on every subsequent scheduled run.
+          alignmentFindings.push({ targetId: configuredTarget.id, alignment: structuredClone(current.alignment) })
+        }
+        const sourceChange = before.source.commit === current.source.commit
+          ? {
+              beforeCommit: before.source.commit,
+              afterCommit: current.source.commit,
+              comparison: 'complete' as const,
+              changedFiles: [],
+              runtimeFiles: [],
+              nonRuntimeFiles: [],
+            }
+          : await source.compare(current.source.repository, before.source.commit, current.source.commit)
+        const change = createChange(configuredTarget, before, current, sourceChange, options.reverseDependencyIndex)
+        if (change.reasons.length === 0) continue
+        let reviewedChange = change
+        if (change.meaningful && current.package !== undefined && options.artifactReviewer !== undefined) {
+          const packageSpec = `npm:${current.package.name}@${current.package.version}`
+          try {
+            reviewedChange = {
+              ...change,
+              artifactReview: await options.artifactReviewer(packageSpec, configuredTarget),
+            }
+          } catch (error: unknown) {
+            // Artifact review is useful evidence, but it must not turn a valid
+            // source observation into a source-observation error. Keep the
+            // change and make the incomplete review explicit for the author and
+            // for a later retry of the whole scheduled run.
+            reviewedChange = {
+              ...change,
+              artifactReview: {
+                spec: packageSpec,
+                verdict: 'review',
+                riskVerdict: 'review',
+                coverageVerdict: 'incomplete',
+                artifactIntegrity: 'not-checked',
+                registrySignature: 'not-checked',
+                provenance: 'not-checked',
+                dependencyResolution: 'manifest-only',
+                dependencyAuditStatus: 'failed',
+                packages: null,
+                unresolved: 0,
+                vulnerabilities: null,
+                installScriptPackages: [],
+                installScriptDetails: [],
+                findings: [],
+                error: safeError(error),
+              },
+            }
           }
         }
+        changes.push(reviewedChange)
+        if (!reviewedChange.meaningful || reviewedChange.taskId === undefined) continue
+        const task = createUpstreamChangeTask(configuredTarget, reviewedChange, checkedAt)
+        newTasks.push(task)
+        if (!taskAlreadyPending(pendingTasks, task.id)) pendingTasks.push(task)
+      } catch (error: unknown) {
+        errors.push({ targetId: configuredTarget.id, message: safeError(error) })
       }
-      changes.push(reviewedChange)
-      if (!reviewedChange.meaningful || reviewedChange.taskId === undefined) continue
-      const task = createUpstreamChangeTask(configuredTarget, reviewedChange, checkedAt)
-      newTasks.push(task)
-      if (!taskAlreadyPending(pendingTasks, task.id)) pendingTasks.push(task)
-    } catch (error: unknown) {
-      errors.push({ targetId: configuredTarget.id, message: safeError(error) })
     }
   }
 
-  const pendingToRetry = options.retryPending === true
+  const pendingToRetry = options.retryPending === true || options.retryPendingOnly === true
     ? pendingTasks.filter(task => !newTasks.some(current => current.id === task.id))
     : []
   const tasksToInvoke = [...newTasks, ...pendingToRetry]
@@ -2005,7 +2009,7 @@ export async function runObserver(
   const report: ObserverReport = {
     schema: OBSERVER_REPORT_SCHEMA,
     checkedAt,
-    targetsChecked: config.targets.length,
+    targetsChecked: options.retryPendingOnly === true ? 0 : config.targets.length,
     baselineTargets,
     alignmentFindings,
     ...(options.reverseDependencyIndex === undefined ? {} : {

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -140,13 +140,15 @@ describe('reusable GitHub Action', () => {
     assert.doesNotMatch(minimalObserverWorkflow, /pnpm install|pnpm build/)
     assert.match(reviewWorkflow, /finding\.remediation/)
     assert.match(checkedInReviewWorkflow, /finding\.remediation/)
+    assert.match(checkedInObserverWorkflow, /agent-retry/)
+    assert.match(checkedInObserverWorkflow, /--retry-pending-only/)
     const observationPersistStep = checkedInObserverWorkflow.indexOf('name: Persist observation and Agent planning state')
     const initialCheckoutStep = checkedInObserverWorkflow.slice(
       checkedInObserverWorkflow.indexOf('name: Check out the observer and its targets'),
       checkedInObserverWorkflow.indexOf('name: Set up pnpm'),
     )
     const installObservationJob = checkedInObserverWorkflow.indexOf('\n  install-observation:')
-    const observerHealthJob = checkedInObserverWorkflow.indexOf('\n  observer-source-health:')
+    const observerHealthJob = checkedInObserverWorkflow.indexOf('\n  observer-final-health:')
     const reconcileStep = checkedInObserverWorkflow.indexOf('name: Reconcile dynamic evidence into the compatibility ledger')
     const publishStep = checkedInObserverWorkflow.indexOf('name: Publish directory-consumable compatibility evidence')
     const persistStep = checkedInObserverWorkflow.indexOf('name: Persist compatibility evidence')

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -242,6 +242,18 @@ describe('CLI option parsing', () => {
     assert.match(observeHelp.stdout, /--reverse-index <index\.json>/)
     assert.match(observeHelp.stdout, /issue-locator\/\.env-style file/)
     assert.match(observeHelp.stdout, /MODEL\/CODEX_MODEL/)
+    assert.match(observeHelp.stdout, /--retry-pending-only consumes durable Agent tasks/)
+
+    const retryWithoutAgent = spawnSync(process.execPath, [
+      cli,
+      'observe',
+      resolve(repository, 'examples/upstream-observer/targets.yml'),
+      '--state',
+      resolve(repository, 'observations.json'),
+      '--retry-pending-only',
+    ], { encoding: 'utf8' })
+    assert.equal(retryWithoutAgent.status, 1)
+    assert.match(retryWithoutAgent.stderr, /--retry-pending-only requires --dsh-agent-command or --llm-env-file/)
 
     const probeHelp = spawnSync(process.execPath, [cli, 'probe', '--help'], { encoding: 'utf8' })
     assert.equal(probeHelp.status, 0)

--- a/test/upstream-observer.test.ts
+++ b/test/upstream-observer.test.ts
@@ -827,6 +827,60 @@ targets:
     assert.doesNotThrow(() => parseObservationState(result.state))
   })
 
+  it('retries durable Agent tasks without observing upstream targets again', async () => {
+    const before = snapshot('commit-1', '1.0.0', 'graph-v1')
+    const after = snapshot('commit-2', '1.1.0', 'graph-v2')
+    const changed = await runObserver({ schema: OBSERVER_TARGETS_SCHEMA, targets: [target] }, {
+      schema: OBSERVATION_STATE_SCHEMA,
+      targets: { [target.id]: before },
+      pendingTasks: [],
+    }, {
+      source: {
+        observe: async () => after,
+        compare: async (repository, beforeCommit, afterCommit) => ({
+          beforeCommit,
+          afterCommit,
+          comparison: 'complete',
+          changedFiles: ['src/index.ts'],
+          runtimeFiles: ['src/index.ts'],
+          nonRuntimeFiles: [],
+        }),
+      },
+      now: new Date('2026-08-17T04:05:00.000Z'),
+    })
+    assert.equal(changed.state.pendingTasks.length, 1)
+
+    let sourceCalls = 0
+    const retried = await runObserver({ schema: OBSERVER_TARGETS_SCHEMA, targets: [target] }, changed.state, {
+      source: {
+        observe: async () => {
+          sourceCalls += 1
+          throw new Error('pending-only retry must not observe GitHub or npm')
+        },
+        compare: async () => {
+          sourceCalls += 1
+          throw new Error('pending-only retry must not compare upstream commits')
+        },
+      },
+      retryPendingOnly: true,
+      agent: async task => ({
+        taskId: task.id,
+        status: 'succeeded',
+        output: '{"impact":"unknown"}',
+        parsedOutput: { impact: 'unknown' },
+      }),
+      now: new Date('2026-08-17T04:10:00.000Z'),
+    })
+
+    assert.equal(sourceCalls, 0)
+    assert.equal(retried.report.targetsChecked, 0)
+    assert.deepEqual(retried.report.changes, [])
+    assert.equal(retried.report.agent.attempted, 1)
+    assert.equal(retried.report.agent.succeeded, 1)
+    assert.equal(retried.report.pendingTasks.length, 0)
+    assert.deepEqual(retried.state.targets, changed.state.targets)
+  })
+
   it('turns source and published version drift into an author-facing task', async () => {
     const before = snapshot('commit-1', '1.0.0', 'graph-v1')
     const after = snapshot('commit-2', '1.0.0', 'graph-v1')


### PR DESCRIPTION
## What changed

- add `observe --retry-pending-only` to consume durable Agent tasks without reading GitHub, npm, or artifacts again
- keep source observation points byte-stable and report `targetsChecked: 0` in this mode
- fail explicit retries when the Agent is missing or a task remains pending
- add an `agent-retry` workflow-dispatch mode that skips the reverse-index build and headless planner
- keep full scheduled runs and the headless compatibility loop unchanged

## Why

One invalid model response previously required another 100-repository observer pass. Durable tasks should be independently retryable so a transient Agent failure does not waste source requests or delay reconciliation.

## Verification

- `pnpm test` (358/358)
- regression test proves zero source calls and unchanged observation points during a pending-only retry