### PR TITLE
Fix headless Agent review after plugin updates

### DIFF
--- a/scripts/plan-dsh-headless-agent.mjs
+++ b/scripts/plan-dsh-headless-agent.mjs
@@ -9,13 +9,14 @@ import {
   parseDshHeadlessAgentDecision,
   parseDshHeadlessAgentPlans,
   renderDshHeadlessAgentPrompt,
+  selectDshHeadlessAgentReviewEntries,
 } from '../dist/src/dsh-headless-agent-plan.js'
+import { parseDshInstallTargets } from '../dist/src/dsh-install-plan.js'
 import { parseDshCompatibilityLedger } from '../dist/src/dsh-compatibility-ledger.js'
 
 const MAX_INPUT_BYTES = 256 * 1024 * 1024
 const MAX_DOCUMENT_BYTES = 48 * 1024
 const MAX_DOCUMENT_TOTAL_BYTES = 128 * 1024
-const MAX_CANDIDATES = 100
 const CONCURRENCY = 4
 
 async function readJson(path) {
@@ -279,16 +280,10 @@ const [targets, cohort, observations, ledger, existingPlans] = await Promise.all
   readJson(ledgerPath).then(parseDshCompatibilityLedger),
   readPlans(plansPath),
 ])
-const targetById = new Map((Array.isArray(targets?.plugins) ? targets.plugins : []).map(target => [target.id, target]))
+const parsedTargets = parseDshInstallTargets(targets)
+const targetById = new Map(parsedTargets.plugins.map(target => [target.id, target]))
 const existingByCase = new Map(existingPlans.entries.map(entry => [entry.caseId, entry]))
-const reviewEntries = ledger.entries.filter(entry => {
-  const target = targetById.get(entry.targetId)
-  return target !== undefined
-    && target.spec === entry.plugin
-    && (entry.result === 'build-approval-required'
-      || entry.result === 'peer-contract-incompatible'
-      || entry.result === 'unknown')
-}).slice(0, MAX_CANDIDATES)
+const reviewEntries = selectDshHeadlessAgentReviewEntries(parsedTargets, observations, ledger)
 const candidates = await mapConcurrent(reviewEntries, async entry => {
   const target = targetById.get(entry.targetId)
   const source = sourceContext(target, observations, cohort)

--- a/src/dsh-headless-agent-plan.ts
+++ b/src/dsh-headless-agent-plan.ts
@@ -6,6 +6,7 @@ import {
 } from './dsh-compatibility-ledger.js'
 import {
   parseDshInstallTargets,
+  resolveDshInstallTargetSpec,
   type DshInstallTargets,
 } from './dsh-install-plan.js'
 
@@ -325,6 +326,30 @@ function planMatchesLedger(entry: DshHeadlessAgentPlanEntry, observed: DshCompat
     && entry.dshVersion === observed.dshVersion
     && entry.nodeMajor === observed.runtime.nodeMajor
     && entry.artifactSha256 === observed.artifact.sha256
+}
+
+/**
+ * Select only review evidence for the exact plugin coordinate currently
+ * represented by each observer-backed install target. This deliberately uses
+ * the same coordinate resolver as the compatibility planner so a new npm
+ * publication cannot be scheduled by one planner and hidden from the other.
+ */
+export function selectDshHeadlessAgentReviewEntries(
+  targetsInput: unknown,
+  stateInput: unknown,
+  ledgerInput: unknown,
+): DshCompatibilityLedgerEntry[] {
+  const targets = parseDshInstallTargets(targetsInput)
+  const ledger = parseDshCompatibilityLedger(ledgerInput)
+  const targetById = new Map(targets.plugins.map(target => [target.id, target]))
+  return ledger.entries.filter(entry => {
+    const target = targetById.get(entry.targetId)
+    return target !== undefined
+      && resolveDshInstallTargetSpec(target, stateInput) === entry.plugin
+      && (entry.result === 'build-approval-required'
+        || entry.result === 'peer-contract-incompatible'
+        || entry.result === 'unknown')
+  }).slice(0, MAX_ENTRIES)
 }
 
 /**

--- a/src/dsh-install-plan.ts
+++ b/src/dsh-install-plan.ts
@@ -239,7 +239,13 @@ function staticTargetEvidence(stateInput: unknown, targetId: string): unknown {
   }
 }
 
-function resolvedPluginCoordinate(target: DshInstallTarget, stateInput: unknown): string {
+/**
+ * Resolve the exact plugin coordinate represented by one maintained target.
+ * The target spec is the bootstrap coordinate; once the observer has seen a
+ * newer publication of the same package, every downstream planner must bind
+ * to that observed coordinate instead of comparing against stale config.
+ */
+export function resolveDshInstallTargetSpec(target: DshInstallTarget, stateInput: unknown): string {
   const expected = parseNpmSpec(target.spec)
   const observed = target.observerTargetId === undefined
     ? undefined
@@ -380,7 +386,7 @@ export function buildDshInstallPlan(
   const selected = new Map<string, DshCompatibilityExpectedCase>()
   let desiredCells = 0
   for (const target of corpus.plugins) {
-    const plugin = resolvedPluginCoordinate(target, stateInput)
+    const plugin = resolveDshInstallTargetSpec(target, stateInput)
     const staticFingerprint = createDshCompatibilityStaticFingerprint({
       plugin,
       dshVersion,

--- a/test/dsh-headless-agent-plan.test.ts
+++ b/test/dsh-headless-agent-plan.test.ts
@@ -7,6 +7,7 @@ import {
   parseDshHeadlessAgentDecision,
   parseDshHeadlessAgentPlans,
   renderDshHeadlessAgentPrompt,
+  selectDshHeadlessAgentReviewEntries,
   type DshHeadlessAgentCandidate,
 } from '../src/dsh-headless-agent-plan.js'
 
@@ -99,6 +100,34 @@ function ledger(overrides: Record<string, unknown> = {}) {
 }
 
 describe('DSH headless Agent planning', () => {
+  it('selects the current observed plugin coordinate instead of the stale corpus coordinate', () => {
+    const mappedTargets = {
+      ...targets,
+      plugins: [{
+        ...targets.plugins[0]!,
+        observerTargetId: 'dsh-vision',
+      }],
+    }
+    const observations = {
+      targets: {
+        'dsh-vision': {
+          package: { name: 'dsh-vision', version: '1.1.0' },
+        },
+      },
+    }
+    const currentLedger = ledger({ plugin: 'dsh-vision@1.1.0' })
+
+    const selected = selectDshHeadlessAgentReviewEntries(mappedTargets, observations, currentLedger)
+
+    assert.deepEqual(selected.map(entry => entry.plugin), ['dsh-vision@1.1.0'])
+    assert.deepEqual(
+      selectDshHeadlessAgentReviewEntries(mappedTargets, {
+        targets: { 'dsh-vision': { package: { name: 'unrelated-package', version: '1.1.0' } } },
+      }, currentLedger),
+      [],
+    )
+  })
+
   it('accepts one exact observed build approval and keeps repository text untrusted', () => {
     const decision = parseDshHeadlessAgentDecision({
       action: 'retry-headless',


### PR DESCRIPTION
## What changed

- resolve each install target to the current package coordinate already captured by the upstream observer
- share that resolver between compatibility scheduling and headless Agent review selection
- reject name-mismatched observations instead of binding unrelated npm packages
- add a regression test for a target configured at 1.0.0 and observed at 1.1.0

## Why

The compatibility planner correctly tested newly observed plugin releases, but the Agent planner compared those ledger entries with the bootstrap versions in `targets.json`. Four current build-approval cases were therefore omitted from review.

With this change, the checked-in 100-plugin corpus selects all 25 current review cells (21 peer-contract reviews and 4 build-approval reviews).

## Verification

- `pnpm test` (359/359)
- local current-state selection: 25 review cells, including all four current build-approval cases