### PR TITLE
Release v0.43.5

### DIFF
--- a/.github/workflows/action-consumer-smoke.yml
+++ b/.github/workflows/action-consumer-smoke.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.4
+      - uses: MicroMilo/upstream-radar@v0.43.5
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/.github/workflows/review-dsh-plugin.yml
+++ b/.github/workflows/review-dsh-plugin.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.43.4
+        uses: MicroMilo/upstream-radar@v0.43.5
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Upstream Radar are documented here.
 
 ## [Unreleased]
 
+## [0.43.5] - 2026-08-25
+
+### Current-state Agent closure
+
+- Keep the directory feed bound to current observations with an explicit
+  `update-pending` state, while letting successful plugin observations continue
+  when an independent upstream source is temporarily unavailable.
+- Start queued observers from the latest durable state and add a lightweight
+  Agent-only retry path that does not rescan GitHub, npm, or plugin artifacts.
+- Recover from DeepSeek's documented empty JSON-mode response with one bounded
+  plain-response retry that still has to pass the exact local result schema.
+- Make the compatibility planner and headless Agent planner share the same
+  observed plugin coordinate, so a newly published version cannot be tested by
+  one planner and hidden from the other.
+- Verify the repaired loop over the maintained 100-plugin cohort: the Agent
+  reviewed all 25 current headless cases, selected four exact build-policy
+  retries, moved two plugins to compatible, and stopped the other two at a
+  measured Web-client boundary. The public feed now records 74 compatible, 22
+  review-only, zero reproduced-incompatible, and four repository-only entries.
+
 ## [0.43.4] - 2026-08-24
 
 ### Always-on observation reliability

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -62,7 +62,7 @@ Agent 读取仓库说明和最新运行证据，决定 headless 是否重试、�
 第一次检查不需要本地 DSH profile，也不会执行插件代码：
 
 ```bash
-npx --yes upstream-radar@0.43.4 inspect \
+npx --yes upstream-radar@0.43.5 inspect \
   @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
   --deep --fail-on never
 ```
@@ -73,7 +73,7 @@ npx --yes upstream-radar@0.43.4 inspect \
 如果要检查自己的公开仓库，而不安装它：
 
 ```bash
-npx --yes upstream-radar@0.43.4 scan \
+npx --yes upstream-radar@0.43.5 scan \
   https://github.com/owner/dsh-plugin \
   --fail-on never
 ```
@@ -92,6 +92,10 @@ npx --yes upstream-radar@0.43.4 scan \
 它不是你的电脑，也不会接收项目密钥。
 
 ## 来自真实生态的结果
+
+当前的[100 插件兼容性 feed](feeds/dsh-plugin-compatibility.md)记录了 74 个精确 headless
+通过、22 个仅待复核结果、0 个已复现不兼容和 4 个仅仓库条目。在真正观测所需的
+Web/client 或仓库安装平面之前，待复核项不会被包装成插件故障。
 
 截至 2026-08-25，Radar 共向维护者提交了 13 条报告。比数量更重要的是处理结果：
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ No local DSH profile is needed for this first check. It reviews one exact
 published artifact without executing plugin code:
 
 ```bash
-npx --yes upstream-radar@0.43.4 inspect \
+npx --yes upstream-radar@0.43.5 inspect \
   @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
   --deep --fail-on never
 ```
@@ -85,7 +85,7 @@ behavior. See the [full evidence report](examples/dsh/reports/sanqi-market-plugi
 To review your own public repository without installing it:
 
 ```bash
-npx --yes upstream-radar@0.43.4 scan \
+npx --yes upstream-radar@0.43.5 scan \
   https://github.com/owner/dsh-plugin \
   --fail-on never
 ```
@@ -111,6 +111,12 @@ uses a fresh GitHub-hosted runner for code-executing checks. The runner is not
 your workstation and does not receive project secrets.
 
 ## Evidence from the ecosystem
+
+The current [100-plugin compatibility feed](feeds/dsh-plugin-compatibility.md)
+records 74 exact headless passes, 22 review-only results, zero reproduced
+incompatibilities, and four repository-only entries. The review-only group is
+kept separate from failures until the required Web/client or repository install
+plane is actually observed.
 
 As of 2026-08-25, Radar has filed 13 maintainer-facing reports. The outcome is
 more useful than the raw count:

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   version:
     description: Exact upstream-radar npm version to execute.
     required: false
-    default: 0.43.4
+    default: 0.43.5
   node-version:
     description: Node.js version used to run the CLI.
     required: false

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -98,7 +98,7 @@ FIRST EPSS estimated exploitation probability: 97.2% (percentile 100.0%)
 想立即检查一个真实发布的 DSH 插件，可以在空目录直接运行：
 
 ```bash
-npx --yes upstream-radar@0.43.4 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.43.5 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 它会直接输出简短的准入结论、覆盖情况、依赖数量、漏洞数量和下一步，不需要先
@@ -111,7 +111,7 @@ npx --yes upstream-radar@0.43.4 inspect dsh-feishu-bot@0.15.8 --deep
 npm 解析环境中目前无法建立完整依赖图：
 
 ```bash
-npx --yes upstream-radar@0.43.4 inspect \
+npx --yes upstream-radar@0.43.5 inspect \
   @sanqi-normal/dsh-webui-market-plugin@0.5.4 \
   --deep --fail-on never
 ```
@@ -337,9 +337,9 @@ npm：     dsh-feishu-bot@0.15.8
 会继续显示为 `incomplete`，不会被当成已经确认的故障。
 
 ```bash
-npx --yes upstream-radar@0.43.4 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.43.5 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.43.4 observe ./targets.yml \
+npx --yes upstream-radar@0.43.5 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -377,7 +377,7 @@ Radar 会在三层目录内自动找到它；npm 名称和源码 manifest 不一
 想明确选择锁文件时再加 `--lockfile`：
 
 ```bash
-npx --yes upstream-radar@0.43.4 observe \
+npx --yes upstream-radar@0.43.5 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state ./observations.json --report ./upstream-radar-observer.md
 ```
@@ -400,7 +400,7 @@ workspace 边保留为未解析证据；不会安装或启动 DSH。
 会额外指定 `--package`：
 
 ```bash
-npx --yes upstream-radar@0.43.4 observe \
+npx --yes upstream-radar@0.43.5 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -679,7 +679,7 @@ cd my-dsh-plugin
 pnpm install --ignore-scripts
 
 # 把插件放进 DSH profile 前，先读取精确依赖图。
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar graph pnpm-lock pnpm-lock.yaml --json
 ```
 
 这棵图会保留精确的 DSH 包版本，也会把未解析的可选 peer 明确显示出来；它不会加载生成的插件，也不会运行 lifecycle script。审查后，把下面这个完整 workflow 复制到 `.github/workflows/upstream-radar.yml`：
@@ -701,7 +701,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.4
+      - uses: MicroMilo/upstream-radar@v0.43.5
         with:
           fail-on: high
           fail-on-compatibility: breaking
@@ -712,7 +712,7 @@ Action 会自动识别唯一的 `pnpm-lock.yaml`，检查同一棵精确依赖�
 也可以直接检查一个真实发布的 DSH 包：
 
 ```bash
-npx --yes upstream-radar@0.43.4 inspect dsh-feishu-bot@0.15.8 --deep
+npx --yes upstream-radar@0.43.5 inspect dsh-feishu-bot@0.15.8 --deep
 ```
 
 这次检查的结论是 `REVIEW`：registry 完整性、签名、provenance 和 89 个已解析包都
@@ -725,7 +725,7 @@ npx --yes upstream-radar@0.43.4 inspect dsh-feishu-bot@0.15.8 --deep
 如果不想分别执行 `inspect`、打包和 `probe`，可以用一个命令完成一次 DSH 插件审查：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar review dsh-plugin \
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar review dsh-plugin \
   dsh-cloudflare-browser-run@0.1.1 \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```
@@ -891,7 +891,7 @@ pnpm run try:dsh
 在把项目接入兼容性门禁前，可以先运行离线规则 benchmark：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar benchmark compatibility
 ```
 
 它覆盖六类契约：安全补丁、只需要项目分析的变化、不兼容的 DSH peer、发布者明确声明 breaking、候选传递依赖漏洞，以及候选依赖图不完整。这个命令不会联网、安装包、加载插件或启动 DSH；它验证的是 Radar 的确定性规则以及 `breaking`/`any` 门禁行为，不是运行时兼容性证明。
@@ -904,7 +904,7 @@ pnpm dlx --package=upstream-radar@0.43.4 upstream-radar benchmark compatibility
 # 打包精确版本，并明确不运行它的 lifecycle script。
 npm pack --ignore-scripts dsh-plugin@1.2.3
 
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6
 ```
@@ -930,7 +930,7 @@ pnpm run showcase:dsh-probe
 如果要比较多个 DSH 版本，可以使用矩阵入口：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar probe dsh-matrix \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.3 \
   --dsh-version 0.1.0-rc.6 \
@@ -948,7 +948,7 @@ JSON 结果结构见[矩阵结果 schema](../schemas/dsh-load-matrix.schema.json
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.43.4
+  - uses: MicroMilo/upstream-radar@v0.43.5
     with:
       fail-on: high
       # 可选：把确定性的 DSH/插件兼容性破坏也作为 CI 失败条件
@@ -962,7 +962,7 @@ steps:
 如果仓库还没有提交 Radar 配置，最短接入方式是省略 `config`、`pnpm-lock` 和 `npm-lock`。checkout 之后，Action 会自动使用唯一存在的 `pnpm-lock.yaml` 或 `package-lock.json`，生成临时的审查清单，再执行同一个 frozen 检查：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.43.4
+- uses: MicroMilo/upstream-radar@v0.43.5
   with:
     fail-on: high
 ```
@@ -972,7 +972,7 @@ steps:
 如果要在插件进入 DSH 前审查精确发布物，可以增加 `inspect-package`：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.43.4
+- uses: MicroMilo/upstream-radar@v0.43.5
   with:
     inspect-package: dsh-cloudflare-browser-run@0.1.1
     # review 是安全默认值；只有允许覆盖不完整时才使用 block
@@ -984,7 +984,7 @@ steps:
 如果仓库只有 pnpm 锁文件，还没有提交 Radar 配置，可以让 Action 在同一个 job 中生成配置；可直接复制[pnpm workflow 示例](../examples/github-actions/upstream-radar-pnpm.yml)：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.43.4
+- uses: MicroMilo/upstream-radar@v0.43.5
   with:
     pnpm-lock: pnpm-lock.yaml
     fail-on: high
@@ -998,7 +998,7 @@ npm 项目可以改用 `npm-lock: package-lock.json`；`pnpm-lock` 和 `npm-lock
 调用方需要先 checkout 仓库。这个 Action 不会安装项目依赖，也不会执行项目的 lifecycle script；它只读取提交到仓库的依赖图并查询配置中的上游漏洞源。如果需要完全显式的底层命令，等价写法是：
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar radar check \
   ./upstream-radar.config.json --frozen --state :memory: --fail-on high \
   --fail-on-compatibility breaking --json
 ```
@@ -1006,7 +1006,7 @@ pnpm dlx --package=upstream-radar@0.43.4 upstream-radar radar check \
 如果还要检查一个已发布插件能否跨多个 DSH 版本加载，可以增加三个 input：
 
 ```yaml
-- uses: MicroMilo/upstream-radar@v0.43.4
+- uses: MicroMilo/upstream-radar@v0.43.5
   id: radar
   with:
     config: upstream-radar.config.json

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -210,7 +210,7 @@ When the native DSH adapter is running, it additionally verifies the exact `@dee
 For a runner that does not have DSH installed, commit the generated config after review and run one frozen check:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar radar check \
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar radar check \
   ./upstream-radar.config.json \
   --frozen --state :memory: --fail-on high --json
 ```
@@ -224,7 +224,7 @@ The published Action packages the same frozen check so a DSH plugin project does
 ```yaml
 steps:
   - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-  - uses: MicroMilo/upstream-radar@v0.43.4
+  - uses: MicroMilo/upstream-radar@v0.43.5
     with:
       config: upstream-radar.config.json
       fail-on: high
@@ -257,7 +257,7 @@ It packs without lifecycle scripts, runs one temporary DSH profile per version, 
 The package includes a no-network compatibility benchmark for the deterministic gate itself:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar benchmark compatibility
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar benchmark compatibility
 ```
 
 It covers a safe patch, analysis-only structural change, DSH peer exclusion, explicit publisher breaking language, a vulnerable candidate dependency, and incomplete candidate coverage. A passing benchmark means the rule contract has not regressed; it does not mean a real plugin is runtime-compatible. The real DSH consumer workflow below remains the integration proof.
@@ -271,7 +271,7 @@ The repository also carries a copyable consumer smoke under [`examples/github-ac
 The `probe dsh-load` command gives the compatibility question its own bounded surface. It takes one exact `.tgz`, uses one exact DSH version, and creates a disposable `headless` profile:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar probe dsh-load \
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar probe dsh-load \
   ./dsh-plugin-1.2.3.tgz \
   --dsh-version 0.1.0-rc.6 --json
 ```

--- a/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
+++ b/examples/dsh/reports/dsh-composer-expand-lockfile-feedback.md
@@ -19,7 +19,7 @@ From a clean checkout, the finding is reproducible without installing or
 executing the plugin:
 
 ```bash
-npx --yes upstream-radar@0.43.4 scan . --json
+npx --yes upstream-radar@0.43.5 scan . --json
 ```
 
 The current static scan reports:

--- a/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
+++ b/examples/dsh/reports/dsh-core-artifact-rc7-2026-08-18.md
@@ -43,5 +43,5 @@ graph, the unresolved peer boundary, the vulnerability result, and the two
 remaining review actions in one report.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.43.4`. Review the Draft PR before relying on the fallback
+`upstream-radar@0.43.5`. Review the Draft PR before relying on the fallback
 resolver from npm.

--- a/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
+++ b/examples/dsh/reports/dsh-feishu-bot-0.15.4-probe.md
@@ -21,7 +21,7 @@ Reproduce it with:
 
 ```bash
 npm pack --ignore-scripts --pack-destination /tmp dsh-feishu-bot@0.15.4
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar probe dsh-matrix \
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar probe dsh-matrix \
   /tmp/dsh-feishu-bot-0.15.4.tgz \
   --dsh-version 0.1.0-rc.6,0.1.0-rc.7
 ```

--- a/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
+++ b/examples/dsh/reports/dsh-progress-viz-public-url-2026-08-18.md
@@ -8,7 +8,7 @@ graph without installing anything.
 ## Reproduction
 
 ```bash
-npx --yes upstream-radar@0.43.4 scan \
+npx --yes upstream-radar@0.43.5 scan \
   https://github.com/2008924/dsh-progress-viz \
   --fail-on never
 ```

--- a/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
+++ b/examples/dsh/reports/dsh-tui-source-vs-npm-2026-08-18.md
@@ -13,11 +13,11 @@ No DSH profile, plugin code, lifecycle script, or LLM was started.
 ## Commands
 
 ```bash
-npx --yes upstream-radar@0.43.4 scan \
+npx --yes upstream-radar@0.43.5 scan \
   https://github.com/ccch1mneyyy/dsh-TUI \
   --fail-on never
 
-npx --yes upstream-radar@0.43.4 inspect \
+npx --yes upstream-radar@0.43.5 inspect \
   npm:@deepseek-harness-tui/dsh-tui@0.8.0 \
   --deep --fail-on never
 ```

--- a/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
+++ b/examples/dsh/reports/lockfile-metadata-follow-up-2026-08-18.md
@@ -8,7 +8,7 @@ release.
 ## Rechecked with the public CLI
 
 Each repository was cloned at its current public `main` commit and scanned with
-`upstream-radar@0.43.4`. No package was installed, loaded, or executed.
+`upstream-radar@0.43.5`. No package was installed, loaded, or executed.
 
 | Repository | Commit | `package.json` | `package-lock.json` root | Result |
 | --- | --- | ---: | ---: | --- |

--- a/examples/github-actions/consumer/README.md
+++ b/examples/github-actions/consumer/README.md
@@ -40,7 +40,7 @@ The optional probe is load-only. It packs with `--ignore-scripts`, uses a tempor
 For your project, generate the config from the actual DSH profile instead of copying this package's snapshot:
 
 ```bash
-pnpm dlx --package=upstream-radar@0.43.4 upstream-radar init \
+pnpm dlx --package=upstream-radar@0.43.5 upstream-radar init \
   --profile <dsh-profile> \
   --project-id <project-id> \
   --project-name "Your project" \

--- a/examples/github-actions/consumer/upstream-radar.yml
+++ b/examples/github-actions/consumer/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.4
+      - uses: MicroMilo/upstream-radar@v0.43.5
         with:
           config: examples/github-actions/consumer/upstream-radar.config.json
           fail-on: high

--- a/examples/github-actions/dsh-plugin-review-minimal.yml
+++ b/examples/github-actions/dsh-plugin-review-minimal.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Inspect and load-test the exact plugin
         id: radar
         continue-on-error: true
-        uses: MicroMilo/upstream-radar@v0.43.4
+        uses: MicroMilo/upstream-radar@v0.43.5
         with:
           inspect-package: ${{ inputs.plugin }}
           inspect-fail-on: never

--- a/examples/github-actions/upstream-observer-minimal.yml
+++ b/examples/github-actions/upstream-observer-minimal.yml
@@ -53,7 +53,7 @@ jobs:
           llm_env_file="$RUNNER_TEMP/issue-locator.env"
           trap 'rm -f "$llm_env_file"' EXIT
           observe_args=(
-            npx --yes upstream-radar@0.43.4 observe "$repository"
+            npx --yes upstream-radar@0.43.5 observe "$repository"
             --ref "$ref"
             --state observations.json
             --report "$report"

--- a/examples/github-actions/upstream-radar-npm.yml
+++ b/examples/github-actions/upstream-radar-npm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.4
+      - uses: MicroMilo/upstream-radar@v0.43.5
         with:
           npm-lock: package-lock.json
           fail-on: high

--- a/examples/github-actions/upstream-radar-pnpm.yml
+++ b/examples/github-actions/upstream-radar-pnpm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.4
+      - uses: MicroMilo/upstream-radar@v0.43.5
         with:
           pnpm-lock: pnpm-lock.yaml
           fail-on: high

--- a/examples/github-actions/upstream-radar.yml
+++ b/examples/github-actions/upstream-radar.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: MicroMilo/upstream-radar@v0.43.4
+      - uses: MicroMilo/upstream-radar@v0.43.5
         with:
           # The Action auto-detects one pnpm-lock.yaml or package-lock.json.
           fail-on: high

--- a/examples/github-actions/upstream-scan-minimal.yml
+++ b/examples/github-actions/upstream-scan-minimal.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           report="$RUNNER_TEMP/upstream-radar-scan.json"
-          npx --yes upstream-radar@0.43.4 scan \
+          npx --yes upstream-radar@0.43.5 scan \
             "$OBSERVER_REPOSITORY_INPUT" \
             --json --fail-on never > "$report"
           if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/examples/upstream-observer/README.md
+++ b/examples/upstream-observer/README.md
@@ -24,7 +24,7 @@ Replace it with the repositories your team depends on.
 For one repository, the shortest path skips YAML and lockfile configuration entirely:
 
 ```bash
-npx --yes upstream-radar@0.43.4 observe \
+npx --yes upstream-radar@0.43.5 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -35,7 +35,7 @@ Radar automatically chooses the committed `pnpm-lock.yaml` or
 the explicit form below adds `--package`:
 
 ```bash
-npx --yes upstream-radar@0.43.4 observe \
+npx --yes upstream-radar@0.43.5 observe \
   https://github.com/PlutoKeating/dsh-lark-bot \
   --package dsh-feishu-bot \
   --lockfile pnpm-lock.yaml --lockfile-type pnpm \
@@ -75,9 +75,9 @@ Build one index from saved DSH plugin scan/review/config JSON, then give it to
 the observer:
 
 ```bash
-npx --yes upstream-radar@0.43.4 graph reverse ./plugin-reports \
+npx --yes upstream-radar@0.43.5 graph reverse ./plugin-reports \
   --output ./reverse-dependency-index.json
-npx --yes upstream-radar@0.43.4 observe ./targets.yml \
+npx --yes upstream-radar@0.43.5 observe ./targets.yml \
   --reverse-index ./reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -99,7 +99,7 @@ and run `pnpm run showcase:observer` to replay a real
 The scheduled workflow uses the checked-in index directly:
 
 ```bash
-npx --yes upstream-radar@0.43.4 observe ./targets.yml \
+npx --yes upstream-radar@0.43.5 observe ./targets.yml \
   --reverse-index ../dsh/first-batch/reverse-dependency-index.json \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md
@@ -126,7 +126,7 @@ Run it from any directory with the published CLI:
 
 ```bash
 export GITHUB_TOKEN='a read-only token with repository metadata access'
-npx --yes upstream-radar@0.43.4 observe \
+npx --yes upstream-radar@0.43.5 observe \
   /path/to/targets.yml \
   --state /tmp/upstream-radar-observations.json \
   --report /tmp/upstream-radar-observer.md

--- a/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
+++ b/examples/upstream-observer/reports/dsh-core-auto-discovery-2026-08-18.md
@@ -30,5 +30,5 @@ than silently monitoring the repository root. Local `workspace:` links remain
 explicitly unresolved; Radar does not guess their published versions.
 
 This report was produced by the current branch, not the already published
-`upstream-radar@0.43.4`. Review the Draft PR before using the auto-discovery
+`upstream-radar@0.43.5`. Review the Draft PR before using the auto-discovery
 path from npm.

--- a/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
+++ b/examples/upstream-observer/reports/sanqi-maintainer-repair-live.md
@@ -14,12 +14,12 @@ The baseline was taken at the commit that produced the published `0.5.4`
 artifact, then the same state was checked against the current `master`:
 
 ```bash
-npx --yes upstream-radar@0.43.4 observe \
+npx --yes upstream-radar@0.43.5 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref aa5f4efc7827176cce27c73f73a2f42514da1ebf \
   --state observations.json --report baseline.md --json
 
-npx --yes upstream-radar@0.43.4 observe \
+npx --yes upstream-radar@0.43.5 observe \
   https://github.com/Sanqi-normal/dsh-webui-market-plugin \
   --ref master \
   --state observations.json --report repair.md --json

--- a/feeds/dsh-plugin-compatibility.json
+++ b/feeds/dsh-plugin-compatibility.json
@@ -1,9 +1,9 @@
 {
   "schema": "upstream-radar.dsh-directory-compatibility-feed/v1alpha2",
-  "generatedAt": "2026-08-25T04:40:21.435Z",
+  "generatedAt": "2026-08-25T04:45:36.128Z",
   "producer": {
     "name": "upstream-radar",
-    "version": "0.43.4",
+    "version": "0.43.5",
     "repository": "https://github.com/MicroMilo/upstream-radar",
     "license": "Apache-2.0"
   },

--- a/feeds/dsh-plugin-compatibility.md
+++ b/feeds/dsh-plugin-compatibility.md
@@ -1,6 +1,6 @@
 # DSH directory compatibility evidence
 
-Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-25T04:40:21.435Z`.
+Generated from catalog commit [`2e19b3c5bd42`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/commit/2e19b3c5bd42f2f688eba9df7933ace9e13e66ea) at `2026-08-25T04:45:36.128Z`.
 Selected host: `@deepseek-ai/dsh@0.1.1-rc.2`.
 
 **74 observed compatible · 0 observed incompatible · 22 needs review · 0 update pending · 4 not observed**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upstream-radar",
-  "version": "0.43.4",
+  "version": "0.43.5",
   "description": "Always-on dependency and compatibility monitoring for DeepSeek Harness plugins, including exact paths, upstream changes, and isolated install/load evidence.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const TOOL_VERSION = '0.43.4'
+export const TOOL_VERSION = '0.43.5'

--- a/test/release-preflight.test.ts
+++ b/test/release-preflight.test.ts
@@ -23,7 +23,7 @@ describe('release preflight', () => {
       checks: Array<{ status: string }>
     }
     assert.equal(report.schema, 'upstream-radar.release-preflight/v1alpha1')
-    assert.equal(report.version, '0.43.4')
+    assert.equal(report.version, '0.43.5')
     assert.equal(report.passed, true)
     assert.equal(report.publishedCheck, false)
     assert.ok(report.checks.length >= 4)


### PR DESCRIPTION
## Release contents

- publish honest current-state directory feed semantics and partial-source resilience
- publish durable Agent-only retries and DeepSeek empty-response recovery
- publish the shared current-coordinate contract used by compatibility and Agent planners
- document the verified 100-plugin outcome: 74 exact headless passes, 22 review-only, 0 reproduced incompatibilities, 4 repository-only entries
- update every copyable npm/Action reference to 0.43.5

## Verification

- `pnpm test` — 359/359
- `pnpm run release:check`
- `pnpm run try:consumer` with authenticated GitHub advisory access — 18 packages queried, 15 release streams queried, 2 DSH compatibility events, 0 active vulnerabilities, policy pass