### PR TITLE
fix: recover from empty DeepSeek JSON output

### DIFF
--- a/src/upstream-observer.ts
+++ b/src/upstream-observer.ts
@@ -1775,53 +1775,91 @@ export async function runOpenAiCompatibleAgent(
     }
   }
   const endpoints = llmCompletionEndpoints(baseUrl)
-  for (let index = 0; index < endpoints.length; index += 1) {
+  const systemPrompt = [
+    '只返回一个严格 JSON 对象。不要输出 Markdown、解释、前缀或后缀；输出必须以 { 开始并以 } 结束。',
+    'Every response must contain exactly the eight fields shown below and no others.',
+    'EXAMPLE JSON OUTPUT:',
+    JSON.stringify({
+      impact: 'unknown',
+      confidence: 'low',
+      evidence: ['State an exact repository path or explicitly name the missing evidence.'],
+      breaking_change: 'unknown',
+      dependency_risk: 'unknown',
+      recommended_action: 'Review the changed runtime paths before upgrading.',
+      urgency: 'monitor',
+      reasoning_summary: 'Separate observed facts from model judgment.',
+    }, null, 2),
+  ].join('\n')
+  endpointLoop: for (let index = 0; index < endpoints.length; index += 1) {
     const endpoint = endpoints[index]!
-    try {
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${apiKey}`,
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify({
-          model,
-          messages: [
-            { role: 'system', content: '只返回一个严格 JSON 对象。不要输出 Markdown、解释、前缀或后缀；输出必须以 { 开始并以 } 结束。' },
-            { role: 'user', content: prompt },
-          ],
-          temperature: 0,
-          // DeepSeek V4 enables thinking by default. For this machine-readable
-          // contract, disable it so the output budget is reserved for the JSON
-          // conclusion instead of an optional reasoning stream.
-          ...(isDeepSeekJsonModel(baseUrl, model) ? { thinking: { type: 'disabled' } } : {}),
-          response_format: { type: 'json_object' },
-          // Keep an explicit output budget so the JSON conclusion is not
-          // truncated by a provider default.
-          max_tokens: DEFAULT_LLM_MAX_TOKENS,
-        }),
-        signal: AbortSignal.timeout(timeoutMs),
-      })
-      if (response.status === 404) continue
-      if (!response.ok) {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const repairAttempt = attempt === 1
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${apiKey}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            model,
+            messages: [
+              {
+                role: 'system',
+                content: repairAttempt
+                  ? `The previous JSON-mode response was empty or invalid. Return the example shape now.\n\n${systemPrompt}`
+                  : systemPrompt,
+              },
+              { role: 'user', content: prompt },
+            ],
+            temperature: 0,
+            // DeepSeek V4 enables thinking by default. For this machine-readable
+            // contract, disable it so the output budget is reserved for the JSON
+            // conclusion instead of an optional reasoning stream.
+            ...(isDeepSeekJsonModel(baseUrl, model) ? { thinking: { type: 'disabled' } } : {}),
+            // DeepSeek documents that JSON Output may occasionally return an
+            // empty content field. Retry once without provider JSON mode; the
+            // same exact local schema validator still gates the conclusion.
+            ...(repairAttempt ? {} : { response_format: { type: 'json_object' } }),
+            // Keep an explicit output budget so the JSON conclusion is not
+            // truncated by a provider default.
+            max_tokens: DEFAULT_LLM_MAX_TOKENS,
+          }),
+          signal: AbortSignal.timeout(timeoutMs),
+        })
+        if (response.status === 404) continue endpointLoop
+        if (!response.ok) {
+          return {
+            taskId: task.id,
+            status: 'failed',
+            error: `LLM endpoint returned HTTP ${response.status}: ${safeLlmEndpoint(endpoint)}`,
+          }
+        }
+        const body = await response.json() as { choices?: Array<{ message?: { content?: unknown } }> }
+        const content = body.choices?.[0]?.message?.content
+        let conclusionError: string
+        if (typeof content !== 'string') {
+          conclusionError = 'LLM response had no message content'
+        } else {
+          try {
+            const parsed = parseAgentOutput(extractJsonObject(content))
+            if (parsed.value !== undefined) {
+              return { taskId: task.id, status: 'succeeded', parsedOutput: parsed.value }
+            }
+            conclusionError = parsed.error ?? 'LLM returned an invalid conclusion'
+          } catch (error: unknown) {
+            conclusionError = safeError(error)
+          }
+        }
+        if (!repairAttempt) continue
         return {
           taskId: task.id,
           status: 'failed',
-          error: `LLM endpoint returned HTTP ${response.status}: ${safeLlmEndpoint(endpoint)}`,
+          error: `LLM returned no valid conclusion after JSON-mode and plain-text attempts at ${safeLlmEndpoint(endpoint)}: ${conclusionError}`,
         }
+      } catch (error: unknown) {
+        return { taskId: task.id, status: 'failed', error: `LLM request failed at ${safeLlmEndpoint(endpoint)}: ${safeError(error)}` }
       }
-      const body = await response.json() as { choices?: Array<{ message?: { content?: unknown } }> }
-      const content = body.choices?.[0]?.message?.content
-      if (typeof content !== 'string') {
-        return { taskId: task.id, status: 'failed', error: `LLM response had no message content: ${safeLlmEndpoint(endpoint)}` }
-      }
-      const parsed = parseAgentOutput(extractJsonObject(content))
-      if (parsed.value === undefined) {
-        return { taskId: task.id, status: 'failed', error: parsed.error ?? 'LLM returned an invalid conclusion' }
-      }
-      return { taskId: task.id, status: 'succeeded', parsedOutput: parsed.value }
-    } catch (error: unknown) {
-      return { taskId: task.id, status: 'failed', error: `LLM request failed at ${safeLlmEndpoint(endpoint)}: ${safeError(error)}` }
     }
   }
   return {

--- a/test/upstream-observer.test.ts
+++ b/test/upstream-observer.test.ts
@@ -1092,6 +1092,56 @@ targets:
       await new Promise<void>((resolve, reject) => server.close(error => error === undefined ? resolve() : reject(error)))
     }
 
+    const emptyJsonBodies: Array<Record<string, unknown>> = []
+    const emptyJsonServer = createServer((request, response) => {
+      let requestBody = ''
+      request.on('data', chunk => { requestBody += chunk.toString('utf8') })
+      request.on('end', () => {
+        emptyJsonBodies.push(JSON.parse(requestBody) as Record<string, unknown>)
+        response.writeHead(200, { 'content-type': 'application/json' })
+        response.end(JSON.stringify({
+          choices: [{ message: { content: emptyJsonBodies.length === 1
+            ? ''
+            : JSON.stringify({
+                impact: 'unknown',
+                confidence: 'low',
+                evidence: ['No project-specific consumer evidence was provided.'],
+                breaking_change: 'unknown',
+                dependency_risk: 'unknown',
+                recommended_action: 'Review the changed runtime entrypoint.',
+                urgency: 'monitor',
+                reasoning_summary: 'The retry returned the required bounded conclusion.',
+              }) } }],
+        }))
+      })
+    })
+    await new Promise<void>((resolve, reject) => {
+      emptyJsonServer.once('error', reject)
+      emptyJsonServer.listen(0, '127.0.0.1', () => resolve())
+    })
+    const emptyJsonAddress = emptyJsonServer.address()
+    if (emptyJsonAddress === null || typeof emptyJsonAddress === 'string') throw new Error('empty JSON test server did not expose an address')
+    const emptyJsonRoot = await mkdtemp(join(tmpdir(), 'upstream-radar-llm-empty-json-'))
+    try {
+      const emptyJsonEnvFile = join(emptyJsonRoot, 'issue-locator.env')
+      await writeFile(emptyJsonEnvFile, [
+        `ISSUE_LOCATOR_LLM_BASE_URL=http://127.0.0.1:${emptyJsonAddress.port}/v1`,
+        'ISSUE_LOCATOR_LLM_API_KEY=test-only',
+        'ISSUE_LOCATOR_LLM_MODEL=deepseek-v4-flash',
+        '',
+      ].join('\n'))
+      const invocation = await runOpenAiCompatibleAgent(task, 'empty JSON retry task', { envFile: emptyJsonEnvFile })
+      assert.equal(invocation.status, 'succeeded')
+      assert.equal(emptyJsonBodies.length, 2)
+      assert.deepEqual(emptyJsonBodies[0]?.response_format, { type: 'json_object' })
+      assert.equal(emptyJsonBodies[1]?.response_format, undefined)
+      assert.match(JSON.stringify(emptyJsonBodies[0]?.messages), /EXAMPLE JSON OUTPUT/)
+      assert.match(JSON.stringify(emptyJsonBodies[1]?.messages), /previous JSON-mode response was empty/)
+    } finally {
+      await rm(emptyJsonRoot, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => emptyJsonServer.close(error => error === undefined ? resolve() : reject(error)))
+    }
+
     const notFoundServer = createServer((request, response) => {
       response.writeHead(404)
       response.end()


### PR DESCRIPTION
## What changed

- give the model an exact eight-field JSON example
- retry one empty or invalid JSON-mode response without provider JSON mode
- continue to accept the conclusion only after the existing strict local schema validation
- keep endpoint fallback, non-thinking mode, output limits, and secret handling unchanged

## Why

DeepSeek documents that JSON Output may occasionally return an empty `content` field. The production `dsh-vision-router` task reproduced that behavior twice, so a durable Agent task could not close even though source and compatibility evidence were complete.

## Verification

- regression server returns empty content first and valid JSON second
- verifies first request uses JSON mode and the repair request does not
- `pnpm test` (358/358)